### PR TITLE
Arch typos

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,9 @@
-an
 ## Installation of LLVM/Clang (C2 version)
 C2 is based on LLVM 4.0 and some parts of Clang 4.0.
 To install C2, follow the steps below. The example shows
 how to install in **$HOME/llvm-c2**, but any other dir should work.
 
-Note that both the Ubuntu/OS X guides *also* use the Generic part
+Note that all OS-specific instructions include the Generic section
 
 ### Ubuntu 14.04
 LLVM/Clang 4.0 needs cmake 3.4.3 or higher, since Ubuntu does not have
@@ -27,6 +26,12 @@ export CC=clang
 export CXX=clang++
 ```
 
+### Arch
+```bash
+pacman -S cmake ncurses-dev clang
+yaourt -S libtinfo
+```
+
 ### OS X (Yosemite/El Capitan)
 Homebrew is currently at cmake-3.3, so a binary package for cmake is also needed on OS X
 ```bash
@@ -37,7 +42,7 @@ export PATH=~/progs/cmake-3.5.2-Darwin-x86_64/CMake.app/Contents/bin:$PATH
 
 ### Generic
 These commands build the C2-modified LLVM/Clang toolchain. The produced clang is still
-fully compatibly with the original one (ie. it can just compile C/C++ just as well).
+fully compatible with the original one (ie. it can compile C/C++ just as well).
 
 ```bash
 git clone git://github.com/llvm-mirror/llvm.git
@@ -66,7 +71,6 @@ cmake -G "Unix Makefiles" \
 make -j4
 make install
 ```
-
 ### OS X (Yosemite/El Capitan) (after building LLVM/Clang)
 You might need to create a link for your new clang to find the C++ headers.
 Since this uses the toolchain that comes with XCode, XCode will have to be installed.
@@ -93,7 +97,7 @@ If all goes well, the **c2c** executable should appear in the build/c2c/ directo
 
 If you get an error with some Clang/C2-related errors, try updating your clang C2 archive.
 
-The env.sh script sets some some environment variables that c2c requires to work,
+The env.sh script sets some some environment variables that c2c requires to work
 like *C2_LIBDIR*. It will also add $HOME/llvm-c2/bin to the $PATH
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Have fun! (and code..)
 
 
 ## Generic
-C2 is based on LLVM 3.8 and some parts of Clang 3.8. The design of C2C's
+C2 is based on LLVM 4.0 and some parts of Clang 4.0. The design of C2C's
 C2Parser and C2Sema class are heavily based on clang's Parser and Sema class,
 so hereby my thanks to the Clang folks!
 
@@ -78,11 +78,11 @@ definition". See the [installation document](INSTALL.md) on how to install.
 How it works is as follows:
 * use --refs or add $refs in recipe.txt to generate **refs** file during compilation.
 * c2c generates a **refs** file per target. This file contains all references
-    and their destination
+    and their respective destinations.
 * c2tags currently doesn't have a full-blown vim-plugin yet, but a small
-    code-fragment in you .vimrc suffices.
-* when standing on any symbol in C2 code, pressing ctrl-h (configurable)
-    will jump to the definition. Pressing ctrl-o (default) will jump back.
+    code-fragment in your .vimrc should suffice.
+* Pressing ctrl-h (configurable) with your cursor on any symbol
+    will jump to its definition. Pressing ctrl-o (default) will jump back.
 
 Just like **c2c** itself, **c2tags** can be called from any (sub)directory in the
 project tree.


### PR DESCRIPTION
This pull-request adds OS-specific instructions for Arch Linux and fixes some typos. I also rephrased a sentence or two and updated version numbers in README.md