### PR TITLE
Windows port update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 PROJECT(c2compiler)
 
-SET(CMAKE_CXX_COMPILER "clang++")
+if(CYGWIN OR WIN32)
+# There is a bug with clang and libstdc++ with the __float128 type which, 
+# quite frankly, affects C2C compilation, hence why we need to use GCC.
+	SET(CMAKE_CXX_COMPILER "g++") 
+else(CYGWIN OR WIN32)
+	SET(CMAKE_CXX_COMPILER "clang++")
+endif(CYGWIN OR WIN32)
 
 #SET(CMAKE_BUILD_TYPE Release)
 SET(CMAKE_BUILD_TYPE Debug)

--- a/c2c/Utils/TargetInfo.cpp
+++ b/c2c/Utils/TargetInfo.cpp
@@ -39,6 +39,10 @@ void TargetInfo::getNative(TargetInfo& info) {
         info.sys = SYS_LINUX;
         info.vendor = VENDOR_UNKNOWN;   // hardcoded
         info.abi = ABI_GNU;             // hardcoded
+    } else if (strncmp(un.sysname, "CYGWIN", 6) == 0) {
+        info.sys = SYS_CYGWIN;
+	info.vendor = VENDOR_UNKNOWN;
+	info.abi = ABI_WIN32;
     } else {
         fprintf(stderr, "unsupported system: %s\n", un.sysname);
         exit(-1);
@@ -65,6 +69,7 @@ const char* C2::Str(TargetInfo::System sys) {
     switch (sys) {
     case TargetInfo::SYS_LINUX:     return "linux";
     case TargetInfo::SYS_DARWIN:    return "darwin";
+    case TargetInfo::SYS_CYGWIN:    return "cygwin";
     case TargetInfo::SYS_UNKNOWN:   return "unknown";
     }
     return "";
@@ -91,6 +96,7 @@ const char* C2::Str(TargetInfo::Abi abi) {
     switch (abi) {
     case TargetInfo::ABI_GNU:   return "gnu";
     case TargetInfo::ABI_MACHO: return "macho";
+    case TargetInfo::ABI_WIN32: return "win32";
     }
     return "";
 }

--- a/c2c/Utils/TargetInfo.h
+++ b/c2c/Utils/TargetInfo.h
@@ -20,10 +20,10 @@ namespace C2 {
 
 class TargetInfo {
 public:
-    enum System { SYS_LINUX, SYS_DARWIN, SYS_UNKNOWN };
+    enum System { SYS_LINUX, SYS_DARWIN, SYS_CYGWIN, SYS_UNKNOWN };
     enum Machine { MACH_I686, MACH_X86_64, MACH_UNKNOWN };
     enum Vendor { VENDOR_UNKNOWN, VENDOR_APPLE };
-    enum Abi { ABI_GNU, ABI_MACHO };
+    enum Abi { ABI_GNU, ABI_MACHO, ABI_WIN32 };
 
     System sys;
     Machine mach;


### PR DESCRIPTION
This pull-request updates CMakeLists.txt to use g++ on Windows/Cygwin because of a bug with clang++ and libstdc++'s __float128 type. It also updates the instructions for Windows installation to be up-to-date with Clang/LLVM 4.0 and building LLVM with CMake instead of the configure script. It also adds Cygwin to targets