### PR TITLE
#50 Prune unary plus from AST, making it a complete no-op.

### DIFF
--- a/c2c/AST/Expr.cpp
+++ b/c2c/AST/Expr.cpp
@@ -623,7 +623,6 @@ const char* UnaryOperator::OpCode2str(c2lang::UnaryOperatorKind opc_) {
     case UO_PreDec:     return "--";
     case UO_AddrOf:     return "&";
     case UO_Deref:      return "*";
-    case UO_Plus:       return "+";
     case UO_Minus:      return "-";
     case UO_Not:        return "~";
     case UO_LNot:       return "!";

--- a/c2c/Analyser/FunctionAnalyser.cpp
+++ b/c2c/Analyser/FunctionAnalyser.cpp
@@ -1495,7 +1495,6 @@ QualType FunctionAnalyser::analyseUnaryOperator(Expr* expr, unsigned side) {
             return P->getPointeeType();
         }
         break;
-    case UO_Plus:
     case UO_Minus:
     case UO_Not:
         LType = analyseExpr(SubExpr, side | RHS);

--- a/c2c/Analyser/LiteralAnalyser.cpp
+++ b/c2c/Analyser/LiteralAnalyser.cpp
@@ -347,7 +347,6 @@ APSInt LiteralAnalyser::checkUnaryLiterals(const Expr* Right) {
         break;
     case UO_AddrOf:
     case UO_Deref:
-    case UO_Plus:
         TODO;
         break;
     case UO_Minus:

--- a/c2c/Analyser/TypeFinder.cpp
+++ b/c2c/Analyser/TypeFinder.cpp
@@ -123,7 +123,6 @@ QualType TypeFinder::getUnaryOpType(const UnaryOperator* unaryop) {
         // just return type
         break;
     case UO_Deref:
-    case UO_Plus:
     case UO_Minus:
     case UO_Not:
         return findType(unaryop->getExpr());

--- a/c2c/CGenerator/CCodeGenerator.cpp
+++ b/c2c/CGenerator/CCodeGenerator.cpp
@@ -408,7 +408,6 @@ void CCodeGenerator::EmitUnaryOperator(const Expr* E, StringBuilder& output) {
     case UO_PreDec:
     case UO_AddrOf:
     case UO_Deref:
-    case UO_Plus:
     case UO_Minus:
     case UO_Not:
     case UO_LNot:

--- a/c2c/Clang/OperationKinds.def
+++ b/c2c/Clang/OperationKinds.def
@@ -270,7 +270,6 @@ UNARY_OPERATION(PreDec, "--")
 UNARY_OPERATION(AddrOf, "&")
 UNARY_OPERATION(Deref, "*")
 // [C99 6.5.3.3] Unary arithmetic
-UNARY_OPERATION(Plus, "+")
 UNARY_OPERATION(Minus, "-")
 UNARY_OPERATION(Not, "~")
 UNARY_OPERATION(LNot, "!")

--- a/c2c/IRGenerator/CodeGenFunction.cpp
+++ b/c2c/IRGenerator/CodeGenFunction.cpp
@@ -815,8 +815,6 @@ llvm::Value* CodeGenFunction::EmitUnaryOperator(const UnaryOperator* unaryOperat
     switch (unaryOperator->getOpcode()) {
         case UO_Not:
             return Builder.CreateNot(EmitExpr(expression), "not");
-        case UO_Plus:
-            return EmitExpr(expression);
         case UO_Minus:
             return expression->isFloat()
                    ? Builder.CreateFNeg(EmitExpr(expression), "fneg")

--- a/c2c/IRGenerator/InterfaceGenerator.cpp
+++ b/c2c/IRGenerator/InterfaceGenerator.cpp
@@ -336,7 +336,6 @@ void InterfaceGenerator::EmitUnaryOperator(const Expr* E) {
     case UO_PreDec:
     case UO_AddrOf:
     case UO_Deref:
-    case UO_Plus:
     case UO_Minus:
     case UO_Not:
     case UO_LNot:

--- a/c2c/Parser/C2Parser.cpp
+++ b/c2c/Parser/C2Parser.cpp
@@ -890,8 +890,11 @@ C2::ExprResult C2Parser::ParseCastExpression(bool isUnaryExpression,
             Res = Actions.ActOnUnaryOp(SavedLoc, SavedKind, Res.get());
         return Res;
     }
-    case tok::star:          // unary-expression: '*' cast-expression
     case tok::plus:          // unary-expression: '+' cast-expression
+        // We let unary + be a no-op.
+        ConsumeToken();
+        return ParseCastExpression(false);
+    case tok::star:          // unary-expression: '*' cast-expression
     case tok::minus:         // unary-expression: '-' cast-expression
     case tok::tilde:         // unary-expression: '~' cast-expression
     case tok::exclaim:       // unary-expression: '!' cast-expression

--- a/c2c/Parser/C2Sema.cpp
+++ b/c2c/Parser/C2Sema.cpp
@@ -116,7 +116,6 @@ static inline UnaryOperatorKind ConvertTokenKindToUnaryOpcode(
     case tok::minusminus:   Opc = UO_PreDec; break;
     case tok::amp:          Opc = UO_AddrOf; break;
     case tok::star:         Opc = UO_Deref; break;
-    case tok::plus:         Opc = UO_Plus; break;
     case tok::minus:        Opc = UO_Minus; break;
     case tok::tilde:        Opc = UO_Not; break;
     case tok::exclaim:      Opc = UO_LNot; break;
@@ -1244,6 +1243,7 @@ C2::ExprResult C2Sema::ActOnUnaryOp(SourceLocation OpLoc, tok::TokenKind Kind, E
 #endif
     UnaryOperatorKind Opc = ConvertTokenKindToUnaryOpcode(Kind);
     MEM_EXPR(EXPR_UNARYOP);
+
     return ExprResult(new (Context) UnaryOperator(OpLoc, Opc, Input));
 }
 


### PR DESCRIPTION
This is a version of unary plus pruning that completely makes it a no-op by skipping over it in AST parsing already. See discussion around #50 on how this differs from C.

Note that this change does not affect normal binary operations.