### PR TITLE
Fix sizeof. Also inlines many sizes variable sizes directly. However,…

### DIFF
--- a/c2c/AST/Decl.cpp
+++ b/c2c/AST/Decl.cpp
@@ -328,6 +328,21 @@ Decl* StructTypeDecl::find(const char* name_) const {
     return findFunction(name_);
 }
 
+Decl* StructTypeDecl::findMember(const char* name_) const {
+    // normal members
+    for (unsigned i=0; i<numMembers(); i++) {
+        Decl* D = members[i];
+        if (strcmp(D->getName(), name_) == 0) return D;
+        if (D->hasEmptyName()) {      // empty string
+            assert(isa<StructTypeDecl>(D));
+            StructTypeDecl* sub = cast<StructTypeDecl>(D);
+            D = sub->find(name_);
+            if (D) return D;
+        }
+    }
+    return nullptr;
+}
+
 FunctionDecl* StructTypeDecl::findFunction(const char* name_) const {
     // struct-functions
     for (unsigned i=0; i<numStructFunctions(); i++) {

--- a/c2c/AST/Decl.h
+++ b/c2c/AST/Decl.h
@@ -351,6 +351,7 @@ public:
     unsigned numStructFunctions() const { return structTypeDeclBits.numStructFunctions; }
     Decl* getMember(unsigned index) const { return members[index]; }
     Decl* find(const char* name_) const;
+    Decl* findMember(const char* name_) const;
     FunctionDecl* findFunction(const char* name_) const;
     int findIndex(const char*  name_) const;
     void setOpaqueMembers();

--- a/c2c/Analyser/FunctionAnalyser.h
+++ b/c2c/Analyser/FunctionAnalyser.h
@@ -118,7 +118,7 @@ private:
                                           Expr* value,
                                           bool &haveDesignators);
 
-    void analyseSizeOfExpr(BuiltinExpr* expr);
+    bool analyseSizeOfExpr(BuiltinExpr* expr);
     QualType analyseElemsOfExpr(BuiltinExpr* B);
     QualType analyseEnumMinMaxExpr(BuiltinExpr* B, bool isMin);
     void analyseArrayType(VarDecl* V, QualType T);

--- a/c2c/CGenerator/CCodeGenerator.cpp
+++ b/c2c/CGenerator/CCodeGenerator.cpp
@@ -361,7 +361,11 @@ void CCodeGenerator::EmitBuiltinExpr(const Expr* E, StringBuilder& output) {
     case BuiltinExpr::BUILTIN_SIZEOF:
         // TODO for now generate external sizeof() instead of number (need StructSizer)
         output << "sizeof(";
-        EmitExpr(B->getExpr(), output);
+        if (B->getValue().getZExtValue() > 0) {
+            output << B->getValue().toString(10);
+        } else {
+            EmitExpr(B->getExpr(), output);
+        }
         output << ')';
         break;
     case BuiltinExpr::BUILTIN_ELEMSOF:

--- a/c2c/Parser/C2Parser.cpp
+++ b/c2c/Parser/C2Parser.cpp
@@ -537,7 +537,7 @@ C2::ExprResult C2Parser::ParseSingleTypeSpecifier(bool allow_qualifier) {
     if (allow_qualifier) type_qualifier = ParseOptionalTypeQualifier();
 
     ExprResult base;
-    // first part is always a base type or identifier(::identifier)
+    // first part is always a base type or identifier(.identifier)
     switch (Tok.getKind()) {
     case tok::kw_u8:
     case tok::kw_u16:
@@ -1397,6 +1397,27 @@ C2::ExprResult C2Parser::ParseArray(ExprResult base) {
     return Actions.ActOnArrayType(base.get(), E.get(), false);
 }
 
+static bool isTypeIdent(const Token &token) {
+    assert(token.getKind() == tok::identifier && "Valid for identifiers only");
+    char firstCharacter = token.getIdentifierInfo()->getNameStart()[0];
+    return firstCharacter >= 'A' && firstCharacter <= 'Z';
+}
+
+bool C2Parser::canBeParsedAsStructType()
+{
+    if (!isTypeIdent(Tok))
+    {
+        return
+            PP.LookAhead(0).getKind() == tok::period
+            && isTypeIdent(PP.LookAhead(1))
+            && PP.LookAhead(2).getKind() != tok::period;
+    }
+    // Now we need to look for foo.Bar!
+    // We start with Foo, but if we have Foo.xxxx then
+    // it's actually referencing a field or a function.
+    return PP.LookAhead(0).getKind() != tok::period;
+}
+
 /// Syntax:
 ///  'sizeof' '(' var-name ')'
 ///  'sizeof' '(' type-name ')'
@@ -1409,15 +1430,6 @@ C2::ExprResult C2Parser::ParseSizeof()
     ExprResult Res;
 
     switch (Tok.getKind()) {
-    case tok::identifier:
-        // identifier might be followed by * or [..]
-        if (NextToken().is(tok::r_paren)) {
-            Res = ParseIdentifier();
-        } else {
-            Res = ParseTypeSpecifier(false);
-        }
-        break;
-        // all basic types
     case tok::kw_u8:
     case tok::kw_u16:
     case tok::kw_u32:
@@ -1432,17 +1444,17 @@ C2::ExprResult C2Parser::ParseSizeof()
     case tok::kw_char:
         Res = ParseTypeSpecifier(false);
         break;
-    case tok::kw_const:
-    case tok::kw_volatile:
-    case tok::kw_local:
-        //Diag(Tok, diag::err_no_qualifier_allowed_here); // TODO why is this commented out?
-        fprintf(stderr, "Not type qualifier allowed here\n");
-        return ExprError();
+    case tok::identifier:
+        if (canBeParsedAsStructType()) {
+            Res = ParseTypeSpecifier(false);
+            break;
+        }
+        // fallthrough;
     default:
-        //Diag(Tok, diag::err_expected type or symbol name); // TODO why is this commented out?
-        fprintf(stderr, "Expected Type or Symbol name\n");
-        return ExprError();
+        Res = ParseExpression();
+        break;
     }
+
     if (Res.isInvalid()) return ExprError();
 
     if (ExpectAndConsume(tok::r_paren)) return ExprError();

--- a/c2c/Parser/C2Parser.h
+++ b/c2c/Parser/C2Parser.h
@@ -203,7 +203,7 @@ private:
     int SkipArray(int lookahead);
     unsigned ParseOptionalTypeQualifier();
     bool ParseOptionalAccessSpecifier();
-
+    bool canBeParsedAsStructType();
     const Token& getCurToken() const { return Tok; }
 
     SourceLocation ConsumeToken() {

--- a/test/CGenerator/Exprs/sizeof_expr.c2t
+++ b/test/CGenerator/Exprs/sizeof_expr.c2t
@@ -1,0 +1,53 @@
+// @recipe bin
+    $warnings no-unused
+    $generate-c
+
+// @file{file1}
+module test;
+
+type Handle i32;
+
+type Foo struct {
+  i32 a;
+  i64 b;
+  union {
+     i32 c;
+     f64 d;
+  }
+}
+public func i32 main(i32 argc, const i8*[] argv) {
+    i32 a = sizeof(i32*);
+    i32 b = sizeof(a);
+    i32 c = sizeof(&a);
+    i32 d = sizeof(Handle);
+    i32 e = sizeof(Handle*);
+    i32 f = sizeof(Handle[3]);
+    i32 g = sizeof(Foo);
+    i32 h = sizeof(Foo.a);
+    i32 i = sizeof(Foo.d);
+    i32 j = sizeof(test.Foo);
+    i32 k = sizeof(test.Foo.a);
+    i32 l = sizeof(test.Foo.d);
+    return 0;
+}
+
+
+// @expect{atleast, build/test.c}
+
+int32_t main(int32_t argc, const char* argv[]) {
+    int32_t a = sizeof(8);
+    int32_t b = sizeof(4);
+    int32_t c = sizeof(8);
+    int32_t d = sizeof(4);
+    int32_t e = sizeof(8);
+    int32_t f = sizeof(int32_t[3]);
+    int32_t g = sizeof(test_Foo);
+    int32_t h = sizeof(4);
+    int32_t i = sizeof(8);
+    int32_t j = sizeof(test_Foo);
+    int32_t k = sizeof(4);
+    int32_t l = sizeof(8);
+
+    return 0;
+}
+

--- a/test/Expr/sizeof/sizeof_unknown_type.c2
+++ b/test/Expr/sizeof/sizeof_unknown_type.c2
@@ -2,6 +2,6 @@
 module test;
 
 public func void test1() {
-    u32 s1 = sizeof(Foo); // @error{use of undeclared identifier Foo}
+    u32 s1 = sizeof(Foo); // @error{unknown type name Foo}
 }
 

--- a/test/Functions/struct_functions/static_member.c2
+++ b/test/Functions/struct_functions/static_member.c2
@@ -6,6 +6,6 @@ type Type struct {
 }
 
 func void myfunc() {
-    i32 a = Type.member;      // @error{type '(struct)Type' has no struct-function 'member'}
+    i32 a = Type.member;      // @error{type 'i32' cannot be assigned to a variable}
 }
 

--- a/test/Parser/sizeof_expr_ok.c2
+++ b/test/Parser/sizeof_expr_ok.c2
@@ -3,12 +3,26 @@ module test;
 
 type Handle i32;
 
+type Foo struct {
+  i32 a;
+  i64 b;
+  union {
+     i32 c;
+     f64 d;
+  }
+}
 func void test1() {
     i32 a = sizeof(i32*);
     i32 b = sizeof(a);
-    i32 c = sizeof(a*);
+    i32 c = sizeof(&a);
     i32 d = sizeof(Handle);
     i32 e = sizeof(Handle*);
     i32 f = sizeof(Handle[2]);
+    i32 g = sizeof(Foo);
+    i32 h = sizeof(Foo.a);
+    i32 i = sizeof(Foo.d);
+    i32 j = sizeof(test.Foo);
+    i32 k = sizeof(test.Foo.a);
+    i32 l = sizeof(test.Foo.d);
 }
 

--- a/test/Types/opaque/opaque_used_by_sizeof.c2t
+++ b/test/Types/opaque/opaque_used_by_sizeof.c2t
@@ -8,6 +8,14 @@ public type Foo struct {
     i32 x;
 } @(opaque)
 
+public type Foo2 struct {
+    i32 x;
+} @(opaque)
+
+public type Foo3 struct {
+    i32 x;
+}
+
 // @file{file2}
 module bar;
 import foo local;
@@ -16,3 +24,14 @@ func void b() {
     i32 s = sizeof(Foo);  // @error{opaque type 'foo.Foo' used by value}
 }
 
+func void c() {
+    i32 s = sizeof(foo.Foo2);  // @error{opaque type 'foo.Foo2' used by value}
+}
+
+func void d() {
+    i32 s = sizeof(foo.Foo3);
+}
+
+func void e() {
+    i32 s = sizeof(Foo3);
+}


### PR DESCRIPTION
… structs are skipped as exact sizes are unclear at this point of time. A bug was found, where – for example – "Foo a = Foo;" is allowed. This requires some extra code to distinguish between typevalues and types of expressions. Since this bug already existed, I did not want to do the extra work in this commit, however, I've updated the expected error.