### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,6 @@ export CXX=clang++
 ### Arch
 ```bash
 pacman -S cmake ncurses-dev clang
-yaourt -S libtinfo
 ```
 
 ### OS X (Yosemite/El Capitan)


### PR DESCRIPTION
On current Arch (and that's the only kind of Arch ;), libtinfo is included with ncurses.