### PR TITLE
[LANG-CHANGE] Update precedence rules, flattening the precedence hier…

### DIFF
--- a/c2c/AST/Expr.cpp
+++ b/c2c/AST/Expr.cpp
@@ -543,6 +543,34 @@ const char* BinaryOperator::OpCode2str(clang::BinaryOperatorKind opc_) {
     assert(0);
 }
 
+bool BinaryOperator::requiresParensForC() const
+{
+    switch (getOpcode()) {
+    case BO_Mul:
+    case BO_Div:
+    case BO_Rem:
+    case BO_Add:
+    case BO_Sub:
+    case BO_Shl:
+    case BO_Shr:
+    case BO_Cmp:
+    case BO_LT:
+    case BO_GT:
+    case BO_LE:
+    case BO_GE:
+    case BO_EQ:
+    case BO_NE:
+    case BO_And:
+    case BO_Xor:
+    case BO_Or:
+    case BO_LAnd:
+    case BO_LOr:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void BinaryOperator::print(StringBuilder& buffer, unsigned indent) const {
     buffer.indent(indent);
     buffer.setColor(COL_EXPR);

--- a/c2c/AST/Expr.h
+++ b/c2c/AST/Expr.h
@@ -457,6 +457,8 @@ public:
     Expr* getRHS() const { return rhs; }
     Opcode getOpcode() const { return static_cast<Opcode>(binaryOperatorBits.opcode); }
 
+    bool requiresParensForC() const;
+
     void printLiteral(StringBuilder& buffer) const;
 private:
     Expr* lhs;

--- a/c2c/CGenerator/CCodeGenerator.cpp
+++ b/c2c/CGenerator/CCodeGenerator.cpp
@@ -375,9 +375,12 @@ void CCodeGenerator::EmitBuiltinExpr(const Expr* E, StringBuilder& output) {
 void CCodeGenerator::EmitBinaryOperator(const Expr* E, StringBuilder& output) {
     LOG_FUNC
     const BinaryOperator* B = cast<BinaryOperator>(E);
+    bool requiresParens = B->requiresParensForC();
+    if (requiresParens) output << '(';
     EmitExpr(B->getLHS(), output);
     output << ' ' << BinaryOperator::OpCode2str(B->getOpcode()) << ' ';
     EmitExpr(B->getRHS(), output);
+    if (requiresParens) output << ')';
 }
 
 void CCodeGenerator::EmitConditionalOperator(const Expr* E, StringBuilder& output) {

--- a/c2c/Parser/C2Parser.cpp
+++ b/c2c/Parser/C2Parser.cpp
@@ -40,11 +40,6 @@ using namespace clang;
 /// \brief Return the precedence of the specified binary operator token.
 static prec::Level getBinOpPrecedence(tok::TokenKind Kind) {
     switch (Kind) {
-    case tok::greater:
-        return prec::Relational;
-    case tok::greatergreater:
-        return prec::Shift;
-    default:                        return prec::Unknown;
     case tok::comma:                return prec::Comma;
     case tok::equal:
     case tok::starequal:
@@ -58,24 +53,27 @@ static prec::Level getBinOpPrecedence(tok::TokenKind Kind) {
     case tok::caretequal:
     case tok::pipeequal:            return prec::Assignment;
     case tok::question:             return prec::Conditional;
-    case tok::pipepipe:             return prec::LogicalOr;
-    case tok::ampamp:               return prec::LogicalAnd;
-    case tok::pipe:                 return prec::InclusiveOr;
-    case tok::caret:                return prec::ExclusiveOr;
-    case tok::amp:                  return prec::And;
+    case tok::pipepipe:
+    case tok::ampamp:               return prec::LogicalAndOr;
+    case tok::pipe:
+    case tok::caret:
+    case tok::amp:                  return prec::Bitwise;
     case tok::exclaimequal:
-    case tok::equalequal:           return prec::Equality;
+    case tok::equalequal:
     case tok::lessequal:
     case tok::less:
+    case tok::greater:
     case tok::greaterequal:         return prec::Relational;
-    case tok::lessless:             return prec::Shift;
     case tok::plus:
     case tok::minus:                return prec::Additive;
+    case tok::lessless:
+    case tok::greatergreater:       return prec::Shift;
     case tok::percent:
     case tok::slash:
     case tok::star:                 return prec::Multiplicative;
     case tok::periodstar:
     case tok::arrowstar:            return prec::PointerToMember;
+    default:                        return prec::Unknown;
     }
 }
 

--- a/c2c/Parser/C2Parser.h
+++ b/c2c/Parser/C2Parser.h
@@ -39,27 +39,23 @@ class Expr;
 class FunctionDecl;
 class StructTypeDecl;
 
-/// PrecedenceLevels - These are precedences for the binary/ternary
-/// operators in the C99 grammar.  These have been named to relate
-/// with the C99 grammar productions.  Low precedences numbers bind
-/// more weakly than high numbers.
+/// PrecedenceLevels - These have been altered from C99 to C2
+/// In particular, addition now comes after bitwise and shifts
+/// Bitwise is directly after shift and equality and relational have
+/// the same precedence.
 namespace prec {
   enum Level {
     Unknown         = 0,    // Not binary operator.
     Comma           = 1,    // ,
     Assignment      = 2,    // =, *=, /=, %=, +=, -=, <<=, >>=, &=, ^=, |=
     Conditional     = 3,    // ?
-    LogicalOr       = 4,    // ||
-    LogicalAnd      = 5,    // &&
-    InclusiveOr     = 6,    // |
-    ExclusiveOr     = 7,    // ^
-    And             = 8,    // &
-    Equality        = 9,    // ==, !=
-    Relational      = 10,   //  >=, <=, >, <
-    Shift           = 11,   // <<, >>
-    Additive        = 12,   // -, +
-    Multiplicative  = 13,   // *, /, %
-    PointerToMember = 14    // .*, ->*
+    LogicalAndOr    = 4,    // &&, ||
+    Relational      = 5,    // ==, !=, >=, <=, >, <
+    Additive        = 6,    // -, +
+    Bitwise         = 7,    // ^, |, &
+    Shift           = 8,    // <<, >>
+    Multiplicative  = 9,    // *, /, %
+    PointerToMember = 10    // .*, ->*
   };
 }
 

--- a/test/CGenerator/Asm/gen_asm.c2t
+++ b/test/CGenerator/Asm/gen_asm.c2t
@@ -66,7 +66,7 @@ __inline__ static uint64_t test_rdtsc() {
   uint32_t hi;
   __asm__ volatile ("rdtsc" : "=a" (lo), "=d" (hi));
   uint32_t res = hi;
-  res << 32;
+  (res << 32);
   res |= lo;
   return res;
 }

--- a/test/CGenerator/Exprs/check_shift.c2t
+++ b/test/CGenerator/Exprs/check_shift.c2t
@@ -16,9 +16,9 @@ public func i32 main(i32 argc, const i8*[] argv) {
 
 int32_t main(int32_t argc, const char* argv[]) {
 
-    int32_t a = 1 << 2 + 1;
-    int32_t b = (1 << 2) + 1;
-		int32_t c = (1 >> 2) + 1;
+    int32_t a = ((1 << 2) + 1);
+    int32_t b = (((1 << 2)) + 1);
+		int32_t c = (((1 >> 2)) + 1);
 
     return 0;
 }

--- a/test/CGenerator/Exprs/prec_expr.c2t
+++ b/test/CGenerator/Exprs/prec_expr.c2t
@@ -1,0 +1,34 @@
+// @recipe bin
+    $warnings no-unused
+    $generate-c
+
+// @file{file1}
+module test;
+
+public func i32 main(i32 argc, const i8*[] argv) {
+    i32 a = 1 << 2 + 3;
+		a = 1 ^ 2 | 3 & 4;
+		a = 1 && 2 || 3 && 4 || 5;
+		a = 1 ^ 2 | 3 & 4 == 5 || 6 <= 5;
+    return 0;
+}
+
+// @expect{atleast, build/test.c}
+
+int32_t main(int32_t argc, const char* argv[]) {
+
+    int32_t a = ((1 << 2) + 3);
+//  int32_t a = (1 << (2 + 3)); C99
+
+		a = (((1 ^ 2) | 3) & 4);
+//	a = ((1 ^ 2) | (3 & 4)); C99
+
+    a = ((((1 && 2) || 3) && 4) || 5);
+//  a = (((1 && 2) || (3 && 4)) || 5); C99
+
+		a = (((((1 ^ 2) | 3) & 4) == 5) || (6 <= 5));
+//  a = (((1 ^ 2) | (3 & (4 == 5))) || (6 <= 5)); C99
+
+    return 0;
+}
+

--- a/test/CGenerator/Module/generate_multiple_modules.c2t
+++ b/test/CGenerator/Module/generate_multiple_modules.c2t
@@ -18,11 +18,11 @@ func i32 sum(i32 c, i32 d) {
 
 // @expect{atleast, build/mod1.c}
 static int32_t mod1_sum(int32_t a, int32_t b) {
-    return a + b;
+    return (a + b);
 }
 
 // @expect{atleast, build/mod2.c}
 static int32_t mod2_sum(int32_t c, int32_t d) {
-    return c + d;
+    return (c + d);
 }
 

--- a/test/CGenerator/Module/generate_single_module.c2t
+++ b/test/CGenerator/Module/generate_single_module.c2t
@@ -18,10 +18,10 @@ func i32 sum(i32 c, i32 d) {
 
 // @expect{atleast, build/test.c}
 static int32_t mod1_sum(int32_t a, int32_t b) {
-    return a + b;
+    return (a + b);
 }
 
 static int32_t mod2_sum(int32_t c, int32_t d) {
-    return c + d;
+    return (c + d);
 }
 

--- a/test/CGenerator/Stmts/for_loop_ok.c2t
+++ b/test/CGenerator/Stmts/for_loop_ok.c2t
@@ -20,10 +20,10 @@ public func i32 main(i32 argc, const i8*[] argv) {
 
 int32_t main(int32_t argc, const char* argv[]) {
     int32_t a = 0;
-    for (a = 0; a < 10; a++) {
+    for (a = 0; (a < 10); a++) {
     }
 
-    for (int32_t b = 0; b < 10; b++) {
+    for (int32_t b = 0; (b < 10); b++) {
     }
 
     for (;;) {

--- a/test/CGenerator/Stmts/while_stmt_expr.c2t
+++ b/test/CGenerator/Stmts/while_stmt_expr.c2t
@@ -24,8 +24,8 @@ public func i32 main(i32 argc, const i8*[] argv) {
 int32_t main(int32_t argc, const char* argv[]) {
     int32_t a = 0;
     while (a) {
-        if (argc == 1) continue;
-        if (argc == 2) break;
+        if ((argc == 1)) continue;
+        if ((argc == 2)) break;
     }
 
     int32_t b = 10;


### PR DESCRIPTION
…archy and increasing precedence of bitwise operators.

I did the (almost) simplest possible change here, adding () in as simple way as possible. A nicer solution would have been to actually check if the parent expression already was surrounded by () when printing to C.

Note that I haven't looked at anything but the AST and the C output. There might be subtle things that I have overlooked. Testcases are updated and a new test case for some of operators have been added.