### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_BUILD_TYPE Release)
 #set(CMAKE_BUILD_TYPE Debug)
 
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wno-overloaded-virtual -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 set(CMAKE_VERBOSE_MAKEFILE false)
 


### PR DESCRIPTION
Good day,

While compiling in Linux Manjaro 20, running kernel 5.8.16-2.

Either make or ninja, I will face this error :

```
[user@manjaro20-pc build]$ ninja
[99/99] Linking CXX executable c2c/c2c
FAILED: c2c/c2c 
: && clang++ -O3 -DNDEBUG -rdynamic c2c/CMakeFiles/c2c.dir/main.cpp.o -o c2c/c2c  c2c/libc2core.a  -L/usr/lib  -lLLVM-10  -ltinfo && :
/usr/bin/ld: c2c/libc2core.a(IRGenerator.cpp.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib/../lib/libpthread.so.0: error adding symbols: DSO missing from command line
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
[user@manjaro20-pc build]$
```

Found the solution here : https://stackoverflow.com/questions/34143265/undefined-reference-to-symbol-pthread-createglibc-2-2-5

set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")



Best regards