### PR TITLE
Refactoring actual errors (panics)

### DIFF
--- a/c2c/AST/Attr.cpp
+++ b/c2c/AST/Attr.cpp
@@ -72,7 +72,7 @@ const AttrInfo& Attr::getInfo(AttrKind kind) {
         const AttrInfo* AI = &attrInfo[i];
         if (AI->kind == kind) return *AI;
     }
-    assert(0);
+    FATAL_ERROR("No attribute info found");
     static AttrInfo none;
     return none;
 }

--- a/c2c/AST/Attr.h
+++ b/c2c/AST/Attr.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <map>
 #include <assert.h>
-
+#include "Utils/Errors.h"
 #include <clang/Basic/SourceLocation.h>
 
 namespace C2 {
@@ -77,11 +77,11 @@ public:
     const char* kind2str() const;
 private:
     void* operator new(size_t bytes) noexcept {
-        assert(0 && "Attr cannot be allocated with regular 'new'");
+        FATAL_ERROR("Attr cannot be allocated with regular 'new'");
         return 0;
     }
     void operator delete(void* data) {
-        assert(0 && "Attr cannot be released with regular 'delete'");
+        FATAL_ERROR("Attr cannot be released with regular 'delete'");
     }
 
     clang::SourceRange Range;

--- a/c2c/AST/Decl.cpp
+++ b/c2c/AST/Decl.cpp
@@ -221,7 +221,7 @@ static const char* VarDeclKind2Str(VarDeclKind k) {
     case VARDECL_PARAM:  return "param";
     case VARDECL_MEMBER: return "member";
     }
-    assert(0);
+    FATAL_ERROR("Unreachable");
 }
 
 

--- a/c2c/AST/Decl.h
+++ b/c2c/AST/Decl.h
@@ -24,7 +24,7 @@
 
 #include "AST/Type.h"
 #include "AST/Attr.h"
-
+#include "Utils/Errors.h"
 using clang::SourceLocation;
 
 namespace llvm {
@@ -93,11 +93,11 @@ public:
     void dump() const;
 protected:
     void* operator new(size_t bytes) noexcept {
-        assert(0 && "Decl cannot be allocated with regular 'new'");
+        FATAL_ERROR("Decl cannot be allocated with regular 'new'");
         return 0;
     }
     void operator delete(void* data) {
-        assert(0 && "Decl cannot be released with regular 'delete'");
+        FATAL_ERROR("Decl cannot be released with regular 'delete'");
     }
 
     void printPublic(StringBuilder& buffer) const;

--- a/c2c/AST/Expr.cpp
+++ b/c2c/AST/Expr.cpp
@@ -393,7 +393,7 @@ static const char* reftype2str(IdentifierExpr::RefType ref) {
     case IdentifierExpr::REF_STRUCT_FUNC:   return "struct_func";
     case IdentifierExpr::REF_LABEL:         return "label";
     }
-    assert(0 && "should not come here");
+    FATAL_ERROR("should not come here");
     return "?";
 }
 
@@ -540,7 +540,7 @@ const char* BinaryOperator::OpCode2str(clang::BinaryOperatorKind opc_) {
     case BO_OrAssign: return "|=";
     case BO_Comma: return ",";
     }
-    assert(0);
+    FATAL_ERROR("should not come here");
 }
 
 void BinaryOperator::print(StringBuilder& buffer, unsigned indent) const {
@@ -604,10 +604,8 @@ const char* UnaryOperator::OpCode2str(clang::UnaryOperatorKind opc_) {
     case UO_Not:        return "~";
     case UO_LNot:       return "!";
     default:
-        assert(0);
-        break;
+        FATAL_ERROR("should not come here");
     }
-    return "";
 }
 
 void UnaryOperator::print(StringBuilder& buffer, unsigned indent) const {

--- a/c2c/AST/Expr.h
+++ b/c2c/AST/Expr.h
@@ -145,7 +145,7 @@ public:
             r = RADIX_16;
             break;
         default:
-            assert(0 && "unsupported radix");
+            FATAL_ERROR("unsupported radix");
             break;
         }
         integerLiteralBits.Radix = r;

--- a/c2c/AST/Stmt.h
+++ b/c2c/AST/Stmt.h
@@ -17,6 +17,7 @@
 #define AST_STMT_H
 
 #include <vector>
+#include "Utils/Errors.h"
 
 #include <clang/Basic/SourceLocation.h>
 
@@ -63,11 +64,11 @@ public:
 protected:
     // See Clang comments in include/clang/AST/Stmt.h about operator new/delete
     void* operator new(size_t bytes) noexcept {
-        assert(0 && "Stmt cannot be allocated with regular 'new'");
+        FATAL_ERROR("Stmt cannot be allocated with regular 'new'");
         return 0;
     }
     void operator delete(void* data) {
-        assert(0 && "Stmt cannot be released with regular 'delete'");
+        FATAL_ERROR("Stmt cannot be released with regular 'delete'");
     }
 
 public:

--- a/c2c/AST/Type.cpp
+++ b/c2c/AST/Type.cpp
@@ -104,17 +104,17 @@ bool QualType::isConstant() const {
         return cast<ArrayType>(T)->getElementType().isConstant();
     case TC_UNRESOLVED:
     case TC_ALIAS:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     case TC_STRUCT:
         return isConstQualified();
     case TC_ENUM:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     case TC_FUNCTION:
         return isConstQualified();
     case TC_MODULE:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     }
     return false;
