### PR TITLE
Fix for #95: check for NULL before printing attributes of module

### DIFF
--- a/c2c/Parser/Sema.cpp
+++ b/c2c/Parser/Sema.cpp
@@ -336,7 +336,7 @@ Sema::~Sema() {
 
 void Sema::printAST() const {
     ast.print(true);
-    module->printAttributes(true);
+    if (module) module->printAttributes(true);
 }
 
 void Sema::ActOnModule(const char* name_, SourceLocation loc) {


### PR DESCRIPTION
This PR is a fix for #95.

I've just added a quick NULL check before the attributes of the module are printed in Sema::printAST().