### PR TITLE
Quick fix: Missing #include

### DIFF
--- a/c2c/Utils/ProcessUtils.cpp
+++ b/c2c/Utils/ProcessUtils.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include "Utils/ProcessUtils.h"
 


### PR DESCRIPTION
There is an assert here in ProcessUtils, but no #include <assert.h>. C2C won't compile without that line, at least for me