@@ -298,7 +298,7 @@ void Type::DiagName(StringBuilder& buf) const {
 #if 0
 void Type::debugPrint(StringBuilder& buffer) const {
     // NOTE: never used
-    assert(0);
+    FATAL_ERROR("Unreachable");
     // only used to print canonical type (called by Sub-Class::debugPrint())
     buffer << "  canonical=";
     if (canonicalType.isNull()) {

--- a/c2c/AST/Type.h
+++ b/c2c/AST/Type.h
@@ -18,7 +18,7 @@
 
 #include <assert.h>
 #include <stddef.h>
-
+#include "Utils/Errors.h"
 #include <llvm/ADT/APInt.h>
 
 #define QUAL_CONST      (0x1)
@@ -140,11 +140,11 @@ protected:
     }
 
     void* operator new(size_t bytes) noexcept {
-        assert(0 && "Type cannot be allocated with regular 'new'");
+        FATAL_ERROR("Type cannot be allocated with regular 'new'");
         return 0;
     }
     void operator delete(void* data) {
-        assert(0 && "Type cannot be released with regular 'delete'");
+        FATAL_ERROR("Type cannot be released with regular 'delete'");
     }
 
     void printName(StringBuilder& buffer) const;

--- a/c2c/Algo/ASTVisitor.cpp
+++ b/c2c/Algo/ASTVisitor.cpp
@@ -20,6 +20,7 @@
 #include "AST/Decl.h"
 #include "AST/Stmt.h"
 #include "AST/Expr.h"
+#include "Utils/Errors.h"
 
 using namespace C2;
 
@@ -37,7 +38,7 @@ void ASTVisitor::checkDecl(const Decl* D) {
         checkVarDecl(cast<VarDecl>(D));
         break;
     case DECL_ENUMVALUE:
-        assert(0);
+        TODO; // Is this a TODO or fatal error?
         break;
     case DECL_ALIASTYPE:
         checkType(cast<AliasTypeDecl>(D)->getRefType());
@@ -66,7 +67,7 @@ void ASTVisitor::checkDecl(const Decl* D) {
         break;
     }
     case DECL_ARRAYVALUE:
-        assert(0 && "TODO");
+        TODO;
         break;
     case DECL_IMPORT:
     case DECL_LABEL:
@@ -125,7 +126,7 @@ void ASTVisitor::checkType(QualType Q, bool isFull) {
     case TC_FUNCTION:
         break;
     case TC_MODULE:
-        assert(0);
+        FATAL_ERROR("Unexpected type");
         break;
     }
 }

--- a/c2c/Algo/DepVisitor.cpp
+++ b/c2c/Algo/DepVisitor.cpp
@@ -37,7 +37,7 @@ void DepVisitor::checkDecl(const Decl* D) {
         checkVarDecl(cast<VarDecl>(D));
         break;
     case DECL_ENUMVALUE:
-        assert(0);
+        TODO; // FATAL_ERROR or handle?
         break;
     case DECL_ALIASTYPE:
         checkType(cast<AliasTypeDecl>(D)->getRefType());
@@ -66,7 +66,7 @@ void DepVisitor::checkDecl(const Decl* D) {
         break;
     }
     case DECL_ARRAYVALUE:
-        assert(0 && "TODO");
+        TODO;
         break;
     case DECL_IMPORT:
     case DECL_LABEL:
@@ -124,7 +124,7 @@ void DepVisitor::checkType(QualType Q, bool isFullDep) {
         addDep(cast<FunctionType>(T)->getDecl(), isFullDep);
         break;
     case TC_MODULE:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     }
 }

--- a/c2c/Analyser/ExprTypeAnalyser.cpp
+++ b/c2c/Analyser/ExprTypeAnalyser.cpp
@@ -23,6 +23,7 @@
 #include "AST/Expr.h"
 #include "AST/Type.h"
 #include "Utils/StringBuilder.h"
+#include "Utils/Errors.h"
 
 using namespace C2;
 using namespace llvm;
@@ -96,7 +97,7 @@ void ExprTypeAnalyser::check(QualType TLeft, const Expr* expr) {
         // always CTC_NONE
     case EXPR_INITLIST:
     case EXPR_DESIGNATOR_INIT:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_BINOP:
         checkBinOp(TLeft, cast<BinaryOperator>(expr));
@@ -116,19 +117,19 @@ void ExprTypeAnalyser::check(QualType TLeft, const Expr* expr) {
     case EXPR_ARRAYSUBSCRIPT:
     case EXPR_MEMBER:
         // can be CTC_NONE or CTC_FULL
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_PAREN:
         check(TLeft, cast<ParenExpr>(expr)->getExpr());
         return;
     case EXPR_BITOFFSET:
-        assert(0 && "TODO");
+        TODO;
         return;
     case EXPR_CAST:
-        assert(0 && "TODO");
+        TODO;
         return;
     }
-    assert(0 && "should not come here");
+    FATAL_ERROR("Unreachable");
 }
 
 bool ExprTypeAnalyser::checkExplicitCast(const ExplicitCastExpr* expr, QualType DestType, QualType SrcType) {
@@ -191,16 +192,16 @@ bool ExprTypeAnalyser::checkNonPointerCast(const ExplicitCastExpr* expr, QualTyp
     case TC_BUILTIN:
         return checkBuiltinCast(expr, DestType, SrcType);
     case TC_POINTER:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     case TC_ARRAY:
-        // TODO
+        TODO;
         break;
     case TC_UNRESOLVED:
-        // TODO
+        TODO;
         break;
     case TC_ALIAS:
-        // TODO
+        TODO;
         break;
     case TC_STRUCT:
         // no casts allowed
@@ -253,21 +254,21 @@ bool ExprTypeAnalyser::checkBuiltinCast(const ExplicitCastExpr* expr, QualType D
         case 5: // loss of fp-precision
             break;
         default:
-            assert(0 && "should not come here");
+            FATAL_ERROR("Unreachable");
         }
         return true;
     }
     case TC_POINTER:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     case TC_ARRAY:
-        // TODO
+        TODO;
         break;
     case TC_UNRESOLVED:
     case TC_ALIAS:
     case TC_STRUCT:
     case TC_ENUM:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     case TC_FUNCTION:
         // only allow if uint32/64 (ptr size)
@@ -282,7 +283,7 @@ bool ExprTypeAnalyser::checkBuiltinCast(const ExplicitCastExpr* expr, QualType D
         }
         break;
     case TC_MODULE:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     }
     return true;
@@ -298,14 +299,14 @@ bool ExprTypeAnalyser::checkEnumCast(const ExplicitCastExpr* expr, QualType Dest
     case TC_UNRESOLVED:
     case TC_ALIAS:
     case TC_STRUCT:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     case TC_ENUM:
         return true;    // allow
     case TC_FUNCTION:
         break;          // deny
     case TC_MODULE:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     }
     StringBuilder buf1(MAX_LEN_TYPENAME);
@@ -339,7 +340,8 @@ bool ExprTypeAnalyser::checkFunctionCast(const ExplicitCastExpr* expr, QualType 
     case TC_UNRESOLVED:
     case TC_ALIAS:
     case TC_STRUCT:
-        assert(0 && "should not come here");
+        FATAL_ERRORF("Test %d", 1);
+        FATAL_ERROR("Unreachable");
         return false;
     case TC_ENUM:
         break;          // deny
@@ -356,7 +358,7 @@ bool ExprTypeAnalyser::checkFunctionCast(const ExplicitCastExpr* expr, QualType 
 */
     }
     case TC_MODULE:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         return false;
     }
     StringBuilder buf1(MAX_LEN_TYPENAME);
@@ -373,7 +375,7 @@ void ExprTypeAnalyser::checkBinOp(QualType TLeft, const BinaryOperator* binop) {
     switch (binop->getOpcode()) {
     case BO_PtrMemD:
     case BO_PtrMemI:
-        assert(0 && "TODO");
+        TODO;
         break;
     case BO_Mul:
     case BO_Div:
@@ -408,10 +410,10 @@ void ExprTypeAnalyser::checkBinOp(QualType TLeft, const BinaryOperator* binop) {
     case BO_AndAssign:
     case BO_XorAssign:
     case BO_OrAssign:
-        assert(0 && "TODO");
+        TODO;
         break;
     case BO_Comma:
-        assert(0 && "TODO?");
+        TODO;
         break;
     }
 }
@@ -440,7 +442,7 @@ bool ExprTypeAnalyser::checkCompatible(QualType left, const Expr* expr) const {
     case TC_FUNCTION:
         return checkFunction(left, expr);
     case TC_MODULE:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     return false;
@@ -493,7 +495,7 @@ bool ExprTypeAnalyser::checkBuiltin(QualType left, QualType right, const Expr* e
             errorMsg = diag::warn_impcast_float_precision;
             break;
         default:
-            assert(0 && "should not come here");
+            FATAL_ERROR("Unreachable");
             break;
         }
         StringBuilder buf1(MAX_LEN_TYPENAME);

--- a/c2c/Analyser/FileAnalyser.cpp
+++ b/c2c/Analyser/FileAnalyser.cpp
@@ -90,7 +90,7 @@ unsigned FileAnalyser::resolveTypeCanonicals() {
         case DECL_FUNC:
         case DECL_VAR:
         case DECL_ENUMVALUE:
-            assert(0);
+            TODO; // fatal error?
             break;
         case DECL_ALIASTYPE:
             // nothing to do
@@ -111,7 +111,7 @@ unsigned FileAnalyser::resolveTypeCanonicals() {
         case DECL_ARRAYVALUE:
         case DECL_IMPORT:
         case DECL_LABEL:
-            assert(0);
+            FATAL_ERROR("Cannot have type");
             break;
         }
     }
@@ -348,7 +348,7 @@ unsigned FileAnalyser::checkTypeDecl(TypeDecl* D) {
     case DECL_FUNC:
     case DECL_VAR:
     case DECL_ENUMVALUE:
-        assert(0);
+        FATAL_ERROR("Cannot have type");
         break;
     case DECL_ALIASTYPE:
         // Any UnresolvedType should point to decl that has type set
@@ -385,7 +385,7 @@ unsigned FileAnalyser::checkTypeDecl(TypeDecl* D) {
     case DECL_ARRAYVALUE:
     case DECL_IMPORT:
     case DECL_LABEL:
-        assert(0);
+        FATAL_ERROR("Cannot have type decl");
         break;
     }
     return errors;

--- a/c2c/Analyser/FunctionAnalyser.cpp
+++ b/c2c/Analyser/FunctionAnalyser.cpp
@@ -259,7 +259,7 @@ void FunctionAnalyser::analyseStmt(Stmt* S, bool haveScope) {
         break;
     case STMT_CASE:
     case STMT_DEFAULT:
-        assert(0 && "not done here");
+        FATAL_ERROR("Unreachable"); // Done at other place.
         break;
     case STMT_BREAK:
         analyseBreakStmt(S);
@@ -382,7 +382,7 @@ void FunctionAnalyser::analyseSwitchStmt(Stmt* stmt) {
             analyseDefaultStmt(C);
             break;
         default:
-            assert(0);
+            FATAL_ERROR("Unreachable");
         }
     }
 
@@ -669,7 +669,7 @@ C2::QualType FunctionAnalyser::analyseExpr(Expr* expr, unsigned side) {
             expr->setConstant();
             break;
         case DECL_LABEL:
-            assert(0 && "TODO");
+            TODO;
             break;
         }
         if (side & RHS) {
@@ -701,7 +701,7 @@ C2::QualType FunctionAnalyser::analyseExpr(Expr* expr, unsigned side) {
     case EXPR_PAREN:
         return analyseParenExpr(expr);
     case EXPR_BITOFFSET:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_CAST:
         return analyseExplicitCastExpr(expr);
@@ -897,6 +897,7 @@ void FunctionAnalyser::analyseInitList(InitListExpr* expr, QualType Q) {
         switch (numValues) {
         case 0:
             fprintf(stderr, "TODO ERROR: scalar initializer cannot be empty\n");
+            TODO;
             break;
         case 1:
         {
@@ -966,7 +967,7 @@ void FunctionAnalyser::analyseSizeOfExpr(BuiltinExpr* B) {
         return;
     case EXPR_CALL:
         // not allowed
-        assert(0 && "TODO good error");
+        TODO; // assert(0 && "TODO good error");
         return;
     case EXPR_IDENTIFIER:
     {
@@ -988,20 +989,20 @@ void FunctionAnalyser::analyseSizeOfExpr(BuiltinExpr* B) {
             // ok
             return;
         case DECL_ARRAYVALUE:
-            assert(0 && "should not happen");
+            FATAL_ERROR("Unreachable");
             break;
         case DECL_IMPORT:
             Diag(id->getLocation(), diag::err_is_a_module) << id->getName();
             return;
         case DECL_LABEL:
-            assert(0 && "TODO");
+            TODO;
             break;
         }
         break;
     }
     case EXPR_INITLIST:
     case EXPR_DESIGNATOR_INIT:
-        assert(0 && "TODO good error");
+        TODO; // Good error
         return;
     case EXPR_TYPE:
     {
@@ -1014,28 +1015,28 @@ void FunctionAnalyser::analyseSizeOfExpr(BuiltinExpr* B) {
     }
     case EXPR_BINOP:
         // not allowed
-        assert(0 && "TODO good error");
+        TODO; // good error
     case EXPR_CONDOP:
-        assert(0 && "TODO allow?");
+        TODO; // TODO allow?
         return;
     case EXPR_UNARYOP:
         // some allowed (&)?
         // TODO
         return;
     case EXPR_BUILTIN:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         return;
     case EXPR_ARRAYSUBSCRIPT:
     case EXPR_MEMBER:
         // allowed
-        assert(0 && "TODO");
+        TODO;
         return;
     case EXPR_PAREN:
     case EXPR_BITOFFSET:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_CAST:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
 }
@@ -1100,7 +1101,7 @@ void FunctionAnalyser::analyseArrayType(VarDecl* V, QualType T) {
 
     switch (T->getTypeClass()) {
     case TC_BUILTIN:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     case TC_POINTER:
         analyseArrayType(V, cast<PointerType>(T)->getPointeeType());
@@ -1113,7 +1114,7 @@ void FunctionAnalyser::analyseArrayType(VarDecl* V, QualType T) {
         break;
     }
     case TC_UNRESOLVED:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     case TC_ALIAS:
         analyseArrayType(V, cast<AliasType>(T)->getRefType());
@@ -1121,10 +1122,10 @@ void FunctionAnalyser::analyseArrayType(VarDecl* V, QualType T) {
     case TC_STRUCT:
     case TC_ENUM:
     case TC_FUNCTION:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     case TC_MODULE:
-        assert(0 && "TBD");
+        TODO;
         break;
     }
 }
@@ -1177,7 +1178,7 @@ static ExprCTC combineCtc(Expr* Result, const Expr* L, const Expr* R) {
         Result->setCTC(CTC_FULL);
         return CTC_FULL;
     }
-    assert(0 && "should not come here");
+    FATAL_ERROR("Unreachable");
     return CTC_NONE;
 }
 
@@ -1217,7 +1218,7 @@ QualType FunctionAnalyser::analyseBinaryOperator(Expr* expr, unsigned side) {
     switch (binop->getOpcode()) {
     case BO_PtrMemD:
     case BO_PtrMemI:
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     case BO_Mul:
     case BO_Div:
@@ -1233,7 +1234,7 @@ QualType FunctionAnalyser::analyseBinaryOperator(Expr* expr, unsigned side) {
         if (Left->isConstant() && Right->isConstant()) expr->setConstant();
         break;
     case BO_Cmp: // C++20 only
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     case BO_LE:
     case BO_LT:
@@ -1279,7 +1280,7 @@ QualType FunctionAnalyser::analyseBinaryOperator(Expr* expr, unsigned side) {
         TRight = analyseExpr(Right, RHS);
         break;
     case BO_Comma:
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     }
     if (TLeft.isNull() || TRight.isNull()) return QualType();
@@ -1289,7 +1290,7 @@ QualType FunctionAnalyser::analyseBinaryOperator(Expr* expr, unsigned side) {
     switch (binop->getOpcode()) {
     case BO_PtrMemD:
     case BO_PtrMemI:
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     case BO_Mul:
     case BO_Div:
@@ -1308,7 +1309,7 @@ QualType FunctionAnalyser::analyseBinaryOperator(Expr* expr, unsigned side) {
         Result = TLeft;
         break;
     case BO_Cmp: // C++20 only
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     case BO_LE:
     case BO_LT:
@@ -1355,7 +1356,7 @@ QualType FunctionAnalyser::analyseBinaryOperator(Expr* expr, unsigned side) {
         Result = TLeft;
         break;
     case BO_Comma:
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     }
     expr->setType(Result);
@@ -1446,7 +1447,7 @@ QualType FunctionAnalyser::analyseUnaryOperator(Expr* expr, unsigned side) {
         expr->setType(LType);
         break;
     default:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     return LType;
@@ -1777,7 +1778,7 @@ QualType FunctionAnalyser::analyseBitOffsetExpr(Expr* expr, QualType BaseType, S
             } else if (width.ult(64+1)) {
                 T = Type::UInt64();
             } else {
-                assert(0 && "should not happen");
+                FATAL_ERROR("Unreachable");
             }
             B->setType(T);
             B->setWidth((unsigned char)width.getSExtValue());
@@ -1892,6 +1893,7 @@ bool FunctionAnalyser::checkCallArgs(FunctionDecl* func, CallExpr* call) {
             // TODO use canonical
             if (callArgType == Type::Void()) {
                 fprintf(stderr, "ERROR: (TODO) passing 'void' to parameter of incompatible type '...'\n");
+                TODO;
                 //Diag(callArg->getLocation(), diag::err_typecheck_convert_incompatible)
                 //    << "from" << "to" << 1;// << callArg->getLocation();
             }
@@ -1978,7 +1980,7 @@ bool FunctionAnalyser::checkAssignee(Expr* expr) const {
         // ok
         return true;
     case EXPR_CAST:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     // expr is not assignable
@@ -2006,6 +2008,7 @@ void FunctionAnalyser::checkDeclAssignment(Decl* decl, Expr* expr) {
     case DECL_FUNC:
         // error
         fprintf(stderr, "TODO cannot assign to non-variable\n");
+        TODO;
         break;
     case DECL_VAR:
     {
@@ -2023,10 +2026,11 @@ void FunctionAnalyser::checkDeclAssignment(Decl* decl, Expr* expr) {
     case DECL_ARRAYVALUE:
         // error
         fprintf(stderr, "TODO cannot assign to non-variable\n");
+        TODO;
         break;
     case DECL_IMPORT:
     case DECL_LABEL:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     }
 }
@@ -2149,7 +2153,7 @@ QualType FunctionAnalyser::getStructType(QualType Q) const {
     case TC_ARRAY:
         return QualType();
     case TC_UNRESOLVED:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         return QualType();
     case TC_ALIAS:
     {
@@ -2163,7 +2167,7 @@ QualType FunctionAnalyser::getStructType(QualType Q) const {
     case TC_MODULE:
         return QualType();
     }
-    assert(0);
+    FATAL_ERROR("Unreachable");
 }
 
 QualType FunctionAnalyser::getConditionType(const Stmt* C) const {
@@ -2173,7 +2177,7 @@ QualType FunctionAnalyser::getConditionType(const Stmt* C) const {
     if (const DeclStmt* D = dyncast<DeclStmt>(C)) {
         return D->getDecl()->getType();
     }
-    assert(0 && "invalid Condition");
+    FATAL_ERROR("Invalid Condition");
     return QualType();
 }
 

--- a/c2c/Analyser/LiteralAnalyser.cpp
+++ b/c2c/Analyser/LiteralAnalyser.cpp
@@ -75,7 +75,7 @@ static const Limit* getLimit(int width) {
     case 64: return &limits[8];
     default:
         fprintf(stderr, "UNHANDLED width %d\n", width);
-        assert(0 && "todo");
+        TODO;
         return 0;
     }
 }
@@ -97,6 +97,7 @@ void LiteralAnalyser::check(QualType TLeft, const Expr* Right) {
 
         // TODO should be done elsewhere (checking if conversion is allowed)
         fprintf(stderr, "TODO refactor checking!!, type conversion not allowed\n");
+        TODO;
 #if 0
         // this part should be used when checking casting CTC's to Enum types
         APSInt Result = checkLiterals(Right);
@@ -217,7 +218,7 @@ APSInt LiteralAnalyser::checkLiterals(const Expr* Right) {
     case EXPR_INITLIST:
         break;
     case EXPR_DESIGNATOR_INIT:
-        assert(0 && "TODO");
+        TODO;
         break;
     case EXPR_BINOP:
         return checkBinaryLiterals(Right);
@@ -244,7 +245,7 @@ APSInt LiteralAnalyser::checkLiterals(const Expr* Right) {
         return checkLiterals(P->getExpr());
     }
     case EXPR_BITOFFSET:
-        assert(0 && "TODO");
+        TODO;
         break;
     case EXPR_CAST:
     {
@@ -292,7 +293,7 @@ bool LiteralAnalyser::checkRange(QualType TLeft, const Expr* Right, clang::Sourc
         availableWidth = TL->getIntegerWidth();
     } else {
         QT.dump();
-        assert(0 && "todo");
+        TODO;
     }
 
     const Limit* L = getLimit(availableWidth);
@@ -346,22 +347,20 @@ APSInt LiteralAnalyser::checkUnaryLiterals(const Expr* Right) {
     case UO_AddrOf:
     case UO_Deref:
     case UO_Plus:
-        // TODO
+        TODO;
         break;
     case UO_Minus:
+        return -checkLiterals(unaryop->getExpr());
+    case UO_Not:
     {
         APSInt Result = checkLiterals(unaryop->getExpr());
-        APInt invert(64, -1, true);
-        APSInt I(invert, false);
-        Result *= I;
+        Result = Result == 0 ? 1 : 0;
         return Result;
     }
-    case UO_Not:
     case UO_LNot:
-        // TODO
-        break;
+        return ~checkLiterals(unaryop->getExpr());
     default:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     return APSInt();
@@ -513,7 +512,7 @@ APSInt LiteralAnalyser::checkDecl(const Decl* D) {
         assert(VD->getInitValue());
         return checkLiterals(VD->getInitValue());
     }
-    assert(0 && "should not come here");
+    FATAL_ERROR("Unreachable");
     return APSInt();
 }
 

--- a/c2c/Analyser/TypeFinder.cpp
+++ b/c2c/Analyser/TypeFinder.cpp
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include "Analyser/TypeFinder.h"
 #include "AST/Expr.h"
+#include "Utils/Errors.h"
 
 using namespace C2;
 using namespace llvm;
@@ -34,13 +35,13 @@ QualType TypeFinder::findType(const Expr* expr) {
     case EXPR_IDENTIFIER:
         break;
     case EXPR_TYPE:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_CALL:
         break;
     case EXPR_INITLIST:
     case EXPR_DESIGNATOR_INIT:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_BINOP:
         return getBinOpType(cast<BinaryOperator>(expr));
@@ -49,7 +50,7 @@ QualType TypeFinder::findType(const Expr* expr) {
     case EXPR_UNARYOP:
         return getUnaryOpType(cast<UnaryOperator>(expr));
     case EXPR_BUILTIN:
-        assert(0 && "should not come here");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_ARRAYSUBSCRIPT:
     case EXPR_MEMBER:
@@ -59,7 +60,7 @@ QualType TypeFinder::findType(const Expr* expr) {
     case EXPR_BITOFFSET:
         break;
     case EXPR_CAST:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     return expr->getType();
@@ -69,7 +70,7 @@ QualType TypeFinder::getBinOpType(const BinaryOperator* binop) {
     switch (binop->getOpcode()) {
     case BO_PtrMemD:
     case BO_PtrMemI:
-        assert(0 && "TODO?");
+        TODO; // ?
         break;
     case BO_Mul:
     case BO_Div:
@@ -80,10 +81,10 @@ QualType TypeFinder::getBinOpType(const BinaryOperator* binop) {
         return LargestType(binop->getLHS(), binop->getRHS());
     case BO_Shl:
     case BO_Shr:
-        assert(0 && "TODO");
+        TODO;
         break;
     case BO_Cmp: // C++20 only
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     case BO_LE:
     case BO_LT:
@@ -112,7 +113,7 @@ QualType TypeFinder::getBinOpType(const BinaryOperator* binop) {
         // return LHS type
         return findType(binop->getLHS());
     case BO_Comma:
-        assert(0 && "TODO?");
+        TODO;
         break;
     }
     return binop->getType();
@@ -137,7 +138,7 @@ QualType TypeFinder::getUnaryOpType(const UnaryOperator* unaryop) {
         // should be bool already
         break;
     default:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     return unaryop->getType();

--- a/c2c/Analyser/TypeResolver.cpp
+++ b/c2c/Analyser/TypeResolver.cpp
@@ -59,10 +59,10 @@ unsigned TypeResolver::checkType(QualType Q, bool used_public) {
         // ok (TypeDecl will be checked)
         return 0;
     case TC_MODULE:
-        assert(0 && "TBD");
+        TODO;
         return 0;
     }
-    assert(0);
+    FATAL_ERROR("Unreachable");
 }
 
 unsigned TypeResolver::checkUnresolvedType(const UnresolvedType* type, bool used_public) {
@@ -147,7 +147,7 @@ QualType TypeResolver::resolveUnresolved(QualType Q) const {
     case TC_FUNCTION:
         return Q;
     case TC_MODULE:
-        assert(0 && "TBD");
+        TODO;
         return Q;
     }
     return Q;
@@ -268,17 +268,15 @@ QualType TypeResolver::checkCanonicals(Decls& decls, QualType Q, bool set) const
     case TC_STRUCT:
         return Q.getCanonicalType();
     case TC_ENUM:
-    {
-        assert(0 && "TODO");
+        TODO;
         return 0;
-    }
     case TC_FUNCTION:
         return Q.getCanonicalType();
     case TC_MODULE:
-        assert(0 && "TBD");
+        TODO;
         return 0;
     }
-    assert(0);
+    FATAL_ERROR("Unreachable");
 }
 
 QualType TypeResolver::resolveCanonical(QualType Q) const {
@@ -324,7 +322,7 @@ QualType TypeResolver::resolveCanonical(QualType Q) const {
         }
     }
     case TC_UNRESOLVED:
-        assert(0 && "should not get here");
+        FATAL_ERROR("Unreachable");
         return QualType();
     case TC_ALIAS:
     case TC_STRUCT:
@@ -332,10 +330,10 @@ QualType TypeResolver::resolveCanonical(QualType Q) const {
     case TC_FUNCTION:
         return Q.getCanonicalType();
     case TC_MODULE:
-        assert(0 && "TBD");
+        TODO;
         return Q;
     }
-    assert(0);
+    FATAL_ERROR("Unreachable");
 }
 
 bool TypeResolver::checkDecls(Decls& decls, const Decl* D) const {

--- a/c2c/Builder/C2Builder.cpp
+++ b/c2c/Builder/C2Builder.cpp
@@ -373,7 +373,7 @@ int C2Builder::build() {
     // add current directory (=project root) to #include path
     char pwd[512];
     if (getcwd(pwd, 512) == 0) {
-        assert(0);
+        FATAL_ERROR("Failed to get current directory");
     }
     HSOpts->AddPath(pwd, clang::frontend::Quoted, false, false);
 

--- a/c2c/CGenerator/CCodeGenerator.cpp
+++ b/c2c/CGenerator/CCodeGenerator.cpp
@@ -338,7 +338,7 @@ void CCodeGenerator::EmitExpr(const Expr* E, StringBuilder& output) {
         return;
     }
     case EXPR_BITOFFSET:
-        assert(0 && "should not happen");
+        FATAL_ERROR("should not happen");
         break;
     case EXPR_CAST:
     {
@@ -414,7 +414,7 @@ void CCodeGenerator::EmitUnaryOperator(const Expr* E, StringBuilder& output) {
         EmitExpr(U->getExpr(), output);
         break;
     default:
-        assert(0);
+        FATAL_ERROR("Unreachable");
     }
 }
 
@@ -745,7 +745,7 @@ void CCodeGenerator::EmitTypeDecl(const TypeDecl* T) {
     case DECL_FUNC:
     case DECL_VAR:
     case DECL_ENUMVALUE:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     case DECL_ALIASTYPE:
         *out << "typedef ";
@@ -768,7 +768,7 @@ void CCodeGenerator::EmitTypeDecl(const TypeDecl* T) {
     case DECL_ARRAYVALUE:
     case DECL_IMPORT:
     case DECL_LABEL:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     }
 }
@@ -810,7 +810,7 @@ void CCodeGenerator::EmitStructType(const StructTypeDecl* S, StringBuilder& out,
         } else if (isa<StructTypeDecl>(member)) {
             EmitStructType(cast<StructTypeDecl>(member), out, indent+INDENT);
         } else {
-            assert(0);
+            FATAL_ERROR("Member is neither struct nor var");
         }
     }
     out.indent(indent);
@@ -925,7 +925,7 @@ void CCodeGenerator::EmitStmt(const Stmt* S, unsigned indent) {
         return;
     case STMT_CASE:
     case STMT_DEFAULT:
-        assert(0 && "Should already be generated");
+        FATAL_ERROR("Should already be generated");
         break;
     case STMT_BREAK:
         cbuf.indent(indent);
@@ -1120,7 +1120,7 @@ void CCodeGenerator::EmitSwitchStmt(const Stmt* S, unsigned indent) {
             break;
         }
         default:
-            assert(0);
+            FATAL_ERROR("Unreachable");
         }
     }
 
@@ -1238,7 +1238,7 @@ static const char* builtin2cname(BuiltinType::Kind kind) {
     case BuiltinType::Bool:     return "int";
     case BuiltinType::Void:     return "void";
     }
-    assert(0 && "should not come here");
+    FATAL_ERROR("Unreachable");
     return 0;
 }
 
@@ -1284,7 +1284,7 @@ void CCodeGenerator::EmitTypePreName(QualType type, StringBuilder& output) {
         EmitDecl(cast<FunctionType>(T)->getDecl(), output);
         break;
     case TC_MODULE:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
 }

--- a/c2c/CMakeLists.txt
+++ b/c2c/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(c2core
     Parser/C2Parser.cpp
     Parser/ParserHelpers.cpp
     Parser/C2Sema.cpp
+    Parser/Lexer.cpp
     Analyser/AnalyserUtils.cpp
     Analyser/Scope.cpp
     Analyser/TypeResolver.cpp

--- a/c2c/IRGenerator/CodeGenFunction.cpp
+++ b/c2c/IRGenerator/CodeGenFunction.cpp
@@ -149,8 +149,8 @@ void CodeGenFunction::EmitStmt(const Stmt* S) {
     case STMT_CONTINUE:
     case STMT_LABEL:
     case STMT_GOTO:
-        assert(0 && "TODO");
         S->dump();
+        TODO;
         break;
     case STMT_COMPOUND:
         EmitCompoundStmt(cast<CompoundStmt>(S));
@@ -159,8 +159,8 @@ void CodeGenFunction::EmitStmt(const Stmt* S) {
         EmitVarDecl(cast<DeclStmt>(S)->getDecl());
         break;
     case STMT_ASM:
-        assert(0 && "TODO");
         S->dump();
+        TODO;
         break;
     }
 }
@@ -196,7 +196,7 @@ void CodeGenFunction::EmitIfStmt(const IfStmt* S) {
     //RunCleanupsScope ConditionScope(*this);
 
     if (S->getConditionVariable()) {
-        assert(0 && "TODO");
+        TODO;
         //EmitAutoVarDecl(S->getConditionVariable());
     }
 
@@ -462,7 +462,7 @@ llvm::Value* CodeGenFunction::EmitExprNoImpCast(const Expr* E) {
         return Builder.CreateGlobalStringPtr(S->getValue());
     }
     case EXPR_NIL:
-        fprintf(stderr, "WARNING: implicit casts missing for NilExpr! - invalid IR\n");
+        fprintf(stderr, "WARNING: implicit casts missing for NilExpr! - invalid IR\n"); //TODO
         return llvm::ConstantPointerNull::get(CGM.getVoidPtrType());
     case EXPR_CALL:
         return EmitCallExpr(cast<CallExpr>(E));
@@ -497,7 +497,7 @@ llvm::Value* CodeGenFunction::EmitExprNoImpCast(const Expr* E) {
         break;
     }
     E->dump();
-    assert(0 && "TODO");
+    TODO;
     return 0;
 }
 
@@ -533,6 +533,7 @@ llvm::Value* CodeGenFunction::EmitCallExpr(const CallExpr* E) {
     break;
     default:
         assert(0 && "TODO unsupported call type");
+        TODO;
         return 0;
     };
     // TODO optimize buffer below (lots of copying)
@@ -590,7 +591,7 @@ llvm::Value* CodeGenFunction::EmitIdentifierExpr(const IdentifierExpr* E) {
     assert(D);
     switch (D->getKind()) {
     case DECL_FUNC:
-        assert(0);
+        FATAL_ERROR("Unexpected declaration");
         break;
     case DECL_VAR:
     {
@@ -621,7 +622,7 @@ llvm::Value* CodeGenFunction::EmitIdentifierExpr(const IdentifierExpr* E) {
     case DECL_LABEL:
         break;
     }
-    assert(0 && "TODO?");
+    TODO;
     return 0;
 }
 
@@ -679,7 +680,7 @@ llvm::Value* CodeGenFunction::EmitBinaryOperator(const BinaryOperator* B) {
     case BO_Shr:
         break;
     case BO_Cmp:
-        assert(0 && "unhandled binary operator type");
+        FATAL_ERROR("unhandled binary operator type");
         break;
     case BO_LT:
         return Builder.CreateICmpULT(L, R, "cmp");
@@ -724,7 +725,7 @@ llvm::Value* CodeGenFunction::EmitBinaryOperator(const BinaryOperator* B) {
         break;
     }
     B->dump();
-    assert(0 && "TODO");
+    TODO;
     return 0;
 }
 
@@ -749,7 +750,7 @@ llvm::Value *CodeGenFunction::EvaluateExprAsBool(const Expr *E) {
         return EmitBinaryOperator(BinOp);
         // TODO convert to Bool if not already
     }
-    assert(0 && "TODO");
+    TODO;
     return 0;
 }
 

--- a/c2c/IRGenerator/CodeGenModule.cpp
+++ b/c2c/IRGenerator/CodeGenModule.cpp
@@ -263,19 +263,19 @@ unsigned CodeGenModule::getAlignment(QualType Q) const {
         return getAlignment(cast<ArrayType>(T)->getElementType());
     case TC_UNRESOLVED:
     case TC_ALIAS:
-        assert(0);
+        FATAL_ERROR("No alignment");
         break;
     case TC_STRUCT:
-        // TEMP, for now always align on 4
+        // TEMP, for now always align on 4 TODO
         return 4;
     case TC_ENUM:
-        assert(0);
+        FATAL_ERROR("Not for enum");
         break;
     case TC_FUNCTION:
-        assert(0 && "TODO");
+        TODO;
         break;
     case TC_MODULE:
-        assert(0);
+        FATAL_ERROR("Not for module");
         break;
     }
     return 0;
@@ -319,7 +319,7 @@ llvm::Type* CodeGenModule::ConvertType(QualType Q) {
     }
     case TC_UNRESOLVED:
     case TC_ALIAS:
-        assert(0 && "should be resolved");
+        FATAL_ERROR("should be resolved");
         break;
     case TC_STRUCT:
         return ConvertStructType(cast<StructType>(canon));
@@ -328,9 +328,10 @@ llvm::Type* CodeGenModule::ConvertType(QualType Q) {
         return builder.getInt32Ty();
     case TC_FUNCTION:
         assert(0 && "TODO func type");
+        TODO;
         break;
     case TC_MODULE:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
     return 0;
@@ -382,7 +383,7 @@ llvm::Constant* CodeGenModule::EvaluateExprAsConstant(const Expr *E) {
     }
     default:
         E->dump();
-        assert(0 && "TODO");
+        TODO;
         return 0;
     }
 }
@@ -449,18 +450,18 @@ llvm::Constant* CodeGenModule::EmitDefaultInit(QualType Q) {
         return EmitArrayInit(cast<ArrayType>(T), 0, 0);
     case TC_UNRESOLVED:
     case TC_ALIAS:
-        assert(0);
+        FATAL_ERROR("Unexpected type");
         break;
     case TC_STRUCT:
         return EmitStructInit(cast<StructType>(T), 0, 0);
     case TC_ENUM:
-        assert(0);
+        FATAL_ERROR("Unexpected type");
         break;
     case TC_FUNCTION:
-        assert(0 && "TODO");
+        TODO;
         break;
     case TC_MODULE:
-        assert(0);
+        FATAL_ERROR("Unexpected type");
         break;
     }
     return 0;
@@ -549,7 +550,7 @@ llvm::Constant* CodeGenModule::EmitArrayInit(const ArrayType *AT, Expr** Vals, u
         return llvm::ConstantDataArray::get(context, Elements);
     }
     default:
-        assert(0 && "TODO?");
+        TODO; // ?
         return 0;
     }
     return 0;
@@ -558,7 +559,7 @@ llvm::Constant* CodeGenModule::EmitArrayInit(const ArrayType *AT, Expr** Vals, u
 llvm::Constant* CodeGenModule::EmitConstantDecl(const Decl* D) {
     switch (D->getKind()) {
     case DECL_FUNC:
-        assert(0 && "TODO");
+        TODO;
         break;
     case DECL_VAR:
     {
@@ -566,7 +567,7 @@ llvm::Constant* CodeGenModule::EmitConstantDecl(const Decl* D) {
         return EvaluateExprAsConstant(V->getInitValue());
     }
     case DECL_ENUMVALUE:
-        assert(0 && "TODO");
+        TODO;
         break;
     case DECL_ALIASTYPE:
     case DECL_STRUCTTYPE:
@@ -575,7 +576,7 @@ llvm::Constant* CodeGenModule::EmitConstantDecl(const Decl* D) {
     case DECL_ARRAYVALUE:
     case DECL_IMPORT:
     case DECL_LABEL:
-        assert(0);
+        FATAL_ERROR("Never constant");
         break;
     }
     return 0;

--- a/c2c/IRGenerator/InterfaceGenerator.cpp
+++ b/c2c/IRGenerator/InterfaceGenerator.cpp
@@ -156,7 +156,7 @@ void InterfaceGenerator::EmitExpr(const Expr* E) {
         iface << "NULL";
         return;
     case EXPR_CALL:
-        assert(0 && "cannot happen");
+        FATAL_ERROR("Unreachable");
         return;
     case EXPR_IDENTIFIER:
         EmitIdentifierExpr(cast<IdentifierExpr>(E));
@@ -221,7 +221,7 @@ void InterfaceGenerator::EmitExpr(const Expr* E) {
             // should be VarDecl(for array/enum) or TypeDecl(array/enum)
             switch (D->getKind()) {
             case DECL_FUNC:
-                assert(0);
+                FATAL_ERROR("Unreachable");
                 break;
             case DECL_VAR:
             {
@@ -238,7 +238,7 @@ void InterfaceGenerator::EmitExpr(const Expr* E) {
                 }
                 // TODO also allow elemsof for EnumType
                 // NOTE cannot be converted to C if used with enums
-                assert(0 && "TODO");
+                TODO;
                 return;
             }
             case DECL_ENUMVALUE:
@@ -250,14 +250,14 @@ void InterfaceGenerator::EmitExpr(const Expr* E) {
             case DECL_ARRAYVALUE:
             case DECL_IMPORT:
             case DECL_LABEL:
-                assert(0);
+                FATAL_ERROR("Unreachable");
                 break;
             }
             break;
         }
         case BuiltinExpr::BUILTIN_ENUM_MIN:
         case BuiltinExpr::BUILTIN_ENUM_MAX:
-            assert(0 && "TODO");
+            TODO;
             break;
         }
         return;
@@ -266,7 +266,7 @@ void InterfaceGenerator::EmitExpr(const Expr* E) {
     {
         const ArraySubscriptExpr* A = cast<ArraySubscriptExpr>(E);
         if (isa<BitOffsetExpr>(A->getIndex())) {
-            assert(0 && "todo?");
+            TODO; // ?
         } else {
             EmitExpr(A->getBase());
             iface << '[';
@@ -287,7 +287,7 @@ void InterfaceGenerator::EmitExpr(const Expr* E) {
         return;
     }
     case EXPR_BITOFFSET:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     case EXPR_CAST:
     {
@@ -345,7 +345,7 @@ void InterfaceGenerator::EmitUnaryOperator(const Expr* E) {
         EmitExpr(U->getExpr());
         break;
     default:
-        assert(0);
+        FATAL_ERROR("Unreachable");
     }
 }
 
@@ -356,6 +356,7 @@ void InterfaceGenerator::EmitMemberExpr(const Expr* E) {
         EmitIdentifierExpr(M->getMember());
     } else {
         assert(0 && "can this happen?");
+        TODO;
     }
 }
 
@@ -399,7 +400,7 @@ void InterfaceGenerator::EmitTypeDecl(const TypeDecl* T) {
     case DECL_FUNC:
     case DECL_VAR:
     case DECL_ENUMVALUE:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     case DECL_ALIASTYPE:
         EmitAliasType(T);
@@ -416,7 +417,7 @@ void InterfaceGenerator::EmitTypeDecl(const TypeDecl* T) {
     case DECL_ARRAYVALUE:
     case DECL_IMPORT:
     case DECL_LABEL:
-        assert(0);
+        FATAL_ERROR("Unreachable");
         break;
     }
 }
@@ -458,7 +459,7 @@ void InterfaceGenerator::EmitStructType(const StructTypeDecl* S, unsigned indent
         } else if (isa<StructTypeDecl>(member)) {
             EmitStructType(cast<StructTypeDecl>(member), indent+INDENT);
         } else {
-            assert(0);
+            FATAL_ERROR("Unreachable");
         }
     }
     iface.indent(indent);
@@ -546,7 +547,7 @@ void InterfaceGenerator::EmitType(QualType type) {
         break;
     }
     case TC_UNRESOLVED:
-        assert(0 && "should be resolved");
+        TODO; // assert(0 && "should be resolved");
         break;
     case TC_ALIAS:
         EmitPrefixedDecl(cast<AliasType>(T)->getDecl());
@@ -561,7 +562,7 @@ void InterfaceGenerator::EmitType(QualType type) {
         EmitPrefixedDecl(cast<FunctionType>(T)->getDecl());
         break;
     case TC_MODULE:
-        assert(0 && "should not happen");
+        FATAL_ERROR("Unreachable");
         break;
     }
 }

--- a/c2c/Parser/C2Parser.cpp
+++ b/c2c/Parser/C2Parser.cpp
@@ -365,7 +365,7 @@ void C2Parser::ParseEnumType(const char* id, SourceLocation idLoc, bool is_publi
 
     if (is_incr) {
         ConsumeToken();  // +
-        assert(0 && "TODO incremental enum");
+        TODO; // incremental enum
     } else {
         // Syntax: enum_block
         typedef SmallVector<EnumConstantDecl*, 10> EnumConstants;
@@ -917,7 +917,7 @@ C2::ExprResult C2Parser::ParseCastExpression(bool isUnaryExpression,
         fprintf(stderr, "UNHANDLED TOKEN: ");
         PP.DumpToken(Tok);
         fprintf(stderr, "\n");
-        assert(0 && "TODO");
+        TODO;
 #endif
     }
 
@@ -1010,7 +1010,7 @@ C2::ExprResult C2Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
     while (1) {
         switch (Tok.getKind()) {
         case tok::code_completion:
-            assert(0);
+            FATAL_ERROR("Should not occure");
         case tok::identifier:
             // Fall through; this isn't a message send.
         default:  // Not a postfix-expression suffix.
@@ -1190,7 +1190,7 @@ C2Parser::ParseParenExpression(ParenParseOption &ExprType, bool stopIfCastExpr,
     // None of these cases should fall through with an invalid Result
     // unless they've already reported an error.
     if (ExprType >= CompoundStmt && Tok.is(tok::l_brace)) {
-        assert(0 && "TODO");
+        TODO;
 #if 0
         Diag(Tok, diag::ext_gnu_statement_expr);
         Actions.ActOnStartStmtExpr();
@@ -1214,13 +1214,13 @@ C2Parser::ParseParenExpression(ParenParseOption &ExprType, bool stopIfCastExpr,
         if (ExpectAndConsume(tok::r_paren)) return ExprError();
 
         if (Tok.is(tok::l_brace)) {
-            assert(0 && "TODO");
+            TODO;
         }
         if (ExprType == CastExpr) {
             // We parsed '(' type-name ')' and the thing after it wasn't a '{'.
 
             if (stopIfCastExpr) {
-                assert(0 && "TODO");
+                TODO;
             }
 
             // Parse the cast-expression that follows it next.
@@ -1233,7 +1233,7 @@ C2Parser::ParseParenExpression(ParenParseOption &ExprType, bool stopIfCastExpr,
         Diag(Tok, diag::err_expected_lbrace_in_compound_literal);
         return ExprError();
     } else if (isTypeCast) {
-        assert(0 && "TODO");
+        TODO;
     } else {
         Result = ParseExpression();
         ExprType = SimpleExpr;
@@ -1444,11 +1444,11 @@ C2::ExprResult C2Parser::ParseSizeof()
     case tok::kw_const:
     case tok::kw_volatile:
     case tok::kw_local:
-        //Diag(Tok, diag::err_no_qualifier_allowed_here);
+        //Diag(Tok, diag::err_no_qualifier_allowed_here); // TODO why is this commented out?
         fprintf(stderr, "Not type qualifier allowed here\n");
         return ExprError();
     default:
-        //Diag(Tok, diag::err_expected type or symbol name);
+        //Diag(Tok, diag::err_expected type or symbol name); // TODO why is this commented out?
         fprintf(stderr, "Expected Type or Symbol name\n");
         return ExprError();
     }
@@ -1570,7 +1570,7 @@ void C2Parser::ParseFuncDef(bool is_public) {
     if (isInterface) {
         if (Tok.is(tok::l_brace)) {
             //Diag(Tok, diag::err_interface_func_body);
-            fprintf(stderr, "INTERFACE functions cannot have function bodies\n");
+            fprintf(stderr, "INTERFACE functions cannot have function bodies\n"); // TODO Why is this commented out
             return;
         }
         if (ExpectAndConsume(tok::semi)) return;
@@ -2171,6 +2171,7 @@ C2::StmtResult C2Parser::ParseDeclOrStatement() {
     case tok::coloncolon:
         // syntax error
         assert(0 && "double module id");
+        TODO; // Unreachable or diagnostic here?
         return StmtError();
     case tok::colon:
         // TODO move this to ParseLabeledStatement
@@ -2763,7 +2764,7 @@ bool C2Parser::SkipUntil(ArrayRef<tok::TokenKind> Toks, SkipUntilFlags Flags) {
             if (!HasFlagsSet(Flags, StopAtCodeCompletion))
                 handleUnexpectedCodeCompletionToken();
 #endif
-            assert(0 && "TODO");
+            TODO;
             return false;
 
         case tok::l_paren:

--- a/c2c/Parser/C2Sema.cpp
+++ b/c2c/Parser/C2Sema.cpp
@@ -1049,7 +1049,7 @@ C2::ExprResult C2Sema::ActOnBuiltinType(tok::TokenKind k) {
     case tok::kw_bool:      qt = Type::Bool(); break;
     case tok::kw_void:      qt = Type::Void(); break;
     default:
-        assert(0);
+        FATAL_ERRORF("Unkown token %d", k);
         break;
     }
 
@@ -1385,7 +1385,7 @@ C2::ExprResult C2Sema::ActOnNumericConstant(const Token& Tok) {
         return ExprError();
 
     if (Literal.hasUDSuffix()) {
-        assert(0 && "HUH?");
+        FATAL_ERROR("HUH?");
     }
 
     Expr* Res;
@@ -1401,7 +1401,7 @@ C2::ExprResult C2Sema::ActOnNumericConstant(const Token& Tok) {
         // we underflowed to zero (APFloat reports denormals as underflow).
         if ((result & APFloat::opOverflow) ||
                 ((result & APFloat::opUnderflow) && Val.isZero())) {
-            assert(0 && "TODO");
+            TODO;
 #if 0
             unsigned diagnostic;
             SmallString<20> buffer;
@@ -1474,7 +1474,7 @@ C2::ExprResult C2Sema::ActOnNumericConstant(const Token& Tok) {
 
             if (Width == 0) {
                 fprintf(stderr, "TOO LARGE\n");
-                assert(0 && "TODO");
+                TODO;
             }
             // set correct width
             if (ResultVal.getBitWidth() != Width) {

--- a/c2c/Parser/Lexer.cpp
+++ b/c2c/Parser/Lexer.cpp
@@ -1,0 +1,479 @@
+/* Copyright 2018 Christoffer Lernö
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Parser/Lexer.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+namespace C2 {
+    
+static inline bool is_alphabet(char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+
+static inline bool is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+
+static inline bool is_digit_or_underscore(char c) {
+    return c == '_' || (c >= '0' && c <= '9');
+}
+
+static inline bool is_oct(char c) {
+    return c >= '0' && c <= '7';
+}
+
+static inline bool is_alpha(char c) {
+    return is_alphabet(c) || is_digit_or_underscore(c);
+}
+
+
+static inline bool is_oct_or_underscore(char c) {
+    return c == '_' || is_oct(c);
+}
+
+
+static inline bool is_binary(char c) {
+    return c == '0' || c == '1';
+}
+
+
+static inline bool is_binary_or_underscore(char c) {
+    return is_binary(c) || c == '_';
+}
+
+
+static inline bool is_hex(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+
+static inline bool is_hex_or_underscore(char c) {
+    return c == '_' || is_hex(c);
+}
+
+
+static inline bool reached_end(Lexer *lexer) {
+    return lexer->current[0] == '\0';
+}
+
+static inline char peek_next(Lexer *lexer) {
+    return lexer->current[1];
+}
+
+static inline char prev(Lexer *lexer) {
+    return lexer->current[-1];
+}
+
+static inline char peek(Lexer *lexer) {
+    return lexer->current[0];
+}
+
+static inline char advance(Lexer *lexer) {
+    return *(lexer->current++);
+}
+
+static Token make_token(Lexer *lexer, TokenType type) {
+    Token token;
+    token.type = type;
+    token.start = lexer->start;
+    token.length = (int)(lexer->current - lexer->start);
+    token.line = lexer->line;
+    return token;
+}
+
+static Token error_token(Lexer *lexer, const char *message) {
+    Token token;
+    token.line = lexer->line;
+    token.start = lexer->start;
+    token.length = (int)strlen(message);
+    token.type = TOKEN_ERROR;
+    return token;
+}
+
+static inline void skip_whitespace(Lexer *lexer) {
+    while (1) {
+        char c = peek(lexer);
+        switch (c) {
+        case '\n':
+            lexer->line++;
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\f':
+            advance(lexer);
+            break;
+        case '/':
+            if (peek_next(lexer) == '/') {
+                while (peek(lexer) != '\n') { advance(lexer); }
+                break;
+            }
+            if (peek_next(lexer) == '*') {
+                advance(lexer);
+                while (!reached_end(lexer)) {
+                    advance(lexer);
+                    if (peek(lexer) == '*' && peek_next(lexer) == '/') {
+                        lexer->current += 2;
+                        break;
+                    }
+                }
+                break;
+            }
+            return;
+        default:
+            return;
+        }
+    }
+}
+
+static inline Token scan_string(Lexer *lexer) {
+    char c;
+    while ((c = advance(lexer)) != '"') {
+        if (c == '\\' && peek(lexer) == '"') {
+            advance(lexer);
+            continue;
+        }
+        if (c == '\n') lexer->line++;
+        if (reached_end(lexer)) {
+            return error_token(lexer, "Unterminated string.");
+        }
+    }
+    return make_token(lexer, TOKEN_STRING);
+}
+
+static inline TokenType check_keyword(Lexer *lexer, const char *keyword, int length, TokenType type) {
+    if (lexer->current - lexer->start == length
+        && memcmp(lexer->start + 1, keyword + 1, (size_t)length - 1) == 0) {
+        return type;
+    }
+    return TOKEN_IDENTIFIER;
+}
+
+static inline TokenType check_two_keywords(Lexer *lexer,
+                                    const char *keyword1,
+                                    const char *keyword2,
+                                    int length,
+                                    int diffPos,
+                                    TokenType type1,
+                                    TokenType type2) {
+    if (lexer->current - lexer->start != length) return TOKEN_IDENTIFIER;
+    if (lexer->start[diffPos] == keyword1[diffPos])
+    {
+        if (memcmp(lexer->start + 1, keyword1 + 1, (size_t)length - 1) == 0) return type1;
+    }
+    else
+    {
+        if (memcmp(lexer->start + 1, keyword2 + 1, (size_t)length - 1) == 0) return type2;
+    }
+    return TOKEN_IDENTIFIER;
+}
+    
+#define CHECK_KW(X, Y) check_keyword(lexer, X, sizeof X, Y)
+#define CHECK_2KW(X1, X2, SPOT, Y1, Y2) check_two_keywords(lexer, X1, X2, sizeof X1, SPOT, Y1, Y2)
+
+// Yes this is an ugly hand written keyword identifier. It should be benchmarked against
+// an table based state machine.
+static inline TokenType indentifier_type(Lexer *lexer) {
+    int len = (int)(lexer->current - lexer->start);
+    switch (*lexer->start) {
+    case 'a':
+        switch (len)
+        {
+        case 2: return CHECK_KW("as", TOKEN_AS);
+        case 4: return CHECK_KW("auto", TOKEN_AUTO);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'b':
+        switch (len)
+        {
+        case 4: return CHECK_KW("bool", TOKEN_BOOL);
+        case 5: return CHECK_KW("break", TOKEN_BREAK);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'c':
+        switch (len)
+        {
+        case 4:
+            switch (lexer->start[3])
+            {
+            case 'r': CHECK_KW("char", TOKEN_CHAR);
+            case 't': CHECK_KW("cast", TOKEN_CAST);
+            case 'e': CHECK_KW("case", TOKEN_CAST);
+            default: return TOKEN_IDENTIFIER;
+            }
+        case 5: return CHECK_KW("const", TOKEN_CONST);
+        case 8: return CHECK_KW("continue", TOKEN_CONTINUE);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'd':
+        switch (len)
+        {
+        case 2: CHECK_KW("do", TOKEN_DO);
+        case 7: CHECK_KW("default", TOKEN_DEFAULT);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'e':
+        switch (len)
+        {
+        case 4: return CHECK_2KW("else", "enum", 1, TOKEN_ELSE, TOKEN_ENUM);
+        case 7: return CHECK_KW("elemsof", TOKEN_ELEMSOF);
+        case 8: return CHECK_2KW("enum_min", "enum_max", 6, TOKEN_ENUM_MIN, TOKEN_ENUM_MAX);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'f':
+        switch (len) {
+        case 3:
+            if (lexer->start[1] == 'o') return CHECK_KW("for", TOKEN_FOR);
+            return CHECK_2KW("f32", "f64", 1, TOKEN_F32, TOKEN_F64);
+        case 4: return CHECK_KW("func", TOKEN_FUNC);
+        case 5: return CHECK_KW("false", TOKEN_FALSE);
+        case 11: return CHECK_KW("fallthrough", TOKEN_FALLTHROUGH);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'g': return CHECK_KW("goto", TOKEN_GOTO);
+    case 'i':
+        switch (len) {
+        case 2: return CHECK_2KW("if", "i8", 1, TOKEN_IF, TOKEN_I8);
+        case 3:
+            switch (lexer->start[1]) {
+            case '1': return CHECK_KW("i16", TOKEN_I16);
+            case '3': return CHECK_KW("i32", TOKEN_I32);
+            case '6': return CHECK_KW("i64", TOKEN_I64);
+            default: return TOKEN_IDENTIFIER;
+            }
+        case 6: return CHECK_KW("import", TOKEN_IMPORT);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'm': return CHECK_KW("module", TOKEN_MODULE);
+    case 'n': return CHECK_KW("nil", TOKEN_NIL);
+    case 'l': return CHECK_KW("local", TOKEN_LOCAL);
+    case 'p': return CHECK_KW("public", TOKEN_PUBLIC);
+    case 'r': return CHECK_KW("return", TOKEN_RETURN);
+    case 's':
+        if (len != 6) return TOKEN_IDENTIFIER;
+        switch (lexer->start[1])
+        {
+        case 't': return CHECK_KW("struct", TOKEN_STRUCT);
+        case 'i': return CHECK_KW("sizeof", TOKEN_SIZEOF);
+        case 'w': return CHECK_KW("switch", TOKEN_SWITCH);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 't': return CHECK_2KW("true", "type", 1, TOKEN_TRUE, TOKEN_TYPE);
+    case 'u':
+        switch (len) {
+        case 2: return CHECK_KW("u8", TOKEN_U8);
+        case 3:
+            switch (lexer->start[1]) {
+            case '1': return CHECK_KW("u16", TOKEN_U16);
+            case '3': return CHECK_KW("u32", TOKEN_U32);
+            case '6': return CHECK_KW("u64", TOKEN_U64);
+            default: return TOKEN_IDENTIFIER;
+            }
+        case 5: return CHECK_KW("union", TOKEN_UNION);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'v':
+        switch (len) {
+        case 4: return CHECK_KW("void", TOKEN_VOID);
+        case 8: return CHECK_KW("volatile", TOKEN_VOLATILE);
+        default: return TOKEN_IDENTIFIER;
+        }
+    case 'w': return CHECK_KW("while", TOKEN_WHILE);
+    default: return TOKEN_IDENTIFIER;
+    }
+}
+
+#undef CHECK_KW
+#undef CHECK_2KW
+
+static inline Token scan_ident(Lexer *lexer) {
+    while (is_alpha(peek(lexer))) {
+        advance(lexer);
+    }
+    return make_token(lexer, indentifier_type(lexer));
+}
+
+static inline bool match(Lexer *lexer, char expected) {
+    if (reached_end(lexer)) return false;
+    if (*lexer->current != expected) return false;
+    lexer->current++;
+    return true;
+}
+
+
+#define PARSE_SPECIAL_NUMBER(is_num, is_num_with_underscore, exp, EXP) \
+    while (is_num_with_underscore(peek(lexer))) advance(lexer); \
+    bool is_float = false; \
+    if (peek(lexer) == '.') \
+    { \
+      is_float = true; \
+      advance(lexer); \
+      char c = peek(lexer); \
+      if (c == '_') return error_token(lexer, "Underscore may only appear between digits."); \
+      if (is_num(c)) advance(lexer); \
+      while (is_num_with_underscore(peek(lexer))) advance(lexer); \
+    } \
+    char c = peek(lexer); \
+    if (c == exp || c == EXP) \
+    { \
+       is_float = true; \
+       advance(lexer); \
+       char c2 = advance(lexer); \
+       if (c2 == '+' || c2 == '-') c2 = advance(lexer); \
+       if (!is_num(c2)) return error_token(lexer, "Invalid exponential expression"); \
+       while (is_digit(peek(lexer))) advance(lexer); \
+    } \
+    if (prev(lexer) == '_') return error_token(lexer, "Underscore may only appear between digits."); \
+    return make_token(lexer, is_float ? TOKEN_FLOAT : TOKEN_INTEGER);
+
+
+static inline Token scan_hex(Lexer *lexer) {
+    advance(lexer); // skip the x
+    if (!is_hex(advance(lexer))) return error_token(lexer, "Invalid hex sequence");
+    PARSE_SPECIAL_NUMBER(is_hex, is_hex_or_underscore, 'p', 'P');
+}
+
+static inline Token scan_oct(Lexer *lexer) {
+    advance(lexer); // Skip the o
+    if (!is_oct(advance(lexer))) return error_token(lexer, "Invalid octal sequence");
+    while (is_oct_or_underscore(peek(lexer))) { advance(lexer); }
+    return make_token(lexer, TOKEN_INTEGER);;
+}
+
+static inline Token scan_binary(Lexer *lexer) {
+    advance(lexer); // Skip the b
+    if (!is_binary(advance(lexer))) return error_token(lexer, "Invalid binary sequence");
+    while (is_binary_or_underscore(peek(lexer))) { advance(lexer); }
+    return make_token(lexer, TOKEN_INTEGER);;
+}
+
+static inline Token scan_digit(Lexer *lexer) {
+    if (prev(lexer) == '0') {
+        switch (peek(lexer)) {
+            // case 'X': Let's not support this? REVISIT
+        case 'x':
+            return scan_hex(lexer);
+        case 'o':
+            return scan_oct(lexer);
+        case 'b':
+            return scan_binary(lexer);
+        default:
+            break;
+        }
+    }
+    PARSE_SPECIAL_NUMBER(is_digit, is_digit_or_underscore, 'e', 'E');
+}
+
+#undef PARSE_SPECIAL_NUMBER
+
+void lexer_init(Lexer *lexer, const char *source) {
+    lexer->start = source;
+    lexer->current = source;
+    lexer->line = 1;
+}
+
+Token lexer_scan_token(Lexer *lexer) {
+    
+    skip_whitespace(lexer);
+
+    lexer->start = lexer->current;
+    if (reached_end(lexer)) return make_token(lexer, TOKEN_EOF);
+
+    char c = advance(lexer);
+    switch (c) {
+    case '"':
+        return scan_string(lexer);
+    case ',':
+        return make_token(lexer, TOKEN_COMMA);
+    case ';':
+        return make_token(lexer, TOKEN_EOS);
+    case '{':
+        return make_token(lexer, TOKEN_BRACE_L);
+    case '}':
+        return make_token(lexer, TOKEN_BRACE_R);
+    case '(':
+        return make_token(lexer, TOKEN_PAREN_L);
+    case ')':
+        return make_token(lexer, TOKEN_PAREN_R);
+    case '[':
+        return make_token(lexer, TOKEN_BRACKET_L);
+    case ']':
+        return make_token(lexer, TOKEN_BRACKET_R);
+    case '.':
+        return make_token(lexer, TOKEN_DOT);
+    case '~':
+        return make_token(lexer, TOKEN_BIT_NOT);
+    case '@':
+        if (match(lexer, '(')) return make_token(lexer, TOKEN_ATTRIBUTE_PAREN);
+        return error_token(lexer, "Unexpected character.");
+    case ':':
+        return make_token(lexer, match(lexer, '=') ? TOKEN_COLON_ASSIGN : TOKEN_COLON);
+    case '!':
+        return make_token(lexer, match(lexer, '=') ? TOKEN_NOT_EQUAL : TOKEN_NOT);
+    case '/':
+        return make_token(lexer, match(lexer, '=') ? TOKEN_DIV_ASSIGN : TOKEN_DIV);
+    case '*':
+        return make_token(lexer, match(lexer, '=') ? TOKEN_MULT_ASSIGN : TOKEN_MULT);
+    case '=':
+        return make_token(lexer, match(lexer, '=') ? TOKEN_EQUAL : TOKEN_ASSIGN);
+    case '^':
+        if (match(lexer, '^')) return make_token(lexer, TOKEN_POW);
+        return make_token(lexer, match(lexer, '=') ? TOKEN_BIT_XOR_ASSIGN : TOKEN_BIT_XOR);
+    case '<':
+        if (match(lexer, '<')) return make_token(lexer, match(lexer, '=') ? TOKEN_LEFT_SHIFT_ASSIGN : TOKEN_LEFT_SHIFT);
+        return make_token(lexer, match(lexer, '=') ? TOKEN_LESS_EQUAL : TOKEN_LESS);
+    case '>':
+        if (match(lexer, '>')) {
+            if (match(lexer, '>')) {
+                return make_token(lexer, match(lexer, '=') ? TOKEN_RIGHT_SHIFT_LOGIC_ASSIGN
+                                            : TOKEN_RIGHT_SHIFT_LOGIC);
+            }
+            return make_token(lexer, match(lexer, '=') ? TOKEN_RIGHT_SHIFT_ASSIGN : TOKEN_RIGHT_SHIFT);
+        }
+        return make_token(lexer, match(lexer, '=') ? TOKEN_GREATER_EQUAL : TOKEN_GREATER);
+    case '&':
+        if (match(lexer, '&')) {
+            return make_token(lexer, match(lexer, '=') ? TOKEN_AND_ASSIGN : TOKEN_AND);
+        }
+        return make_token(lexer, match(lexer, '=') ? TOKEN_BIT_AND_ASSIGN : TOKEN_BIT_AND);
+    case '|':
+        if (match(lexer, '|')) {
+            return make_token(lexer, match(lexer, '=') ? TOKEN_OR_ASSIGN : TOKEN_OR);
+        }
+        return make_token(lexer, match(lexer, '=') ? TOKEN_BIT_OR_ASSIGN : TOKEN_BIT_OR);
+    case '+':
+        if (match(lexer, '+')) return make_token(lexer, TOKEN_PLUSPLUS);
+        if (match(lexer, '=')) return make_token(lexer, TOKEN_PLUS_ASSIGN);
+        return make_token(lexer, TOKEN_PLUS);
+    case '-':
+        if (match(lexer, '-')) return make_token(lexer, match(lexer, '-') ? TOKEN_NO_INIT : TOKEN_MINUSMINUS);
+        if (match(lexer, '=')) return make_token(lexer, TOKEN_MINUS_ASSIGN);
+        return make_token(lexer, TOKEN_MINUS);
+
+    default:
+        if (is_digit(c)) return scan_digit(lexer);
+        if (is_alphabet(c)) return scan_ident(lexer);
+        return error_token(lexer, "Unexpected character.");
+    }
+
+}
+    
+}
+

--- a/c2c/Parser/Lexer.h
+++ b/c2c/Parser/Lexer.h
@@ -1,0 +1,162 @@
+/* Copyright 2018 Christoffer Lernö
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PARSER_LEXER_H
+#define PARSER_LEXER_H
+
+namespace C2 {
+
+typedef enum {
+	// Single-character tokens.
+	TOKEN_PAREN_L,
+	TOKEN_PAREN_R,
+	TOKEN_BRACE_L,
+	TOKEN_BRACE_R,
+    TOKEN_BRACKET_L,
+    TOKEN_BRACKET_R,
+	TOKEN_COMMA,
+	TOKEN_DOT,
+	TOKEN_EOS,
+
+	// One or two character tokens.
+    TOKEN_ATTRIBUTE_PAREN,
+	TOKEN_PLUS,
+	TOKEN_PLUSPLUS,
+	TOKEN_PLUS_ASSIGN,
+	TOKEN_BIT_NOT,
+	TOKEN_NOT,
+	TOKEN_MINUS,
+	TOKEN_MINUSMINUS,
+	TOKEN_MINUS_ASSIGN,
+	TOKEN_MULT,
+	TOKEN_MULT_ASSIGN,
+	TOKEN_POW,
+	TOKEN_DIV,
+	TOKEN_DIV_ASSIGN,
+	TOKEN_NOT_EQUAL,
+	TOKEN_ASSIGN,
+	TOKEN_EQUAL,
+	TOKEN_COLON,
+	TOKEN_COLON_ASSIGN,
+	// Three or more
+		TOKEN_GREATER,
+	TOKEN_GREATER_EQUAL,
+	TOKEN_RIGHT_SHIFT,
+	TOKEN_RIGHT_SHIFT_ASSIGN,
+	TOKEN_RIGHT_SHIFT_LOGIC,
+	TOKEN_RIGHT_SHIFT_LOGIC_ASSIGN,
+	TOKEN_LESS,
+	TOKEN_LESS_EQUAL,
+	TOKEN_LEFT_SHIFT,
+	TOKEN_LEFT_SHIFT_ASSIGN,
+	TOKEN_AND,
+	TOKEN_AND_ASSIGN,
+	TOKEN_BIT_AND,
+	TOKEN_BIT_AND_ASSIGN,
+	TOKEN_OR,
+	TOKEN_OR_ASSIGN,
+	TOKEN_BIT_OR,
+	TOKEN_BIT_OR_ASSIGN,
+	TOKEN_BIT_XOR,
+	TOKEN_BIT_XOR_ASSIGN,
+	TOKEN_NO_INIT,
+    
+    
+	// Literals.
+	TOKEN_IDENTIFIER,
+	TOKEN_STRING,
+	TOKEN_INTEGER,
+	TOKEN_FLOAT,
+
+
+	// Keywords.
+	TOKEN_MODULE,
+	TOKEN_IMPORT,
+	TOKEN_AS,
+	TOKEN_PUBLIC,
+
+	TOKEN_AUTO,
+	TOKEN_BOOL,
+	TOKEN_CAST,
+	TOKEN_CHAR,
+	TOKEN_CONST,
+	TOKEN_ELEMSOF,
+	TOKEN_ENUM_MIN,
+	TOKEN_ENUM_MAX,
+	TOKEN_ENUM,
+	TOKEN_FALSE,
+	TOKEN_F32,
+	TOKEN_F64,
+	TOKEN_I8,
+	TOKEN_I16,
+	TOKEN_I32,
+	TOKEN_I64,
+	TOKEN_LOCAL,
+	TOKEN_NIL,
+	TOKEN_SIZEOF,
+	TOKEN_STRUCT,
+	TOKEN_TRUE,
+	TOKEN_TYPE,
+	TOKEN_U8,
+	TOKEN_U16,
+	TOKEN_U32,
+	TOKEN_U64,
+	TOKEN_UNION,
+	TOKEN_VOID,
+	TOKEN_VOLATILE,
+
+	TOKEN_BREAK,
+	TOKEN_CASE,
+	TOKEN_CONTINUE,
+	TOKEN_DEFAULT,
+	TOKEN_DO,
+	TOKEN_ELSE,
+	TOKEN_FALLTHROUGH,
+	TOKEN_FOR,
+	TOKEN_GOTO,
+	TOKEN_IF,
+	TOKEN_RETURN,
+	TOKEN_SWITCH,
+	TOKEN_WHILE,
+	TOKEN_FUNC,
+	TOKEN_VAR,
+
+
+	TOKEN_ERROR,
+	TOKEN_EOF,
+
+} TokenType;
+
+typedef struct {
+	TokenType type;
+	const char *start;
+	int length;
+	int line;
+} Token;
+
+typedef struct
+{
+	const char *start;
+	const char *current;
+	int line;
+} Lexer;
+
+void lexer_init(Lexer *lexer, const char *source);
+Token lexer_scan_token(Lexer *lexer);
+
+}
+
+#endif
+

--- a/c2c/Refactor/RefFinder.cpp
+++ b/c2c/Refactor/RefFinder.cpp
@@ -227,7 +227,7 @@ void RefFinder::searchExpr(const Expr* E) {
     }
     break;
     case EXPR_CAST:
-        assert(0 && "TODO");
+        TODO;
         break;
     }
 }

--- a/c2c/Utils/Errors.h
+++ b/c2c/Utils/Errors.h
@@ -1,0 +1,24 @@
+/* Copyright 2018 Christoffer Lernö
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define FATAL_ERROR(fmt) \
+  do { fprintf(stderr, "FATAL ERROR in %s:%d:%s(): " fmt "\n", __FILE__, \
+      __LINE__, __func__); exit(-1); } while (0)
+
+#define FATAL_ERRORF(fmt, ...) \
+  do { fprintf(stderr, "FATAL ERROR in %s:%d:%s(): " fmt "\n", __FILE__, \
+      __LINE__, __func__, __VA_ARGS__); exit(-1); } while (0)
+
+#define TODO do { fprintf(stderr, "Exit due to TODO in %s:%d:%s()\n", __FILE__, __LINE__, __func__); exit(-2); } while (0)


### PR DESCRIPTION
1. TODO is moved to a macro, so that the location of the error is easy to detect.
2. A FATAL_ERROR macro is introduced to replace assert(0) and other things.
3. Some review of current TODO / assert(0) to insert the right type of assert.
4. Fix issues with ListeralAnalyser and unary operations on literals.