### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To see all available options, run:
 ```
 c2c -h
 ```
-##c2tags
+## c2tags
 **c2tags** is C2's version of ctags. This tool is used by vim (e.a.) to "jump to
 definition". See the [installation document](INSTALL.md) on how to install.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
