### PR TITLE
Some IR work, switching from plain iteration.

### DIFF
--- a/c2c/AST/Expr.h
+++ b/c2c/AST/Expr.h
@@ -98,6 +98,11 @@ public:
     bool hasImpCast() const {
         return getImpCast() != BuiltinType::Void;
     }
+
+    bool isFloat() const {
+        return QT.isFloatType();
+    }
+
     BuiltinType::Kind getImpCast() const {
         return static_cast<BuiltinType::Kind>(exprBits.ImpCast);
     }

--- a/c2c/AST/Type.cpp
+++ b/c2c/AST/Type.cpp
@@ -63,6 +63,15 @@ bool QualType::isIntegerType() const {
     }
     return false;
 }
+
+bool QualType::isFloatType() const {
+    QualType Canon = getTypePtr()->getCanonicalType();
+    if (BuiltinType* BI = dyncast<BuiltinType>(Canon.getTypePtr())) {
+        return BI->isFloatingPoint();
+    }
+    return false;
+}
+
 bool QualType::isArithmeticType() const {
     QualType Canon = getTypePtr()->getCanonicalType();
     if (BuiltinType* BI = dyncast<BuiltinType>(Canon.getTypePtr())) {

--- a/c2c/AST/Type.h
+++ b/c2c/AST/Type.h
@@ -97,6 +97,7 @@ public:
     bool isArithmeticType() const;
     bool isScalarType() const;
     bool isIncompleteType() const;
+    bool isFloatType() const;
 
     bool isConstant() const;    // NOTE: not is const!
 
@@ -547,6 +548,7 @@ inline bool Type::isSubscriptable() const {
     assert(canonicalType.isValid());
     return isa<PointerType>(canonicalType) || isa<ArrayType>(canonicalType);
 }
+
 
 }
 

--- a/c2c/Analyser/ComponentAnalyser.cpp
+++ b/c2c/Analyser/ComponentAnalyser.cpp
@@ -45,49 +45,55 @@ ComponentAnalyser::ComponentAnalyser(Component& C,
 }
 
 ComponentAnalyser::~ComponentAnalyser() {
-    for (unsigned i=0; i<analysers.size(); i++) {
-        delete analysers[i];
+    for (auto &analyser : analysers) {
+        delete analyser;
     }
 }
 
 unsigned ComponentAnalyser::analyse(bool print1, bool print2, bool print3, bool printLib) {
     unsigned errors = 0;
-    const size_t count = analysers.size();
 
-    for (unsigned i=0; i<count; i++) {
-        analysers[i]->addImports();
+    for (auto &analyser : analysers) {
+        analyser->addImports();
     }
 
-    for (unsigned i=0; i<count; i++) {
-        analysers[i]->resolveTypes();
+    for (auto &analyser : analysers) {
+        analyser->resolveTypes();
     }
+
     if (Diags.hasErrorOccurred()) return 1;
 
-    for (unsigned i=0; i<count; i++) {
-        errors += analysers[i]->resolveTypeCanonicals();
+    for (auto &analyser : analysers) {
+        errors += analyser->resolveTypeCanonicals();
     }
+
     if (errors) return errors;
 
-    for (unsigned i=0; i<count; i++) {
-        errors += analysers[i]->resolveStructMembers();
+    for (auto &analyser : analysers) {
+        errors += analyser->resolveStructMembers();
     }
+
     if (print1) printASTs(printLib);
     if (errors) return errors;
 
-    for (unsigned i=0; i<count; i++) {
-        errors += analysers[i]->resolveVars();
+    for (auto &analyser : analysers) {
+        errors += analyser->resolveVars();
     }
+
     if (errors) return errors;
 
-    for (unsigned i=0; i<count; i++) {
-        errors += analysers[i]->resolveEnumConstants();
+    for (auto &analyser : analysers) {
+        errors += analyser->resolveEnumConstants();
     }
+
     if (errors) return errors;
 
     IncrementalArrayVals ia_values;
-    for (unsigned i=0; i<count; i++) {
-        errors += analysers[i]->checkArrayValues(ia_values);
+
+    for (auto &analyser : analysers) {
+        errors += analyser->checkArrayValues(ia_values);
     }
+
     if (errors) return errors;
 
     // Set ArrayValues
@@ -107,9 +113,11 @@ unsigned ComponentAnalyser::analyse(bool print1, bool print2, bool print3, bool 
     ia_values.clear();
 
     StructFunctionList structFuncs;
-    for (unsigned i=0; i<count; i++) {
-        errors += analysers[i]->checkFunctionProtos(structFuncs);
+
+    for (auto &analyser : analysers) {
+        errors += analyser->checkFunctionProtos(structFuncs);
     }
+
     if (errors) return errors;
     // Set StructFunctions
     // NOTE: since these are linked anyways, just use special ASTContext from Builder
@@ -122,19 +130,21 @@ unsigned ComponentAnalyser::analyse(bool print1, bool print2, bool print3, bool 
         S->setStructFuncs(funcs, numFuncs);
     }
 
-    for (unsigned i=0; i<count; i++) {
-        analysers[i]->checkVarInits();
+    for (auto &analyser : analysers) {
+        analyser->checkVarInits();
     }
+
     if (print2) printASTs(printLib);
     if (Diags.hasErrorOccurred()) return 1;
 
-    for (unsigned i=0; i<count; i++) {
-        analysers[i]->checkFunctionBodies();
+
+    for (auto &analyser : analysers) {
+        analyser->checkFunctionBodies();
     }
     if (Diags.hasErrorOccurred()) return 1;
 
-    for (unsigned i=0; i<count; i++) {
-        analysers[i]->checkDeclsForUsed();
+    for (auto &analyser : analysers) {
+        analyser->checkDeclsForUsed();
     }
 
     if (print3) printASTs(printLib);

--- a/c2c/Analyser/ComponentAnalyser.h
+++ b/c2c/Analyser/ComponentAnalyser.h
@@ -48,7 +48,6 @@ private:
     bool verbose;
 
     typedef std::vector<FileAnalyser*> Analysers;
-    typedef Analysers::iterator AnalysersIter;
     Analysers analysers;
 
     ComponentAnalyser(const ComponentAnalyser&);

--- a/c2c/Analyser/FileAnalyser.cpp
+++ b/c2c/Analyser/FileAnalyser.cpp
@@ -56,18 +56,26 @@ void FileAnalyser::printAST(bool printInterface) const {
     ast.print(true);
 }
 
+void FileAnalyser::beginNewPass(FileAnalyserPass newPass)
+{
+    assert(((int)currentPass == (int)newPass - 1) && "Incorrect ordering of passes");
+    currentPass = newPass;
+}
+
 void FileAnalyser::addImports() {
     LOG_FUNC
-    for (unsigned i=0; i<ast.numImports(); i++) {
+    beginNewPass(FileAnalyserPass::ADD_IMPORTS);
+    for (unsigned i = 0; i < ast.numImports(); i++) {
         globals->addImportDecl(ast.getImport(i));
     }
 }
 
 void FileAnalyser::resolveTypes() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::RESOLVE_TYPES);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
-    for (unsigned i=0; i<ast.numTypes(); i++) {
-        TypeDecl* T = ast.getType(i);
+    for (unsigned i = 0; i < ast.numTypes(); i++) {
+        TypeDecl *T = ast.getType(i);
         checkTypeDecl(T);
         checkAttributes(T);
     }
@@ -75,6 +83,7 @@ void FileAnalyser::resolveTypes() {
 
 unsigned FileAnalyser::resolveTypeCanonicals() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::RESOLVE_TYPE_CANONICALS);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     unsigned errors = 0;
     for (unsigned i=0; i<ast.numTypes(); i++) {
@@ -120,6 +129,7 @@ unsigned FileAnalyser::resolveTypeCanonicals() {
 
 unsigned FileAnalyser::resolveStructMembers() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::RESOLVE_STRUCT_MEMBERS);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     unsigned errors = 0;
     for (unsigned i=0; i<ast.numTypes(); i++) {
@@ -133,6 +143,7 @@ unsigned FileAnalyser::resolveStructMembers() {
 
 unsigned FileAnalyser::resolveVars() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::RESOLVE_VARS);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     unsigned errors = 0;
     for (unsigned i=0; i<ast.numVars(); i++) {
@@ -149,6 +160,7 @@ unsigned FileAnalyser::resolveVars() {
 
 unsigned FileAnalyser::checkArrayValues(IncrementalArrayVals& values) {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::CHECK_ARRAY_VALUES);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     unsigned errors = 0;
     for (unsigned i=0; i<ast.numArrayValues(); i++) {
@@ -159,6 +171,7 @@ unsigned FileAnalyser::checkArrayValues(IncrementalArrayVals& values) {
 
 void FileAnalyser::checkVarInits() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::CHECK_VAR_INITS);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     for (unsigned i=0; i<ast.numVars(); i++) {
         VarDecl* V = ast.getVar(i);
@@ -181,6 +194,7 @@ void FileAnalyser::checkVarInits() {
 
 unsigned FileAnalyser::resolveEnumConstants() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::RESOLVE_ENUM_CONSTANTS);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     unsigned errors = 0;
     for (unsigned i=0; i<ast.numTypes(); i++) {
@@ -220,6 +234,7 @@ unsigned FileAnalyser::resolveEnumConstants() {
 
 unsigned FileAnalyser::checkFunctionProtos(StructFunctionList& structFuncs) {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::CHECK_FUNCTION_PROTOS);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     unsigned errors = 0;
     for (unsigned i=0; i<ast.numFunctions(); i++) {
@@ -245,6 +260,7 @@ unsigned FileAnalyser::checkFunctionProtos(StructFunctionList& structFuncs) {
 
 void FileAnalyser::checkFunctionBodies() {
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::CHECK_FUNCTION_BODIES);
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
     for (unsigned i=0; i<ast.numFunctions(); i++) {
         functionAnalyser.check(ast.getFunction(i));
@@ -252,9 +268,9 @@ void FileAnalyser::checkFunctionBodies() {
 }
 
 void FileAnalyser::checkDeclsForUsed() {
-    if (ast.isInterface()) return;
-
     LOG_FUNC
+    beginNewPass(FileAnalyserPass::CHECK_DECLS_FOR_USED);
+    if (ast.isInterface()) return;
     if (verbose) printf(COL_VERBOSE "%s %s" ANSI_NORMAL "\n", __func__, ast.getFileName().c_str());
 
     // checkfor unused uses
@@ -326,6 +342,7 @@ void FileAnalyser::checkDeclsForUsed() {
 }
 
 void FileAnalyser::checkStructMembersForUsed(const StructTypeDecl* S) {
+    assert(currentPass == FileAnalyserPass::CHECK_DECLS_FOR_USED);
     for (unsigned j=0; j<S->numMembers(); j++) {
         Decl* M = S->getMember(j);
         if (!M->isUsed() && !M->hasEmptyName()) {   // dont warn for anonymous structs/unions
@@ -340,6 +357,8 @@ void FileAnalyser::checkStructMembersForUsed(const StructTypeDecl* S) {
 
 unsigned FileAnalyser::checkTypeDecl(TypeDecl* D) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::RESOLVE_TYPES);
+
     // check generic type
     unsigned errors = TR->checkType(D->getType(), D->isPublic());
 
@@ -392,6 +411,7 @@ unsigned FileAnalyser::checkTypeDecl(TypeDecl* D) {
 }
 
 void FileAnalyser::checkStructFunction(FunctionDecl* F, StructFunctionList& structFuncs) {
+    assert(currentPass == FileAnalyserPass::CHECK_FUNCTION_PROTOS);
     IdentifierExpr* structName = F->getStructName();
     Decl* D = globals->findSymbolInModule(structName->getName(), structName->getLocation(), F->getModule());
     if (!D) return;
@@ -415,6 +435,7 @@ void FileAnalyser::checkStructFunction(FunctionDecl* F, StructFunctionList& stru
 }
 
 void FileAnalyser::analyseStructNames(const StructTypeDecl* S, Names& names, bool isStruct) {
+    assert(currentPass == FileAnalyserPass::RESOLVE_TYPES);
     typedef Names::iterator NamesIter;
     for (unsigned i=0; i<S->numMembers(); i++) {
         const Decl* member = S->getMember(i);
@@ -442,6 +463,8 @@ void FileAnalyser::analyseStructNames(const StructTypeDecl* S, Names& names, boo
 
 unsigned FileAnalyser::checkStructTypeDecl(StructTypeDecl* D) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::RESOLVE_STRUCT_MEMBERS);
+
     if (!D->isGlobal() && !ast.isInterface() && !D->hasEmptyName() && !islower(D->getName()[0])) {
         Diags.Report(D->getLocation(), diag::err_var_casing);
     }
@@ -469,6 +492,11 @@ unsigned FileAnalyser::checkStructTypeDecl(StructTypeDecl* D) {
 
 unsigned FileAnalyser::resolveVarDecl(VarDecl* D) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::RESOLVE_VARS ||
+           currentPass == FileAnalyserPass::RESOLVE_STRUCT_MEMBERS ||
+           currentPass == FileAnalyserPass::RESOLVE_TYPE_CANONICALS ||
+           currentPass == FileAnalyserPass::CHECK_FUNCTION_PROTOS);
+
     // TODO duplicate code with FileAnalyser::analyseDeclExpr()
     QualType Q = TR->resolveType(D->getType(), D->isPublic());
     if (!Q.isValid()) return 1;
@@ -510,6 +538,9 @@ unsigned FileAnalyser::resolveVarDecl(VarDecl* D) {
 
 unsigned FileAnalyser::resolveFunctionDecl(FunctionDecl* D, bool checkArgs) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::RESOLVE_TYPE_CANONICALS ||
+           currentPass == FileAnalyserPass::CHECK_FUNCTION_PROTOS);
+
     unsigned errors = 0;
     // return type
     QualType Q = TR->resolveType(D->getReturnType(), D->isPublic());
@@ -535,6 +566,8 @@ unsigned FileAnalyser::resolveFunctionDecl(FunctionDecl* D, bool checkArgs) {
 
 unsigned FileAnalyser::checkArrayValue(ArrayValueDecl* D, IncrementalArrayVals& values) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::CHECK_ARRAY_VALUES);
+
     // find decl
     Decl* found = globals->findSymbolInModule(D->getName(), D->getLocation(), D->getModule());
     if (!found) return 1;
@@ -575,6 +608,7 @@ unsigned FileAnalyser::checkArrayValue(ArrayValueDecl* D, IncrementalArrayVals& 
 
 void FileAnalyser::checkVarDeclAttributes(VarDecl* D) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::RESOLVE_VARS);
     if (!D->hasAttributes()) return;
     checkAttributes(D);
 
@@ -607,6 +641,10 @@ void FileAnalyser::checkVarDeclAttributes(VarDecl* D) {
 
 void FileAnalyser::checkAttributes(Decl* D) {
     LOG_FUNC
+    assert(currentPass == FileAnalyserPass::RESOLVE_TYPES ||
+           currentPass == FileAnalyserPass::CHECK_FUNCTION_PROTOS ||
+           currentPass == FileAnalyserPass::RESOLVE_VARS);
+
     if (!D->hasAttributes()) return;
 
     const AttrList& AL = D->getAttributes();

--- a/c2c/Analyser/FileAnalyser.h
+++ b/c2c/Analyser/FileAnalyser.h
@@ -49,6 +49,21 @@ typedef StructFunctionList::const_iterator StructFunctionListIter;
 typedef std::map<VarDecl*, ExprList> IncrementalArrayVals;
 typedef IncrementalArrayVals::const_iterator IncrementalArrayValsIter;
 
+enum class FileAnalyserPass {
+    NOT_STARTED,
+    ADD_IMPORTS,
+    RESOLVE_TYPES,
+    RESOLVE_TYPE_CANONICALS,
+    RESOLVE_STRUCT_MEMBERS,
+    RESOLVE_VARS,
+    RESOLVE_ENUM_CONSTANTS,
+    CHECK_ARRAY_VALUES,
+    CHECK_FUNCTION_PROTOS,
+    CHECK_VAR_INITS,
+    CHECK_FUNCTION_BODIES,
+    CHECK_DECLS_FOR_USED
+};
+
 class FileAnalyser {
 public:
     FileAnalyser(const Module& module_, const Modules& modules,
@@ -71,6 +86,7 @@ public:
     void checkDeclsForUsed();
 
 private:
+    void beginNewPass(FileAnalyserPass newPass);
     unsigned checkTypeDecl(TypeDecl* D);
     unsigned checkStructTypeDecl(StructTypeDecl* D);
     unsigned resolveVarDecl(VarDecl* D);
@@ -90,7 +106,7 @@ private:
     c2lang::DiagnosticsEngine& Diags;
     FunctionAnalyser functionAnalyser;
     bool verbose;
-
+    FileAnalyserPass currentPass = FileAnalyserPass::NOT_STARTED;
     FileAnalyser(const FileAnalyser&);
     FileAnalyser& operator= (const FileAnalyser&);
 };

--- a/c2c/Analyser/FunctionAnalyser.cpp
+++ b/c2c/Analyser/FunctionAnalyser.cpp
@@ -128,13 +128,14 @@ void FunctionAnalyser::check(FunctionDecl* func) {
 
     // check labels
     for (LabelsIter iter = labels.begin(); iter != labels.end(); ++iter) {
-        LabelDecl* LD = *iter;
+        LabelDecl *LD = *iter;
         if (LD->getStmt()) {    // have label part
             if (!LD->isUsed()) {
                 Diag(LD->getLocation(), diag::warn_unused_label) << LD->DiagName();
             }
-        } else {    // only have goto part
-            Diag(LD->getLocation(), diag:: err_undeclared_label_use) << LD->DiagName();
+        }
+        else {    // only have goto part
+            Diag(LD->getLocation(), diag::err_undeclared_label_use) << LD->DiagName();
         }
     }
     labels.clear();
@@ -1022,7 +1023,7 @@ void FunctionAnalyser::analyseSizeOfExpr(BuiltinExpr* B) {
         return;
     case EXPR_UNARYOP:
         // some allowed (&)?
-        // TODO
+        TODO;
         return;
     case EXPR_BUILTIN:
         FATAL_ERROR("Unreachable");

--- a/c2c/Analyser/Scope.cpp
+++ b/c2c/Analyser/Scope.cpp
@@ -52,9 +52,15 @@ Scope::Scope(const std::string& name_, const Modules& modules_, c2lang::Diagnost
 }
 
 void Scope::addImportDecl(ImportDecl* importDecl) {
-    assert(importDecl->getModule());
+    assert(importDecl->getModule() && "Module missing");
+
+    // Store module as local.
     if (importDecl->isLocal()) locals.push_back(importDecl->getModule());
+
+    // Add module to imports.
     importedModules[importDecl->getName()] = importDecl;
+
+    // Link the name to the declaration in the symbol cache.
     symbolCache[importDecl->getName()] = importDecl;
 }
 

--- a/c2c/IRGenerator/CodeGenFunction.h
+++ b/c2c/IRGenerator/CodeGenFunction.h
@@ -36,10 +36,12 @@ class CompoundStmt;
 class ReturnStmt;
 class IfStmt;
 class Expr;
+class ForStmt;
 class CallExpr;
 class IdentifierExpr;
 class VarDecl;
 class BinaryOperator;
+class UnaryOperator;
 class BuiltinExpr;
 
 // This class organizes the per-function state that is used
@@ -56,6 +58,7 @@ private:
     void EmitCompoundStmt(const CompoundStmt* S);
     void EmitReturnStmt(const ReturnStmt* S);
     void EmitIfStmt(const IfStmt* S);
+    void EmitForStmt(const ForStmt *S);
 
     llvm::Value* EmitExpr(const Expr* E);
     llvm::Value* EmitExprNoImpCast(const Expr* E);
@@ -64,6 +67,7 @@ private:
     llvm::Value* EmitBuiltinExpr(const BuiltinExpr* E);
     void EmitVarDecl(const VarDecl* D);
     llvm::Value* EmitBinaryOperator(const BinaryOperator* E);
+    llvm::Value* EmitUnaryOperator(const UnaryOperator* E);
 
     llvm::BasicBlock* createBasicBlock(const llvm::Twine &name = "",
                                       llvm::Function* parent = 0,
@@ -133,6 +137,11 @@ private:
   };
 
 
+  struct BreakContinue {
+      llvm::BasicBlock *breakJump;
+      llvm::BasicBlock *continueJump;
+  };
+
     CodeGenModule& CGM;
     FunctionDecl* FuncDecl;
     llvm::Function* CurFn;      // only set for generateBody() not generateProto()
@@ -140,6 +149,8 @@ private:
     llvm::LLVMContext& context;
     llvm::Module* module;
     llvm::IRBuilder<> Builder;  // NOTE: do we really need to create a new builder?
+
+    std::vector<BreakContinue> breakContinueStack;
 
     /// AllocaInsertPoint - This is an instruction in the entry block before which
     /// we prefer to insert allocas.

--- a/c2c/IRGenerator/CodeGenModule.cpp
+++ b/c2c/IRGenerator/CodeGenModule.cpp
@@ -140,7 +140,7 @@ void CodeGenModule::generate() {
 }
 
 bool CodeGenModule::verify() {
-    if (verifyModule(*module)) {
+    if (verifyModule(*module, &errs())) {
         errs() << "Error in Module!\n";
         return false;
     }


### PR DESCRIPTION
- Changed to use foreach loops - skip this one if you want old school loops.
- Forced to add a isFloat() to QualType
- Added explicit state to the FileAnalyser. Note that this is not actually adding any behaviour, but it becomes very clear what can happen in what state. It was very hard to tell from just reading the code. It can be excluded.
- Fixed some unary IR (not/neg) emits.
- Added a break-continue stack (I actually started on the for loop, but it's not included in this checkin)