### PR TITLE
[FIX] LiteralAnalyser: Missing shift operations causes compiler crash.

### DIFF
--- a/c2c/Parser/C2Parser.cpp
+++ b/c2c/Parser/C2Parser.cpp
@@ -30,6 +30,7 @@ using namespace C2;
 using namespace clang;
 
 #ifdef PARSER_DEBUG
+#include <iostream>
 #include "Utils/color.h"
 #define LOG_FUNC std::cerr << ANSI_YELLOW << __func__ << "()" << ANSI_NORMAL << "\n";
 #else

--- a/test/CGenerator/Exprs/check_shift.c2t
+++ b/test/CGenerator/Exprs/check_shift.c2t
@@ -1,0 +1,25 @@
+// @recipe bin
+    $warnings no-unused
+    $generate-c
+
+// @file{file1}
+module test;
+
+public func i32 main(i32 argc, const i8*[] argv) {
+    i32 a = 1 << 2 + 1;
+    i32 b = (1 << 2) + 1;
+		i32 c = (1 >> 2) + 1;
+    return 0;
+}
+
+// @expect{atleast, build/test.c}
+
+int32_t main(int32_t argc, const char* argv[]) {
+
+    int32_t a = 1 << 2 + 1;
+    int32_t b = (1 << 2) + 1;
+		int32_t c = (1 >> 2) + 1;
+
+    return 0;
+}
+

--- a/test/Literals/warn_shift_gt_typewidth.c2
+++ b/test/Literals/warn_shift_gt_typewidth.c2
@@ -1,0 +1,5 @@
+// @warnings{no-unused}
+module test;
+
+i32 a = 13 >> 65;       // @warning{shift count >= width of type}
+

--- a/test/Literals/warn_shift_lhs_negative.c2
+++ b/test/Literals/warn_shift_lhs_negative.c2
@@ -1,0 +1,6 @@
+// @warnings{no-unused}
+module test;
+
+i32 a = -2 << 2;       // @warning{shifting a negative signed value is undefined}
+i32 b = -2 >> 2;       // @warning{shifting a negative signed value is undefined}
+

--- a/test/Literals/warn_shift_negative.c2
+++ b/test/Literals/warn_shift_negative.c2
@@ -1,0 +1,6 @@
+// @warnings{no-unused}
+module test;
+
+i32 a = 2 << -2;       // @warning{shift count is negative}
+i32 b = 3 >> -4;       // @warning{shift count is negative}
+


### PR DESCRIPTION
Added code for handling shr/shl operators in LiteralAnalyser. The previous default made them return a 1 bit result :(

Added warnings for lhs < 0, rhs < 0, and shift where shift was wider than lhs bit width.
Should probably add warning for lhs overflow too. But that requires a discussion. Added tests, one to reproduce the problem, three for the warnings.

I also added a missing include for when C2Parser has debug on.

Minor refactoring: since getting lhs/rhs was common, I extracted those values into locals.