### PR TITLE
improve env.sh to allow making the env variable changes permanent with .bashrc and custom c2 clang path

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -7,13 +7,13 @@ OPTIND=1 #reset getopts
 C2_PATH=$HOME/llvm-c2/bin
 PERMANENT=false
 
-while getopts "pd:h" opt; do
+while getopts ":phd:" opt; do
     case "$opt" in
     p) PERMANENT=true
        ;;
     d) C2_PATH=$OPTARG
        ;;
-    h) echo "Usage: env.sh [-d DIR] [--permanent]"
+    h) echo "Usage: env.sh [-h] [-d DIR] [-p]"
         if [ "$EXECUTION_MANNER" = sourced ] ; then
           return
         else

--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,43 @@
-echo 'setting C2 environment'
-alias c2c=$PWD/build/c2c/c2c
-export C2_LIBDIR=$PWD/c2libs
-export PATH=$PATH:$HOME/llvm-c2/bin
+#!/bin/bash
+
+#check if script is sourced or in a sub-shell
+[[ "$_" != "$0" ]] && EXECUTION_MANNER=sourced || EXECUTION_MANNER=subshell
+
+OPTIND=1 #reset getopts
+C2_PATH=$HOME/llvm-c2/bin
+PERMANENT=false
+
+while getopts "pd:h" opt; do
+    case "$opt" in
+    p) PERMANENT=true
+       ;;
+    d) C2_PATH=$OPTARG
+       ;;
+    h) echo "Usage: env.sh [-d DIR] [--permanent]"
+        if [ "$EXECUTION_MANNER" = sourced ] ; then
+          return
+        else
+          echo "the script should be ran with the \"source\" command"
+          exit
+        fi
+       ;;
+esac
+shift
+done
+
+if [ "$EXECUTION_MANNER" = sourced ] ; then
+  echo 'setting C2 environment'
+
+  if [ "$PERMANENT" = true ] ; then
+    echo "appending to $HOME/.bashrc"
+    echo "alias c2c=$PWD/build/c2c/c2c" >> $HOME/.bashrc
+    echo "export C2_LIBDIR=$PWD/c2libs" >> $HOME/.bashrc
+    echo "export PATH=$PATH:$C2_PATH" >> $HOME/.bashrc
+  fi
+
+  alias c2c=$PWD/build/c2c/c2c
+  export C2_LIBDIR=$PWD/c2libs
+  export PATH=$PATH:$C2_PATH
+else
+  echo "error: the script should be ran with the \"source\" command or dot"
+fi


### PR DESCRIPTION
This pull-request updates env.sh to:
1) Allow using a different LLVM installation directory with -d option
2) Allow writing to .bashrc to set the variables on shell start up with -p option
3) Detect if user is running the script with **source** or not warn the user
4) Have a simple usage text with -h option

Note: if both options are being used, -p has to be the last argument passed to the script. Don't know why, but getopts otherwise doesnt process -d properly