### PR TITLE
Some improvements to IR. Also clarified state in AST analysis.

### DIFF
--- a/c2c/AST/Expr.h
+++ b/c2c/AST/Expr.h
@@ -98,6 +98,11 @@ public:
     bool hasImpCast() const {
         return getImpCast() != BuiltinType::Void;
     }
+
+    bool isFloat() const {
+        return QT.isFloatType();
+    }
+
     BuiltinType::Kind getImpCast() const {
         return static_cast<BuiltinType::Kind>(exprBits.ImpCast);
     }

--- a/c2c/AST/Type.cpp
+++ b/c2c/AST/Type.cpp
@@ -63,6 +63,23 @@ bool QualType::isIntegerType() const {
     }
     return false;
 }
+
+bool QualType::isFloatType() const {
+    QualType Canon = getTypePtr()->getCanonicalType();
+    if (BuiltinType* BI = dyncast<BuiltinType>(Canon.getTypePtr())) {
+        return BI->isFloatingPoint();
+    }
+    return false;
+}
+
+bool QualType::isUnsignedType() const {
+    QualType Canon = getTypePtr()->getCanonicalType();
+    if (BuiltinType* BI = dyncast<BuiltinType>(Canon.getTypePtr())) {
+        return BI->isUnsignedInteger();
+    }
+    return false;
+}
+
 bool QualType::isArithmeticType() const {
     QualType Canon = getTypePtr()->getCanonicalType();
     if (BuiltinType* BI = dyncast<BuiltinType>(Canon.getTypePtr())) {

--- a/c2c/AST/Type.h
+++ b/c2c/AST/Type.h
@@ -97,6 +97,8 @@ public:
     bool isArithmeticType() const;
     bool isScalarType() const;
     bool isIncompleteType() const;
+    bool isFloatType() const;
+    bool isUnsignedType() const;
 
     bool isConstant() const;    // NOTE: not is const!
 

--- a/c2c/Analyser/ComponentAnalyser.cpp
+++ b/c2c/Analyser/ComponentAnalyser.cpp
@@ -45,8 +45,8 @@ ComponentAnalyser::ComponentAnalyser(Component& C,
 }
 
 ComponentAnalyser::~ComponentAnalyser() {
-    for (unsigned i=0; i<analysers.size(); i++) {
-        delete analysers[i];
+    for (auto &analyser : analysers) {
+        delete analyser;
     }
 }
 

--- a/c2c/Analyser/ComponentAnalyser.h
+++ b/c2c/Analyser/ComponentAnalyser.h
@@ -48,7 +48,6 @@ private:
     bool verbose;
 
     typedef std::vector<FileAnalyser*> Analysers;
-    typedef Analysers::iterator AnalysersIter;
     Analysers analysers;
 
     ComponentAnalyser(const ComponentAnalyser&);

--- a/c2c/Analyser/FileAnalyser.h
+++ b/c2c/Analyser/FileAnalyser.h
@@ -49,6 +49,21 @@ typedef StructFunctionList::const_iterator StructFunctionListIter;
 typedef std::map<VarDecl*, ExprList> IncrementalArrayVals;
 typedef IncrementalArrayVals::const_iterator IncrementalArrayValsIter;
 
+enum class FileAnalyserPass {
+    NOT_STARTED,
+    ADD_IMPORTS,
+    RESOLVE_TYPES,
+    RESOLVE_TYPE_CANONICALS,
+    RESOLVE_STRUCT_MEMBERS,
+    RESOLVE_VARS,
+    RESOLVE_ENUM_CONSTANTS,
+    CHECK_ARRAY_VALUES,
+    CHECK_FUNCTION_PROTOS,
+    CHECK_VAR_INITS,
+    CHECK_FUNCTION_BODIES,
+    CHECK_DECLS_FOR_USED
+};
+
 class FileAnalyser {
 public:
     FileAnalyser(const Module& module_, const Modules& modules,
@@ -71,6 +86,7 @@ public:
     void checkDeclsForUsed();
 
 private:
+    void beginNewPass(FileAnalyserPass newPass);
     unsigned checkTypeDecl(TypeDecl* D);
     unsigned checkStructTypeDecl(StructTypeDecl* D);
     unsigned resolveVarDecl(VarDecl* D);
@@ -90,7 +106,7 @@ private:
     c2lang::DiagnosticsEngine& Diags;
     FunctionAnalyser functionAnalyser;
     bool verbose;
-
+    FileAnalyserPass currentPass = FileAnalyserPass::NOT_STARTED;
     FileAnalyser(const FileAnalyser&);
     FileAnalyser& operator= (const FileAnalyser&);
 };

--- a/c2c/Analyser/FunctionAnalyser.cpp
+++ b/c2c/Analyser/FunctionAnalyser.cpp
@@ -1022,7 +1022,7 @@ void FunctionAnalyser::analyseSizeOfExpr(BuiltinExpr* B) {
         return;
     case EXPR_UNARYOP:
         // some allowed (&)?
-        // TODO
+        TODO;
         return;
     case EXPR_BUILTIN:
         FATAL_ERROR("Unreachable");

--- a/c2c/Analyser/Scope.cpp
+++ b/c2c/Analyser/Scope.cpp
@@ -52,9 +52,15 @@ Scope::Scope(const std::string& name_, const Modules& modules_, c2lang::Diagnost
 }
 
 void Scope::addImportDecl(ImportDecl* importDecl) {
-    assert(importDecl->getModule());
+    assert(importDecl->getModule() && "Module missing");
+
+    // Store module as local.
     if (importDecl->isLocal()) locals.push_back(importDecl->getModule());
+
+    // Add module to imports.
     importedModules[importDecl->getName()] = importDecl;
+
+    // Link the name to the declaration in the symbol cache.
     symbolCache[importDecl->getName()] = importDecl;
 }
 

--- a/c2c/IRGenerator/CodeGenFunction.h
+++ b/c2c/IRGenerator/CodeGenFunction.h
@@ -29,6 +29,7 @@ class Twine;
 }
 
 namespace C2 {
+class QualType;
 class CodeGenModule;
 class FunctionDecl;
 class Stmt;
@@ -36,10 +37,12 @@ class CompoundStmt;
 class ReturnStmt;
 class IfStmt;
 class Expr;
+class ForStmt;
 class CallExpr;
 class IdentifierExpr;
 class VarDecl;
 class BinaryOperator;
+class UnaryOperator;
 class BuiltinExpr;
 
 // This class organizes the per-function state that is used
@@ -56,6 +59,7 @@ private:
     void EmitCompoundStmt(const CompoundStmt* S);
     void EmitReturnStmt(const ReturnStmt* S);
     void EmitIfStmt(const IfStmt* S);
+    void EmitForStmt(const ForStmt *S);
 
     llvm::Value* EmitExpr(const Expr* E);
     llvm::Value* EmitExprNoImpCast(const Expr* E);
@@ -64,6 +68,10 @@ private:
     llvm::Value* EmitBuiltinExpr(const BuiltinExpr* E);
     void EmitVarDecl(const VarDecl* D);
     llvm::Value* EmitBinaryOperator(const BinaryOperator* E);
+    llvm::Value* EmitUnaryOperator(const UnaryOperator* E);
+
+    void promoteCast(llvm::Value **lhs, const QualType &lhsType, llvm::Value **rhs, const QualType &rhsType);
+    llvm::Value *castIfNecessary(llvm::Type *targetType, const QualType &astTargetType, llvm::Value *value, const QualType &valueType);
 
     llvm::BasicBlock* createBasicBlock(const llvm::Twine &name = "",
                                       llvm::Function* parent = 0,
@@ -133,6 +141,11 @@ private:
   };
 
 
+  struct BreakContinue {
+      llvm::BasicBlock *breakJump;
+      llvm::BasicBlock *continueJump;
+  };
+
     CodeGenModule& CGM;
     FunctionDecl* FuncDecl;
     llvm::Function* CurFn;      // only set for generateBody() not generateProto()
@@ -140,6 +153,8 @@ private:
     llvm::LLVMContext& context;
     llvm::Module* module;
     llvm::IRBuilder<> Builder;  // NOTE: do we really need to create a new builder?
+
+    std::vector<BreakContinue> breakContinueStack;
 
     /// AllocaInsertPoint - This is an instruction in the entry block before which
     /// we prefer to insert allocas.

--- a/c2c/IRGenerator/CodeGenModule.cpp
+++ b/c2c/IRGenerator/CodeGenModule.cpp
@@ -140,7 +140,7 @@ void CodeGenModule::generate() {
 }
 
 bool CodeGenModule::verify() {
-    if (verifyModule(*module)) {
+    if (verifyModule(*module, &errs())) {
         errs() << "Error in Module!\n";
         return false;
     }

--- a/test/Codegen/unary.c2
+++ b/test/Codegen/unary.c2
@@ -1,0 +1,16 @@
+// @warnings{no-unused}
+module test;
+
+func void foo() {
+ i32 a = 10;
+ i32 aNot = !a;
+ i32 aMinus = -a;
+ u32 b = 12;
+ u32 bNot = !b;
+ u32 d = 11;
+ u32 dbAnd = d & b;
+ u32 dbOr = d | b;
+ u32 dbXor = d ^ b;
+}
+
+// Need test code checks


### PR DESCRIPTION
- Changed to use foreach loops - skip this one if you want old school loops.
- Forced to add a isFloat() to QualType
- Added explicit state to the FileAnalyser. Note that this is not actually adding any behaviour, but it becomes very clear what can happen in what state. It was very hard to tell from just reading the code. It can be excluded.
- Added a break-continue stack (I actually started on the for loop, but it's not included in this checkin)
- Fixed some unary IR emits (~, -, !, +).
- Add implicit casting for binary expressions. Probably should already be done in AST analysis instead.
- * - + should now work both for floats and ints
- xor/or/and works for ints