### PR TITLE
Partial port to Darwin arm64

### DIFF
--- a/bootstrap/.gitignore
+++ b/bootstrap/.gitignore
@@ -1,1 +1,5 @@
 c2c_bootstrap
+c2c_bootstrap2
+globals.i
+globals
+bootstrap-darwin-arm64.c

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -46,19 +46,7 @@ rebuild:
 	mv -f ../output/c2c/cgen/build.c bootstrap.c
 	$(C2C) --target arm64-apple-darwin-macho --test c2c
 	mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
-	-diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch
-	rm bootstrap-darwin-arm64.c
-
-bootstrap-darwin-arm64.c: bootstrap-darwin-arm64.patch bootstrap.c
-	patch -o $@ bootstrap.c $*.patch
-
-rebuild:
-	@echo "---- rebuilding bootstrap compiler ----"
-	$(C2C) --target x86_64-unknown-linux-gnu --test c2c
-	mv -f ../output/c2c/cgen/build.c bootstrap.c
-	$(C2C) --target arm64-apple-darwin-macho --test c2c
-	mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
-	-diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch
+	( diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch ; true )
 	rm bootstrap-darwin-arm64.c
 
 clean:

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -4,7 +4,6 @@ CC=gcc
 CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch -Wno-char-subscripts
 CFLAGS+=-Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-zero-length
 CFLAGS+=-pipe -std=c99 -O0 -g
-
 TARGET_ARCH:=$(shell uname -s)-$(shell uname -m)
 
 C2C:=../output/c2c/c2c
@@ -18,39 +17,51 @@ endif
 all: $(C2C)
 
 c2c_bootstrap: $(BOOTSTRAP_FILE) external.h
-	    @echo "---- compiling bootstrap compiler ----"
-	    $(CC) $(CFLAGS) $(BOOTSTRAP_FILE) -o c2c_bootstrap -ldl
+	@echo "---- compiling bootstrap compiler ----"
+	@$(CC) $(CFLAGS) $(BOOTSTRAP_FILE) -o c2c_bootstrap -ldl
 
 c2c_bootstrap2: c2c_bootstrap bootstrap.c
-		@echo "---- running (bootstrapped) c2c ----"
-		./c2c_bootstrap c2c --fast --noplugins
-		mv -f ../output/c2c/c2c c2c_bootstrap2
+	@echo "---- running (bootstrapped) c2c ----"
+	@./c2c_bootstrap c2c --fast --noplugins
+	@mv -f ../output/c2c/c2c c2c_bootstrap2
 
 $(C2C): c2c_bootstrap2
-		@echo "---- running c2c (no plugins) ----"
-		./c2c_bootstrap2 --noplugins
-		@echo "---- running c2c (with plugins) ----"
-		@( cd .. && ./install_plugins.sh )
-		@../output/c2c/c2c c2c
+	@echo "---- running c2c (no plugins) ----"
+	@./c2c_bootstrap2 --noplugins
+	@echo "---- running c2c (with plugins) ----"
+	@( cd .. && ./install_plugins.sh )
+	@../output/c2c/c2c c2c
 
 globals: globals.c
-		$(CC) -E - < globals.c > globals.i
-		$(CC) globals.c -o globals
-		./globals
+	$(CC) -E - < globals.c > globals.i
+	$(CC) globals.c -o globals
+	./globals
 
 bootstrap-darwin-arm64.c: bootstrap-darwin-arm64.patch bootstrap.c
-		patch -o $@ bootstrap.c $*.patch
+	@patch -o $@ bootstrap.c $*.patch
 
 rebuild:
-		@echo "---- rebuilding bootstrap compiler ----"
-		$(C2C) --target x86_64-unknown-linux-gnu --test c2c
-		mv -f ../output/c2c/cgen/build.c bootstrap.c
-		$(C2C) --target arm64-apple-darwin-macho --test c2c
-		mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
-		-diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch
-		rm bootstrap-darwin-arm64.c
+	@echo "---- rebuilding bootstrap compiler ----"
+	$(C2C) --target x86_64-unknown-linux-gnu --test c2c
+	mv -f ../output/c2c/cgen/build.c bootstrap.c
+	$(C2C) --target arm64-apple-darwin-macho --test c2c
+	mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
+	-diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch
+	rm bootstrap-darwin-arm64.c
+
+bootstrap-darwin-arm64.c: bootstrap-darwin-arm64.patch bootstrap.c
+	patch -o $@ bootstrap.c $*.patch
+
+rebuild:
+	@echo "---- rebuilding bootstrap compiler ----"
+	$(C2C) --target x86_64-unknown-linux-gnu --test c2c
+	mv -f ../output/c2c/cgen/build.c bootstrap.c
+	$(C2C) --target arm64-apple-darwin-macho --test c2c
+	mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
+	-diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch
+	rm bootstrap-darwin-arm64.c
 
 clean:
-		rm -f c2c_bootstrap c2c_bootstrap2 globals.i globals
-		rm -f bootstrap-darwin-arm64.c
-		rm -rf ../output/ c2c_bootstrap.dSYM
+	rm -f c2c_bootstrap c2c_bootstrap2 globals.i globals
+	rm -f bootstrap-darwin-arm64.c
+	rm -rf ../output/ c2c_bootstrap.dSYM

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -5,21 +5,52 @@ CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch -Wno-char-subscripts
 CFLAGS+=-Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-zero-length
 CFLAGS+=-pipe -std=c99 -O0 -g
 
-all: ../output/c2c/c2c
+TARGET_ARCH:=$(shell uname -s)-$(shell uname -m)
 
-c2c_bootstrap: bootstrap.c external.h
-		@echo "---- compiling bootstrap compiler ----"
-		@$(CC) $(CFLAGS) bootstrap.c -o c2c_bootstrap -ldl
+C2C:=../output/c2c/c2c
 
-../output/c2c/c2c: c2c_bootstrap
+ifeq (Darwin-arm64,$(TARGET_ARCH))
+BOOTSTRAP_FILE=bootstrap-darwin-arm64.c
+else
+BOOTSTRAP_FILE=bootstrap.c
+endif
+
+all: $(C2C)
+
+c2c_bootstrap: $(BOOTSTRAP_FILE) external.h
+	    @echo "---- compiling bootstrap compiler ----"
+	    $(CC) $(CFLAGS) $(BOOTSTRAP_FILE) -o c2c_bootstrap -ldl
+
+c2c_bootstrap2: c2c_bootstrap bootstrap.c
 		@echo "---- running (bootstrapped) c2c ----"
-		@./c2c_bootstrap c2c --fast --noplugins
+		./c2c_bootstrap c2c --fast --noplugins
+		mv -f ../output/c2c/c2c c2c_bootstrap2
+
+$(C2C): c2c_bootstrap2
 		@echo "---- running c2c (no plugins) ----"
-		@../output/c2c/c2c --noplugins
+		./c2c_bootstrap2 --noplugins
 		@echo "---- running c2c (with plugins) ----"
-		@(cd .. && ./install_plugins.sh )
+		@( cd .. && ./install_plugins.sh )
 		@../output/c2c/c2c c2c
 
-clean:
-		@rm -rf c2c_bootstrap ../output/
+globals: globals.c
+		$(CC) -E - < globals.c > globals.i
+		$(CC) globals.c -o globals
+		./globals
 
+bootstrap-darwin-arm64.c: bootstrap-darwin-arm64.patch bootstrap.c
+		patch -o $@ bootstrap.c $*.patch
+
+rebuild:
+		@echo "---- rebuilding bootstrap compiler ----"
+		$(C2C) --target x86_64-unknown-linux-gnu --test c2c
+		mv -f ../output/c2c/cgen/build.c bootstrap.c
+		$(C2C) --target arm64-apple-darwin-macho --test c2c
+		mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
+		-diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch
+		rm bootstrap-darwin-arm64.c
+
+clean:
+		rm -f c2c_bootstrap c2c_bootstrap2 globals.i globals
+		rm -f bootstrap-darwin-arm64.c
+		rm -rf ../output/ c2c_bootstrap.dSYM

--- a/bootstrap/bootstrap-darwin-arm64.patch
+++ b/bootstrap/bootstrap-darwin-arm64.patch
@@ -1,0 +1,318 @@
+103c103
+< int32_t* __errno_location(void);
+---
+> int32_t* __error(void);
+145c145
+<    int64_t d_off;
+---
+>    uint64_t d_seekoff;
+146a147
+>    uint16_t d_namlen;
+148c149
+<    char d_name[256];
+---
+>    char d_name[1024];
+162,167c163,168
+< #define O_CREAT 0100
+< #define O_NOCTTY 0400
+< #define O_TRUNC 01000
+< #define O_NONBLOCK 04000
+< #define O_DIRECTORY 0200000
+< #define O_NOFOLLOW 0400000
+---
+> #define O_CREAT 01000
+> #define O_NOCTTY 0400000
+> #define O_TRUNC 02000
+> #define O_NONBLOCK 04
+> #define O_DIRECTORY 04000000
+> #define O_NOFOLLOW 0400
+169c170
+< #define AT_FDCWD -100
+---
+> #define AT_FDCWD -2
+191c192
+< extern FILE* stdout;
+---
+> extern FILE* __stdoutp;
+193c194
+< extern FILE* stderr;
+---
+> extern FILE* __stderrp;
+268a270,274
+> struct timespec {
+>    int64_t tv_sec;
+>    int64_t tv_nsec;
+> };
+> 
+270c276,278
+<    uint64_t st_dev;
+---
+>    int32_t st_dev;
+>    uint16_t st_mode;
+>    uint16_t st_nlink;
+272,273d279
+<    uint64_t st_nlink;
+<    uint32_t st_mode;
+276,288c282,293
+<    uint64_t st_rdev;
+<    int64_t st_size;
+<    int64_t st_blksize;
+<    int64_t st_blocks;
+<    int64_t st_atime;
+<    uint64_t st_atime_nsec;
+<    uint64_t st_mtime;
+<    uint64_t st_mtime_nsec;
+<    uint64_t st_ctime;
+<    uint64_t st_ctime_nsec;
+<    uint32_t __unused4;
+<    uint32_t __unused5;
+<    int64_t reserved[2];
+---
+>    uint32_t st_rdev;
+>    struct timespec st_atimespec;
+>    struct timespec st_mtimespec;
+>    struct timespec st_ctimespec;
+>    struct timespec st_birthtimespec;
+>    uint64_t st_size;
+>    uint64_t st_blocks;
+>    uint32_t st_blksize;
+>    uint32_t st_flags;
+>    uint32_t st_gen;
+>    int32_t st_lspare;
+>    int64_t st_qspare[2];
+324c329
+< #define NAME_LEN 65
+---
+> #define NAME_LEN 256
+326,331c331,336
+<    char sysname[65];
+<    char nodename[65];
+<    char release[65];
+<    char version[65];
+<    char machine[65];
+<    char domainname[65];
+---
+>    char sysname[256];
+>    char nodename[256];
+>    char release[256];
+>    char version[256];
+>    char machine[256];
+>    char domainname[256];
+421c426
+<       file->errno = *__errno_location();
+---
+>       file->errno = *__error();
+427c432
+<       file->errno = *__errno_location();
+---
+>       file->errno = *__error();
+494c499
+<    if ((err && (*__errno_location() != EEXIST))) return -1;
+---
+>    if ((err && (*__error() != EEXIST))) return -1;
+499c504
+<    if ((fd == -1)) return *__errno_location();
+---
+>    if ((fd == -1)) return *__error();
+511c516
+<    if ((fd == -1)) return *__errno_location();
+---
+>    if ((fd == -1)) return *__error();
+532c537
+<    if (err) errno_ = *__errno_location();
+---
+>    if (err) errno_ = *__error();
+549c554
+<       sprintf(writer->msg, "error opening %s: %s", filename, strerror(*__errno_location()));
+---
+>       sprintf(writer->msg, "error opening %s: %s", filename, strerror(*__error()));
+554c559
+<       sprintf(writer->msg, "error writing %s: %s", filename, strerror(*__errno_location()));
+---
+>       sprintf(writer->msg, "error writing %s: %s", filename, strerror(*__error()));
+1903,1904c1908,1909
+<    fprintf(stderr, "[exec] %s\n", msg);
+<    fflush(stderr);
+---
+>    fprintf(__stderrp, "[exec] %s\n", msg);
+>    fflush(__stderrp);
+1912c1917
+<       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
+1916c1921
+<       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
+1920c1925
+<       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
+1931c1936
+<       fflush(stdout);
+---
+>       fflush(__stdoutp);
+1935c1940
+<          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
+1940c1945
+<          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "dup(): %s", strerror(*__error()));
+1945c1950
+<          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
+1955,1956c1960,1961
+<       int32_t lasterr = *__errno_location();
+<       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
+---
+>       int32_t lasterr = *__error();
+>       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
+1967c1972
+<          fprintf(stderr, "Error reading pipe\n");
+---
+>          fprintf(__stderrp, "Error reading pipe\n");
+1977c1982
+<          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
+---
+>          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
+2036c2041
+<       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
+2040c2045
+<       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
+2044c2049
+<       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
+2055c2060
+<       fflush(stdout);
+---
+>       fflush(__stdoutp);
+2059c2064
+<          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
+2064c2069
+<          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "dup(): %s", strerror(*__error()));
+2069c2074
+<          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
+2082,2083c2087,2088
+<       int32_t lasterr = *__errno_location();
+<       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
+---
+>       int32_t lasterr = *__error();
+>       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
+2094c2099
+<          fprintf(stderr, "Error reading pipe\n");
+---
+>          fprintf(__stderrp, "Error reading pipe\n");
+2104c2109
+<          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
+---
+>          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
+2280c2285
+<          if ((*__errno_location() != ENOENT)) {
+---
+>          if ((*__error() != ENOENT)) {
+3212c3217
+<       fprintf(stderr, "%swarning: %s%s\n", color_Yellow, buf, color_Normal);
+---
+>       fprintf(__stderrp, "%swarning: %s%s\n", color_Yellow, buf, color_Normal);
+3214c3219
+<       fprintf(stderr, "warning: %s\n", buf);
+---
+>       fprintf(__stderrp, "warning: %s\n", buf);
+3227c3232
+<       fprintf(stderr, "%serror: %s%s\n", color_Red, buf, color_Normal);
+---
+>       fprintf(__stderrp, "%serror: %s%s\n", color_Red, buf, color_Normal);
+3229c3234
+<       fprintf(stderr, "error: %s\n", buf);
+---
+>       fprintf(__stderrp, "error: %s\n", buf);
+3465c3470
+<          fprintf(stderr, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(sm, loc), color_Red, color_Normal, error_msg);
+---
+>          fprintf(__stderrp, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(sm, loc), color_Red, color_Normal, error_msg);
+3467c3472
+<          fprintf(stderr, "%serror%s: %s\n", color_Red, color_Normal, error_msg);
+---
+>          fprintf(__stderrp, "%serror%s: %s\n", color_Red, color_Normal, error_msg);
+3520c3525
+<          fprintf(stderr, "%serror%s: too many files open\n", color_Red, color_Normal);
+---
+>          fprintf(__stderrp, "%serror%s: too many files open\n", color_Red, color_Normal);
+3564c3569
+<          fprintf(stderr, "%serror%s: too many files open\n", color_Red, color_Normal);
+---
+>          fprintf(__stderrp, "%serror%s: too many files open\n", color_Red, color_Normal);
+3918c3923
+<       console_error("error getting system info: %s", strerror(*__errno_location()));
+---
+>       console_error("error getting system info: %s", strerror(*__error()));
+4881c4886
+<          fprintf(stderr, "[build-file] warning: environment variable '%s' not set!\n", (raw + 1));
+---
+>          fprintf(__stderrp, "[build-file] warning: environment variable '%s' not set!\n", (raw + 1));
+4928c4933
+<             fprintf(stderr, "[build-file] missing options for %s\n", name);
+---
+>             fprintf(__stderrp, "[build-file] missing options for %s\n", name);
+4945c4950
+<       fprintf(stderr, "Error: %s\n", yaml_Parser_getMessage(parser));
+---
+>       fprintf(__stderrp, "Error: %s\n", yaml_Parser_getMessage(parser));
+5569c5574
+<    fprintf(stderr, "%s\n", string_buffer_Buf_data(out));
+---
+>    fprintf(__stderrp, "%s\n", string_buffer_Buf_data(out));
+5600c5605
+<       fputs(string_buffer_Buf_data(out), stderr);
+---
+>       fputs(string_buffer_Buf_data(out), __stderrp);
+19287c19292
+<       fprintf(stderr, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), color_Red, color_Normal, msg);
+---
+>       fprintf(__stderrp, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), color_Red, color_Normal, msg);
+19289c19294
+<       fprintf(stderr, "%s: error: %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), msg);
+---
+>       fprintf(__stderrp, "%s: error: %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), msg);
+31435c31440
+<       fprintf(stderr, "error: missing node %s\n", path);
+---
+>       fprintf(__stderrp, "error: missing node %s\n", path);
+31459c31464
+<             fprintf(stderr, "error in manifest: invalid library kind '%s'\n", kind);
+---
+>             fprintf(__stderrp, "error in manifest: invalid library kind '%s'\n", kind);
+31466c31471
+<       fprintf(stderr, "error in manifest: a library must be dynamic and/or static\n");
+---
+>       fprintf(__stderrp, "error in manifest: a library must be dynamic and/or static\n");
+31530c31535
+< static const char* plugin_mgr_lib_ext = ".so";
+---
+> static const char* plugin_mgr_lib_ext = ".dylib";
+31613c31618
+<          console_warn("cannot read '%s': %s", path, strerror(*__errno_location()));
+---
+>          console_warn("cannot read '%s': %s", path, strerror(*__error()));
+36711c36716
+<       console_error("cannot open library dir '%s': %s", dirname, strerror(*__errno_location()));
+---
+>       console_error("cannot open library dir '%s': %s", dirname, strerror(*__error()));
+37086c37091
+<          console_error("cannot chdir to %s: %s", opts.other_dir, strerror(*__errno_location()));
+---
+>          console_error("cannot chdir to %s: %s", opts.other_dir, strerror(*__error()));

--- a/bootstrap/bootstrap-darwin-arm64.patch
+++ b/bootstrap/bootstrap-darwin-arm64.patch
@@ -1,18 +1,18 @@
-103c103
+131c131
 < int32_t* __errno_location(void);
 ---
 > int32_t* __error(void);
-145c145
+173c173
 <    int64_t d_off;
 ---
 >    uint64_t d_seekoff;
-146a147
+174a175
 >    uint16_t d_namlen;
-148c149
+176c177
 <    char d_name[256];
 ---
 >    char d_name[1024];
-162,167c163,168
+190,195c191,196
 < #define O_CREAT 0100
 < #define O_NOCTTY 0400
 < #define O_TRUNC 01000
@@ -26,34 +26,34 @@
 > #define O_NONBLOCK 04
 > #define O_DIRECTORY 04000000
 > #define O_NOFOLLOW 0400
-169c170
+197c198
 < #define AT_FDCWD -100
 ---
 > #define AT_FDCWD -2
-191c192
+219c220
 < extern FILE* stdout;
 ---
 > extern FILE* __stdoutp;
-193c194
+221c222
 < extern FILE* stderr;
 ---
 > extern FILE* __stderrp;
-268a270,274
+296a298,302
 > struct timespec {
 >    int64_t tv_sec;
 >    int64_t tv_nsec;
 > };
 > 
-270c276,278
+298c304,306
 <    uint64_t st_dev;
 ---
 >    int32_t st_dev;
 >    uint16_t st_mode;
 >    uint16_t st_nlink;
-272,273d279
+300,301d307
 <    uint64_t st_nlink;
 <    uint32_t st_mode;
-276,288c282,293
+304,316c310,321
 <    uint64_t st_rdev;
 <    int64_t st_size;
 <    int64_t st_blksize;
@@ -80,11 +80,11 @@
 >    uint32_t st_gen;
 >    int32_t st_lspare;
 >    int64_t st_qspare[2];
-324c329
+352c357
 < #define NAME_LEN 65
 ---
 > #define NAME_LEN 256
-326,331c331,336
+354,359c359,364
 <    char sysname[65];
 <    char nodename[65];
 <    char release[65];
@@ -98,221 +98,221 @@
 >    char version[256];
 >    char machine[256];
 >    char domainname[256];
-421c426
+449c454
 <       file->errno = *__errno_location();
 ---
 >       file->errno = *__error();
-427c432
+455c460
 <       file->errno = *__errno_location();
 ---
 >       file->errno = *__error();
-494c499
+522c527
 <    if ((err && (*__errno_location() != EEXIST))) return -1;
 ---
 >    if ((err && (*__error() != EEXIST))) return -1;
-499c504
+527c532
 <    if ((fd == -1)) return *__errno_location();
 ---
 >    if ((fd == -1)) return *__error();
-511c516
+539c544
 <    if ((fd == -1)) return *__errno_location();
 ---
 >    if ((fd == -1)) return *__error();
-532c537
+560c565
 <    if (err) errno_ = *__errno_location();
 ---
 >    if (err) errno_ = *__error();
-549c554
+577c582
 <       sprintf(writer->msg, "error opening %s: %s", filename, strerror(*__errno_location()));
 ---
 >       sprintf(writer->msg, "error opening %s: %s", filename, strerror(*__error()));
-554c559
+582c587
 <       sprintf(writer->msg, "error writing %s: %s", filename, strerror(*__errno_location()));
 ---
 >       sprintf(writer->msg, "error writing %s: %s", filename, strerror(*__error()));
-1903,1904c1908,1909
+1931,1932c1936,1937
 <    fprintf(stderr, "[exec] %s\n", msg);
 <    fflush(stderr);
 ---
 >    fprintf(__stderrp, "[exec] %s\n", msg);
 >    fflush(__stderrp);
-1912c1917
-<       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
----
->       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
-1916c1921
-<       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
----
->       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
-1920c1925
-<       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
----
->       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
-1931c1936
-<       fflush(stdout);
----
->       fflush(__stdoutp);
-1935c1940
-<          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
----
->          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
 1940c1945
-<          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
----
->          sprintf(errmsg, "dup(): %s", strerror(*__error()));
-1945c1950
-<          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
----
->          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
-1955,1956c1960,1961
-<       int32_t lasterr = *__errno_location();
-<       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
----
->       int32_t lasterr = *__error();
->       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
-1967c1972
-<          fprintf(stderr, "Error reading pipe\n");
----
->          fprintf(__stderrp, "Error reading pipe\n");
-1977c1982
-<          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
----
->          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
-2036c2041
 <       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
 ---
 >       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
-2040c2045
+1944c1949
 <       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
 ---
 >       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
-2044c2049
+1948c1953
 <       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
 ---
 >       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
-2055c2060
+1959c1964
 <       fflush(stdout);
 ---
 >       fflush(__stdoutp);
-2059c2064
+1963c1968
 <          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
 ---
 >          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
-2064c2069
+1968c1973
 <          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
 ---
 >          sprintf(errmsg, "dup(): %s", strerror(*__error()));
-2069c2074
+1973c1978
 <          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
 ---
 >          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
-2082,2083c2087,2088
+1983,1984c1988,1989
 <       int32_t lasterr = *__errno_location();
 <       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
 ---
 >       int32_t lasterr = *__error();
 >       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
-2094c2099
+1995c2000
 <          fprintf(stderr, "Error reading pipe\n");
 ---
 >          fprintf(__stderrp, "Error reading pipe\n");
-2104c2109
+2005c2010
 <          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
 ---
 >          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
-2280c2285
+2064c2069
+<       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
+2068c2073
+<       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
+2072c2077
+<       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
+2083c2088
+<       fflush(stdout);
+---
+>       fflush(__stdoutp);
+2087c2092
+<          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
+2092c2097
+<          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "dup(): %s", strerror(*__error()));
+2097c2102
+<          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
+2110,2111c2115,2116
+<       int32_t lasterr = *__errno_location();
+<       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
+---
+>       int32_t lasterr = *__error();
+>       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
+2122c2127
+<          fprintf(stderr, "Error reading pipe\n");
+---
+>          fprintf(__stderrp, "Error reading pipe\n");
+2132c2137
+<          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
+---
+>          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
+2308c2313
 <          if ((*__errno_location() != ENOENT)) {
 ---
 >          if ((*__error() != ENOENT)) {
-3212c3217
+3240c3245
 <       fprintf(stderr, "%swarning: %s%s\n", color_Yellow, buf, color_Normal);
 ---
 >       fprintf(__stderrp, "%swarning: %s%s\n", color_Yellow, buf, color_Normal);
-3214c3219
+3242c3247
 <       fprintf(stderr, "warning: %s\n", buf);
 ---
 >       fprintf(__stderrp, "warning: %s\n", buf);
-3227c3232
+3255c3260
 <       fprintf(stderr, "%serror: %s%s\n", color_Red, buf, color_Normal);
 ---
 >       fprintf(__stderrp, "%serror: %s%s\n", color_Red, buf, color_Normal);
-3229c3234
+3257c3262
 <       fprintf(stderr, "error: %s\n", buf);
 ---
 >       fprintf(__stderrp, "error: %s\n", buf);
-3465c3470
+3494c3499
 <          fprintf(stderr, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(sm, loc), color_Red, color_Normal, error_msg);
 ---
 >          fprintf(__stderrp, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(sm, loc), color_Red, color_Normal, error_msg);
-3467c3472
+3496c3501
 <          fprintf(stderr, "%serror%s: %s\n", color_Red, color_Normal, error_msg);
 ---
 >          fprintf(__stderrp, "%serror%s: %s\n", color_Red, color_Normal, error_msg);
-3520c3525
+3549c3554
 <          fprintf(stderr, "%serror%s: too many files open\n", color_Red, color_Normal);
 ---
 >          fprintf(__stderrp, "%serror%s: too many files open\n", color_Red, color_Normal);
-3564c3569
+3593c3598
 <          fprintf(stderr, "%serror%s: too many files open\n", color_Red, color_Normal);
 ---
 >          fprintf(__stderrp, "%serror%s: too many files open\n", color_Red, color_Normal);
-3918c3923
+3947c3952
 <       console_error("error getting system info: %s", strerror(*__errno_location()));
 ---
 >       console_error("error getting system info: %s", strerror(*__error()));
-4881c4886
+4912c4917
 <          fprintf(stderr, "[build-file] warning: environment variable '%s' not set!\n", (raw + 1));
 ---
 >          fprintf(__stderrp, "[build-file] warning: environment variable '%s' not set!\n", (raw + 1));
-4928c4933
+4959c4964
 <             fprintf(stderr, "[build-file] missing options for %s\n", name);
 ---
 >             fprintf(__stderrp, "[build-file] missing options for %s\n", name);
-4945c4950
+4976c4981
 <       fprintf(stderr, "Error: %s\n", yaml_Parser_getMessage(parser));
 ---
 >       fprintf(__stderrp, "Error: %s\n", yaml_Parser_getMessage(parser));
-5569c5574
+5600c5605
 <    fprintf(stderr, "%s\n", string_buffer_Buf_data(out));
 ---
 >    fprintf(__stderrp, "%s\n", string_buffer_Buf_data(out));
-5600c5605
+5631c5636
 <       fputs(string_buffer_Buf_data(out), stderr);
 ---
 >       fputs(string_buffer_Buf_data(out), __stderrp);
-19287c19292
+19335c19340
 <       fprintf(stderr, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), color_Red, color_Normal, msg);
 ---
 >       fprintf(__stderrp, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), color_Red, color_Normal, msg);
-19289c19294
+19337c19342
 <       fprintf(stderr, "%s: error: %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), msg);
 ---
 >       fprintf(__stderrp, "%s: error: %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), msg);
-31435c31440
+31533c31538
 <       fprintf(stderr, "error: missing node %s\n", path);
 ---
 >       fprintf(__stderrp, "error: missing node %s\n", path);
-31459c31464
+31557c31562
 <             fprintf(stderr, "error in manifest: invalid library kind '%s'\n", kind);
 ---
 >             fprintf(__stderrp, "error in manifest: invalid library kind '%s'\n", kind);
-31466c31471
+31564c31569
 <       fprintf(stderr, "error in manifest: a library must be dynamic and/or static\n");
 ---
 >       fprintf(__stderrp, "error in manifest: a library must be dynamic and/or static\n");
-31530c31535
+31628c31633
 < static const char* plugin_mgr_lib_ext = ".so";
 ---
 > static const char* plugin_mgr_lib_ext = ".dylib";
-31613c31618
+31711c31716
 <          console_warn("cannot read '%s': %s", path, strerror(*__errno_location()));
 ---
 >          console_warn("cannot read '%s': %s", path, strerror(*__error()));
-36711c36716
+36804c36809
 <       console_error("cannot open library dir '%s': %s", dirname, strerror(*__errno_location()));
 ---
 >       console_error("cannot open library dir '%s': %s", dirname, strerror(*__error()));
-37086c37091
+37171c37176
 <          console_error("cannot chdir to %s: %s", opts.other_dir, strerror(*__errno_location()));
 ---
 >          console_error("cannot chdir to %s: %s", opts.other_dir, strerror(*__error()));

--- a/bootstrap/globals.c
+++ b/bootstrap/globals.c
@@ -1,0 +1,630 @@
+#include <errno.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/dir.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+typedef unsigned int u32;
+
+int pf(const char *fmt, ...) {
+    int res;
+    va_list ap;
+    va_start(ap, fmt);
+    res = va_arg(ap, int);
+    va_end(ap);
+    return res;
+}
+
+void nothing(void *p) {
+}
+
+int main() {
+    FILE *stdin_ = stdin;
+    FILE *stdout_ = stdout;
+    FILE *stderr_ = stderr;
+    jmp_buf buf;
+    setjmp(buf);
+
+    nothing(stdin_);
+    nothing(stdout_);
+    nothing(stderr_);
+
+    printf("// libc/c_errno.c2i\n\n");
+#ifdef EPERM
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EPERM", EPERM, "Operation not permitted");
+#endif
+#ifdef ENOENT
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOENT", ENOENT, "No such file or directory");
+#endif
+#ifdef ESRCH
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ESRCH", ESRCH, "No such process");
+#endif
+#ifdef EINTR
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EINTR", EINTR, "Interrupted system call");
+#endif
+#ifdef EIO
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EIO", EIO, "I/O error");
+#endif
+#ifdef ENXIO
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENXIO", ENXIO, "No such device or address");
+#endif
+#ifdef E2BIG
+    printf("const i32 %-13s= %3d;  /* %s */\n", "E2BIG", E2BIG, "Argument list too long");
+#endif
+#ifdef ENOEXEC
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOEXEC", ENOEXEC, "Exec format error");
+#endif
+#ifdef EBADF
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EBADF", EBADF, "Bad file number");
+#endif
+#ifdef ECHILD
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ECHILD", ECHILD, "No child processes");
+#endif
+#ifdef EAGAIN
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EAGAIN", EAGAIN, "Try again");
+#endif
+#ifdef ENOMEM
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOMEM", ENOMEM, "Out of memory");
+#endif
+#ifdef EACCES
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EACCES", EACCES, "Permission denied");
+#endif
+#ifdef EFAULT
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EFAULT", EFAULT, "Bad address");
+#endif
+#ifdef ENOTBLK
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOTBLK", ENOTBLK, "Block device required");
+#endif
+#ifdef EBUSY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EBUSY", EBUSY, "Device or resource busy");
+#endif
+#ifdef EEXIST
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EEXIST", EEXIST, "File exists");
+#endif
+#ifdef EXDEV
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EXDEV", EXDEV, "Cross-device link");
+#endif
+#ifdef ENODEV
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENODEV", ENODEV, "No such device");
+#endif
+#ifdef ENOTDIR
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOTDIR", ENOTDIR, "Not a directory");
+#endif
+#ifdef EISDIR
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EISDIR", EISDIR, "Is a directory");
+#endif
+#ifdef EINVAL
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EINVAL", EINVAL, "Invalid argument");
+#endif
+#ifdef ENFILE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENFILE", ENFILE, "File table overflow");
+#endif
+#ifdef EMFILE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EMFILE", EMFILE, "Too many open files");
+#endif
+#ifdef ENOTTY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOTTY", ENOTTY, "Not a typewriter");
+#endif
+#ifdef ETXTBSY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ETXTBSY", ETXTBSY, "Text file busy");
+#endif
+#ifdef EFBIG
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EFBIG", EFBIG, "File too large");
+#endif
+#ifdef ENOSPC
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOSPC", ENOSPC, "No space left on device");
+#endif
+#ifdef ESPIPE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ESPIPE", ESPIPE, "Illegal seek");
+#endif
+#ifdef EROFS
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EROFS", EROFS, "Read-only file system");
+#endif
+#ifdef EMLINK
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EMLINK", EMLINK, "Too many links");
+#endif
+#ifdef EPIPE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EPIPE", EPIPE, "Broken pipe");
+#endif
+#ifdef EDOM
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EDOM", EDOM, "Math argument out of domain of func");
+#endif
+#ifdef ERANGE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ERANGE", ERANGE, "Math result not representable");
+#endif
+#ifdef EALREADY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EALREADY", EALREADY, "Operation already in progress");
+#endif
+#ifdef EINPROGRESS
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EINPROGRESS", EINPROGRESS, "Operation now in progress");
+#endif
+#ifdef ESTALE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ESTALE", ESTALE, "Stale file handle");
+#endif
+
+    printf("\n");
+    printf("// libc/fcntl.c2i\n\n");
+#ifdef O_RDONLY
+    printf("const u32 O_RDONLY    =%#9o;\n",  O_RDONLY);
+#endif
+#ifdef O_WRONLY
+    printf("const u32 O_WRONLY    =%#9o;\n",  O_WRONLY);
+#endif
+#ifdef O_RDWR
+    printf("const u32 O_RDWR      =%#9o;\n",  O_RDWR);
+#endif
+#ifdef O_CREAT
+    printf("const u32 O_CREAT     =%#9o;\n",  O_CREAT);
+#endif
+#ifdef O_EXCL
+    printf("const u32 O_EXCL      =%#9o;\n",  O_EXCL);
+#endif
+#ifdef O_NOCTTY
+    printf("const u32 O_NOCTTY    =%#9o;\n",  O_NOCTTY);
+#endif
+#ifdef O_TRUNC
+    printf("const u32 O_TRUNC     =%#9o;\n",  O_TRUNC);
+#endif
+#ifdef O_APPEND
+    printf("const u32 O_APPEND    =%#9o;\n",  O_APPEND);
+#endif
+#ifdef O_NONBLOCK
+    printf("const u32 O_NONBLOCK  =%#9o;\n",  O_NONBLOCK);
+#endif
+#ifdef O_DIRECT
+    printf("const u32 O_DIRECT    =%#9o;\n",  O_DIRECT);
+#endif
+#ifdef O_LARGEFILE
+    printf("const u32 O_LARGEFILE =%#9o;\n",  O_LARGEFILE);
+#endif
+#ifdef O_DIRECTORY
+    printf("const u32 O_DIRECTORY =%#9o;\n",  O_DIRECTORY);
+#endif
+#ifdef O_NOFOLLOW
+    printf("const u32 O_NOFOLLOW  =%#9o;\n",  O_NOFOLLOW);
+#endif
+#ifdef O_SYNC
+    printf("const u32 O_SYNC      =%#9o;\n",  O_SYNC);
+#endif
+#ifdef O_NOATIME
+    printf("const u32 O_NOATIME   =%#9o;\n",  O_NOATIME);
+#endif
+#ifdef O_CLOEXEC
+    printf("const u32 O_CLOEXEC   =%#9o;\n",  O_CLOEXEC);
+#endif
+#ifdef O_PATH
+    printf("const u32 O_PATH      =%#9o;\n",  O_PATH);
+#endif
+#ifdef O_TMPFILE
+    printf("const u32 O_TMPFILE   =%#9o;\n",  O_TMPFILE);
+#endif
+    printf("\n");
+#ifdef F_DUPFD
+    printf("const u32 F_DUPFD = %d;\n",  F_DUPFD);
+#endif
+#ifdef F_GETFD
+    printf("const u32 F_GETFD = %d;\n",  F_GETFD);
+#endif
+#ifdef F_SETFD
+    printf("const u32 F_SETFD = %d;\n",  F_SETFD);
+#endif
+#ifdef F_GETFL
+    printf("const u32 F_GETFL = %d;\n",  F_GETFL);
+#endif
+#ifdef F_SETFL
+    printf("const u32 F_SETFL = %d;\n",  F_SETFL);
+#endif
+    printf("\n");
+#ifdef AT_FDCWD
+    printf("const i32 AT_FDCWD = %d;\n",  AT_FDCWD);
+#endif
+#ifdef FD_CLOEXEC
+    printf("const u32 FD_CLOEXEC = %u;\n",  FD_CLOEXEC);
+#endif
+    printf("\n");
+    printf("// libc/dirent.c2i\n\n");
+#ifdef DT_UNKNOWN
+    printf("const c_uint DT_UNKNOWN = %d;\n", DT_UNKNOWN);
+#endif
+#ifdef DT_FIFO
+    printf("const c_uint DT_FIFO = %d;\n", DT_FIFO);
+#endif
+#ifdef DT_CHR
+    printf("const c_uint DT_CHR = %d;\n", DT_CHR);
+#endif
+#ifdef DT_DIR
+    printf("const c_uint DT_DIR = %d;\n", DT_DIR);
+#endif
+#ifdef DT_BLK
+    printf("const c_uint DT_BLK = %d;\n", DT_BLK);
+#endif
+#ifdef DT_REG
+    printf("const c_uint DT_REG = %d;\n", DT_REG);
+#endif
+#ifdef DT_LNK
+    printf("const c_uint DT_LNK = %d;\n", DT_LNK);
+#endif
+#ifdef DT_SOCK
+    printf("const c_uint DT_SOCK = %d;\n", DT_SOCK);
+#endif
+#ifdef DT_WHT
+    printf("const c_uint DT_WHT = %d;\n", DT_WHT);
+#endif
+    printf("\n");
+
+    printf("// libc/unistd.c2i\n\n");
+#ifdef R_OK
+    printf("const u8 R_OK = %d;\n", R_OK);
+#endif
+#ifdef W_OK
+    printf("const u8 W_OK = %d;\n", W_OK);
+#endif
+#ifdef X_OK
+    printf("const u8 X_OK = %d;\n", X_OK);
+#endif
+#ifdef F_OK
+    printf("const u8 F_OK = %d;\n", F_OK);
+#endif
+    printf("\n");
+
+#ifdef _SC_ARG_MAX
+    printf("u32 _SC_ARG_MAX = %d;\n", _SC_ARG_MAX);
+#endif
+#ifdef _SC_CHILD_MAX
+    printf("u32 _SC_CHILD_MAX = %d;\n", _SC_CHILD_MAX);
+#endif
+#ifdef _SC_CLK_TCK
+    printf("u32 _SC_CLK_TCK = %d;\n", _SC_CLK_TCK);
+#endif
+#ifdef _SC_NGROUPS_MAX
+    printf("u32 _SC_NGROUPS_MAX = %d;\n", _SC_NGROUPS_MAX);
+#endif
+#ifdef _SC_OPEN_MAX
+    printf("u32 _SC_OPEN_MAX = %d;\n", _SC_OPEN_MAX);
+#endif
+#ifdef _SC_JOB_CONTROL
+    printf("u32 _SC_JOB_CONTROL = %d;\n", _SC_JOB_CONTROL);
+#endif
+#ifdef _SC_SAVED_IDS
+    printf("u32 _SC_SAVED_IDS = %d;\n", _SC_SAVED_IDS);
+#endif
+#ifdef _SC_VERSION
+    printf("u32 _SC_VERSION = %d;\n", _SC_VERSION);
+#endif
+#ifdef _SC_PAGESIZE
+    printf("u32 _SC_PAGESIZE = %d;\n", _SC_PAGESIZE);
+#endif
+#ifdef _SC_PAGE_SIZE
+    printf("u32 _SC_PAGE_SIZE = %d;\n", _SC_PAGE_SIZE);
+#endif
+#ifdef _SC_NPROCESSORS_CONF
+    printf("u32 _SC_NPROCESSORS_CONF = %d;\n", _SC_NPROCESSORS_CONF);
+#endif
+#ifdef _SC_NPROCESSORS_ONLN
+    printf("u32 _SC_NPROCESSORS_ONLN = %d;\n", _SC_NPROCESSORS_ONLN);
+#endif
+#ifdef _SC_PHYS_PAGES
+    printf("u32 _SC_PHYS_PAGES = %d;\n", _SC_PHYS_PAGES);
+#endif
+#ifdef _SC_AVPHYS_PAGES
+    printf("u32 _SC_AVPHYS_PAGES = %d;\n", _SC_AVPHYS_PAGES);
+#endif
+#ifdef _SC_MQ_OPEN_MAX
+    printf("u32 _SC_MQ_OPEN_MAX = %d;\n", _SC_MQ_OPEN_MAX);
+#endif
+#ifdef _SC_MQ_PRIO_MAX
+    printf("u32 _SC_MQ_PRIO_MAX = %d;\n", _SC_MQ_PRIO_MAX);
+#endif
+#ifdef _SC_RTSIG_MAX
+    printf("u32 _SC_RTSIG_MAX = %d;\n", _SC_RTSIG_MAX);
+#endif
+#ifdef _SC_SEM_NSEMS_MAX
+    printf("u32 _SC_SEM_NSEMS_MAX = %d;\n", _SC_SEM_NSEMS_MAX);
+#endif
+#ifdef _SC_SEM_VALUE_MAX
+    printf("u32 _SC_SEM_VALUE_MAX = %d;\n", _SC_SEM_VALUE_MAX);
+#endif
+#ifdef _SC_SIGQUEUE_MAX
+    printf("u32 _SC_SIGQUEUE_MAX = %d;\n", _SC_SIGQUEUE_MAX);
+#endif
+#ifdef _SC_TIMER_MAX
+    printf("u32 _SC_TIMER_MAX = %d;\n", _SC_TIMER_MAX);
+#endif
+#ifdef _SC_TZNAME_MAX
+    printf("u32 _SC_TZNAME_MAX = %d;\n", _SC_TZNAME_MAX);
+#endif
+#ifdef _SC_ASYNCHRONOUS_IO
+    printf("u32 _SC_ASYNCHRONOUS_IO = %d;\n", _SC_ASYNCHRONOUS_IO);
+#endif
+#ifdef _SC_FSYNC
+    printf("u32 _SC_FSYNC = %d;\n", _SC_FSYNC);
+#endif
+#ifdef _SC_MAPPED_FILES
+    printf("u32 _SC_MAPPED_FILES = %d;\n", _SC_MAPPED_FILES);
+#endif
+#ifdef _SC_MEMLOCK
+    printf("u32 _SC_MEMLOCK = %d;\n", _SC_MEMLOCK);
+#endif
+#ifdef _SC_MEMLOCK_RANGE
+    printf("u32 _SC_MEMLOCK_RANGE = %d;\n", _SC_MEMLOCK_RANGE);
+#endif
+#ifdef _SC_MEMORY_PROTECTION
+    printf("u32 _SC_MEMORY_PROTECTION = %d;\n", _SC_MEMORY_PROTECTION);
+#endif
+#ifdef _SC_MESSAGE_PASSING
+    printf("u32 _SC_MESSAGE_PASSING = %d;\n", _SC_MESSAGE_PASSING);
+#endif
+#ifdef _SC_PRIORITIZED_IO
+    printf("u32 _SC_PRIORITIZED_IO = %d;\n", _SC_PRIORITIZED_IO);
+#endif
+#ifdef _SC_REALTIME_SIGNALS
+    printf("u32 _SC_REALTIME_SIGNALS = %d;\n", _SC_REALTIME_SIGNALS);
+#endif
+#ifdef _SC_SEMAPHORES
+    printf("u32 _SC_SEMAPHORES = %d;\n", _SC_SEMAPHORES);
+#endif
+#ifdef _SC_SHARED_MEMORY_OBJECTS
+    printf("u32 _SC_SHARED_MEMORY_OBJECTS = %d;\n", _SC_SHARED_MEMORY_OBJECTS);
+#endif
+#ifdef _SC_SYNCHRONIZED_IO
+    printf("u32 _SC_SYNCHRONIZED_IO = %d;\n", _SC_SYNCHRONIZED_IO);
+#endif
+#ifdef _SC_TIMERS
+    printf("u32 _SC_TIMERS = %d;\n", _SC_TIMERS);
+#endif
+#ifdef _SC_AIO_LISTIO_MAX
+    printf("u32 _SC_AIO_LISTIO_MAX = %d;\n", _SC_AIO_LISTIO_MAX);
+#endif
+#ifdef _SC_AIO_MAX
+    printf("u32 _SC_AIO_MAX = %d;\n", _SC_AIO_MAX);
+#endif
+#ifdef _SC_AIO_PRIO_DELTA_MAX
+    printf("u32 _SC_AIO_PRIO_DELTA_MAX = %d;\n", _SC_AIO_PRIO_DELTA_MAX);
+#endif
+#ifdef _SC_DELAYTIMER_MAX
+    printf("u32 _SC_DELAYTIMER_MAX = %d;\n", _SC_DELAYTIMER_MAX);
+#endif
+#ifdef _SC_THREAD_KEYS_MAX
+    printf("u32 _SC_THREAD_KEYS_MAX = %d;\n", _SC_THREAD_KEYS_MAX);
+#endif
+#ifdef _SC_THREAD_STACK_MIN
+    printf("u32 _SC_THREAD_STACK_MIN = %d;\n", _SC_THREAD_STACK_MIN);
+#endif
+#ifdef _SC_THREAD_THREADS_MAX
+    printf("u32 _SC_THREAD_THREADS_MAX = %d;\n", _SC_THREAD_THREADS_MAX);
+#endif
+#ifdef _SC_TTY_NAME_MAX
+    printf("u32 _SC_TTY_NAME_MAX = %d;\n", _SC_TTY_NAME_MAX);
+#endif
+#ifdef _SC_THREADS
+    printf("u32 _SC_THREADS = %d;\n", _SC_THREADS);
+#endif
+#ifdef _SC_THREAD_ATTR_STACKADDR
+    printf("u32 _SC_THREAD_ATTR_STACKADDR = %d;\n", _SC_THREAD_ATTR_STACKADDR);
+#endif
+#ifdef _SC_THREAD_ATTR_STACKSIZE
+    printf("u32 _SC_THREAD_ATTR_STACKSIZE = %d;\n", _SC_THREAD_ATTR_STACKSIZE);
+#endif
+#ifdef _SC_THREAD_PRIORITY_SCHEDULING
+    printf("u32 _SC_THREAD_PRIORITY_SCHEDULING = %d;\n", _SC_THREAD_PRIORITY_SCHEDULING);
+#endif
+#ifdef _SC_THREAD_PRIO_INHERIT
+    printf("u32 _SC_THREAD_PRIO_INHERIT = %d;\n", _SC_THREAD_PRIO_INHERIT);
+#endif
+#ifdef _SC_THREAD_PRIO_PROTECT
+    printf("u32 _SC_THREAD_PRIO_PROTECT = %d;\n", _SC_THREAD_PRIO_PROTECT);
+#endif
+#ifdef _SC_THREAD_PRIO_CEILING
+    printf("u32 _SC_THREAD_PRIO_CEILING = %d;\n", _SC_THREAD_PRIO_CEILING);
+#endif
+#ifdef _SC_THREAD_PROCESS_SHARED
+    printf("u32 _SC_THREAD_PROCESS_SHARED = %d;\n", _SC_THREAD_PROCESS_SHARED);
+#endif
+#ifdef _SC_THREAD_SAFE_FUNCTIONS
+    printf("u32 _SC_THREAD_SAFE_FUNCTIONS = %d;\n", _SC_THREAD_SAFE_FUNCTIONS);
+#endif
+#ifdef _SC_GETGR_R_SIZE_MAX
+    printf("u32 _SC_GETGR_R_SIZE_MAX = %d;\n", _SC_GETGR_R_SIZE_MAX);
+#endif
+#ifdef _SC_GETPW_R_SIZE_MAX
+    printf("u32 _SC_GETPW_R_SIZE_MAX = %d;\n", _SC_GETPW_R_SIZE_MAX);
+#endif
+#ifdef _SC_LOGIN_NAME_MAX
+    printf("u32 _SC_LOGIN_NAME_MAX = %d;\n", _SC_LOGIN_NAME_MAX);
+#endif
+#ifdef SC_THREAD_DESTRUCTOR_ITERATIONS
+    printf("u32 SC_THREAD_DESTRUCTOR_ITERATIONS = %d;\n", SC_THREAD_DESTRUCTOR_ITERATIONS);
+#endif
+#ifdef _SC_ADVISORY_INFO
+    printf("u32 _SC_ADVISORY_INFO = %d;\n", _SC_ADVISORY_INFO);
+#endif
+#ifdef _SC_ATEXIT_MAX
+    printf("u32 _SC_ATEXIT_MAX = %d;\n", _SC_ATEXIT_MAX);
+#endif
+#ifdef _SC_BARRIERS
+    printf("u32 _SC_BARRIERS = %d;\n", _SC_BARRIERS);
+#endif
+#ifdef _SC_BC_BASE_MAX
+    printf("u32 _SC_BC_BASE_MAX = %d;\n", _SC_BC_BASE_MAX);
+#endif
+#ifdef _SC_BC_DIM_MAX
+    printf("u32 _SC_BC_DIM_MAX = %d;\n", _SC_BC_DIM_MAX);
+#endif
+#ifdef _SC_BC_SCALE_MAX
+    printf("u32 _SC_BC_SCALE_MAX = %d;\n", _SC_BC_SCALE_MAX);
+#endif
+#ifdef _SC_BC_STRING_MAX
+    printf("u32 _SC_BC_STRING_MAX = %d;\n", _SC_BC_STRING_MAX);
+#endif
+#ifdef _SC_CLOCK_SELECTION
+    printf("u32 _SC_CLOCK_SELECTION = %d;\n", _SC_CLOCK_SELECTION);
+#endif
+#ifdef _SC_COLL_WEIGHTS_MAX
+    printf("u32 _SC_COLL_WEIGHTS_MAX = %d;\n", _SC_COLL_WEIGHTS_MAX);
+#endif
+#ifdef _SC_CPUTIME
+    printf("u32 _SC_CPUTIME = %d;\n", _SC_CPUTIME);
+#endif
+#ifdef _SC_EXPR_NEST_MAX
+    printf("u32 _SC_EXPR_NEST_MAX = %d;\n", _SC_EXPR_NEST_MAX);
+#endif
+#ifdef _SC_HOST_NAME_MAX
+    printf("u32 _SC_HOST_NAME_MAX = %d;\n", _SC_HOST_NAME_MAX);
+#endif
+#ifdef _SC_IOV_MAX
+    printf("u32 _SC_IOV_MAX = %d;\n", _SC_IOV_MAX);
+#endif
+#ifdef _SC_IPV6
+    printf("u32 _SC_IPV6 = %d;\n", _SC_IPV6);
+#endif
+#ifdef _SC_LINE_MAX
+    printf("u32 _SC_LINE_MAX = %d;\n", _SC_LINE_MAX);
+#endif
+#ifdef _SC_MONOTONIC_CLOCK
+    printf("u32 _SC_MONOTONIC_CLOCK = %d;\n", _SC_MONOTONIC_CLOCK);
+#endif
+#ifdef _SC_RAW_SOCKETS
+    printf("u32 _SC_RAW_SOCKETS = %d;\n", _SC_RAW_SOCKETS);
+#endif
+#ifdef _SC_READER_WRITER_LOCKS
+    printf("u32 _SC_READER_WRITER_LOCKS = %d;\n", _SC_READER_WRITER_LOCKS);
+#endif
+#ifdef _SC_REGEXP
+    printf("u32 _SC_REGEXP = %d;\n", _SC_REGEXP);
+#endif
+#ifdef _SC_RE_DUP_MAX
+    printf("u32 _SC_RE_DUP_MAX = %d;\n", _SC_RE_DUP_MAX);
+#endif
+#ifdef _SC_SHELL
+    printf("u32 _SC_SHELL = %d;\n", _SC_SHELL);
+#endif
+#ifdef _SC_SPAWN
+    printf("u32 _SC_SPAWN = %d;\n", _SC_SPAWN);
+#endif
+#ifdef _SC_SPIN_LOCKS
+    printf("u32 _SC_SPIN_LOCKS = %d;\n", _SC_SPIN_LOCKS);
+#endif
+#ifdef _SC_SPORADIC_SERVER
+    printf("u32 _SC_SPORADIC_SERVER = %d;\n", _SC_SPORADIC_SERVER);
+#endif
+#ifdef _SC_SS_REPL_MAX
+    printf("u32 _SC_SS_REPL_MAX = %d;\n", _SC_SS_REPL_MAX);
+#endif
+#ifdef _SC_SYMLOOP_MAX
+    printf("u32 _SC_SYMLOOP_MAX = %d;\n", _SC_SYMLOOP_MAX);
+#endif
+#ifdef _SC_THREAD_CPUTIME
+    printf("u32 _SC_THREAD_CPUTIME = %d;\n", _SC_THREAD_CPUTIME);
+#endif
+#ifdef _SC_THREAD_SPORADIC_SERVER
+    printf("u32 _SC_THREAD_SPORADIC_SERVER = %d;\n", _SC_THREAD_SPORADIC_SERVER);
+#endif
+#ifdef _SC_TIMEOUTS
+    printf("u32 _SC_TIMEOUTS = %d;\n", _SC_TIMEOUTS);
+#endif
+#ifdef _SC_TRACE
+    printf("u32 _SC_TRACE = %d;\n", _SC_TRACE);
+#endif
+#ifdef _SC_TRACE_EVENT_FILTER
+    printf("u32 _SC_TRACE_EVENT_FILTER = %d;\n", _SC_TRACE_EVENT_FILTER);
+#endif
+#ifdef _SC_TRACE_EVENT_NAME_MAX
+    printf("u32 _SC_TRACE_EVENT_NAME_MAX = %d;\n", _SC_TRACE_EVENT_NAME_MAX);
+#endif
+#ifdef _SC_TRACE_INHERIT
+    printf("u32 _SC_TRACE_INHERIT = %d;\n", _SC_TRACE_INHERIT);
+#endif
+#ifdef _SC_TRACE_LOG
+    printf("u32 _SC_TRACE_LOG = %d;\n", _SC_TRACE_LOG);
+#endif
+#ifdef _SC_TRACE_NAME_MAX
+    printf("u32 _SC_TRACE_NAME_MAX = %d;\n", _SC_TRACE_NAME_MAX);
+#endif
+#ifdef _SC_TRACE_SYS_MAX
+    printf("u32 _SC_TRACE_SYS_MAX = %d;\n", _SC_TRACE_SYS_MAX);
+#endif
+#ifdef _SC_TRACE_USER_EVENT_MAX
+    printf("u32 _SC_TRACE_USER_EVENT_MAX = %d;\n", _SC_TRACE_USER_EVENT_MAX);
+#endif
+#ifdef _SC_TYPED_MEMORY_OBJECTS
+    printf("u32 _SC_TYPED_MEMORY_OBJECTS = %d;\n", _SC_TYPED_MEMORY_OBJECTS);
+#endif
+#ifdef _SC_V7_ILP32_OFF32
+    printf("u32 _SC_V7_ILP32_OFF32 = %d;\n", _SC_V7_ILP32_OFF32);
+#endif
+    printf("\n");
+
+    printf("// libc/sys_mman.c2i\n\n");
+#ifdef PROT_NONE
+    printf("const u32 PROT_NONE = %d;\n", PROT_NONE);
+#endif
+#ifdef PROT_READ
+    printf("const u32 PROT_READ = %d;\n", PROT_READ);
+#endif
+#ifdef PROT_WRITE
+    printf("const u32 PROT_WRITE = %d;\n", PROT_WRITE);
+#endif
+#ifdef PROT_EXEC
+    printf("const u32 PROT_EXEC = %d;\n", PROT_EXEC);
+#endif
+    printf("\n");
+#ifdef MAP_SHARED
+    printf("const u32 MAP_SHARED = 0x%02x;\n", MAP_SHARED);
+#endif
+#ifdef MAP_PRIVATE
+    printf("const u32 MAP_PRIVATE = 0x%02x;\n", MAP_PRIVATE);
+#endif
+#ifdef MAP_FIXED
+    printf("const u32 MAP_FIXED = 0x%02x;\n", MAP_FIXED);
+#endif
+#ifdef MAP_ANONYMOUS
+    printf("const u32 MAP_ANONYMOUS = 0x%02x;\n", MAP_ANONYMOUS);
+#endif
+#ifdef MAP_POPULATE
+    printf("const u32 MAP_POPULATE = 0x%02x;\n", MAP_POPULATE);
+#endif
+#ifdef MAP_FAILED
+    printf("const usize MAP_FAILED = %lld;\n", (long long)MAP_FAILED);
+#endif
+    printf("\n");
+
+    printf("// libc/sys_ioctl.c2i\n\n");
+#ifdef TCGETS
+    printf("const c_uint TCGETS = %d;\n", TCGETS);
+#endif
+#ifdef TCSETS
+    printf("const c_uint TCSETS = %d;\n", TCSETS);
+#endif
+#ifdef TCSETSW
+    printf("const c_uint TCSETSW = %d;\n", TCSETSW);
+#endif
+#ifdef TCSETSF
+    printf("const c_uint TCSETSF = %d;\n", TCSETSF);
+#endif
+#ifdef TCGETA
+    printf("const c_uint TCGETA = %d;\n", TCGETA);
+#endif
+#ifdef TCSETA
+    printf("const c_uint TCSETA = %d;\n", TCSETA);
+#endif
+    printf("\n");
+
+    printf("// pthread/pthread.c2i\n\n");
+    printf("const u32 SIZEOF_ATTR_T = %zu;\n", sizeof(pthread_attr_t));
+    printf("const u32 SIZEOF_MUTEX_T = %zu;\n", sizeof(pthread_mutex_t));
+    printf("const u32 SIZEOF_MUTEXATTR_T = %zu;\n", sizeof(pthread_mutexattr_t));
+    printf("const u32 SIZEOF_COND_T = %zu;\n", sizeof(pthread_cond_t));
+    printf("const u32 SIZEOF_CONDATTR_T = %zu;\n", sizeof(pthread_condattr_t));
+    printf("\n");
+
+    return errno;
+}

--- a/common/target_info.c2
+++ b/common/target_info.c2
@@ -78,7 +78,9 @@ public type Info struct {
     u32 intWidth;
 
     char[80] triple;
-    char[40] define;
+    char[32] system_define;
+    char[32] arch_define;
+    char[32] target_define;
 }
 
 public fn void Info.getNative(Info* info) {
@@ -115,6 +117,18 @@ public fn void Info.getNative(Info* info) {
     }
 
     info.init();
+}
+
+fn void make_define(char *s, const char *s1, const char *s2, const char *s3) {
+    if (s3 == nil) {
+        stdio.snprintf(s, 32, "%s_%s", s1, s2);
+    } else {
+        stdio.snprintf(s, 32, "%s_%s_%s", s1, s2, s3);
+    }
+    for (usize i = 0; s[i]; i++) {
+        u8 c = cast<u8>(s[i]);
+        s[i] = (c == '-') ? '_' : cast<char>(ctype.toupper(c));
+    }
 }
 
 fn void Info.init(Info* info) {

--- a/common/target_info.c2
+++ b/common/target_info.c2
@@ -17,6 +17,7 @@ module target_info;
 
 import console;
 
+import ctype;
 import c_errno local;
 import stdio;
 import stdlib local;
@@ -31,7 +32,7 @@ public type Abi enum u8 { Unknown, GNU, GNU_EABI, MACHO, WIN32, Rv32G }
 const char*[] system_names = { "unknown", "linux", "darwin", "cygwin" }
 static_assert(elemsof(System), elemsof(system_names));
 
-const char*[] arch_names = { "unknown", "i686", "arm", "x86_64", "arm_64", "riscv32" }
+const char*[] arch_names = { "unknown", "i686", "arm", "x86_64", "arm64", "riscv32" }
 static_assert(elemsof(Arch), elemsof(arch_names));
 
 const char*[] vendor_names = { "unknown", "apple" }
@@ -77,6 +78,7 @@ public type Info struct {
     u32 intWidth;
 
     char[80] triple;
+    char[40] define;
 }
 
 public fn void Info.getNative(Info* info) {
@@ -138,6 +140,9 @@ fn void Info.init(Info* info) {
         vendor_names[info.vendor],
         system_names[info.sys],
         abi_names[info.abi]);
+    make_define(info.system_define, "SYSTEM", system_names[info.sys], nil);
+    make_define(info.arch_define, "ARCH", arch_names[info.arch], nil);
+    make_define(info.target_define, "TARGET", system_names[info.sys], arch_names[info.arch]);
 }
 
 public fn bool Info.fromString(Info* info, const char* triple) {

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -270,7 +270,8 @@ fn void Compiler.build(Compiler* c,
         c.targetInfo.getNative();
     }
     console.debug("triple: %s", c.targetInfo.str());
-
+    // Add target define for C library implementation selection
+    target.addFeature(c.auxPool.addStr(c.targetInfo.define, true));
     ast.init(c.context, c.astPool, c.targetInfo.intWidth / 8, color.useColor());
 
     c.analyser = module_analyser.create(c.diags,

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -74,6 +74,7 @@ public type Options struct {
     bool show_libs;
     bool print_qbe;
     u32 libdir; // from environment varible C2_LIBDIR, into auxPool
+    const char *target_triple;
 }
 
 public fn void build(string_pool.Pool* auxPool,
@@ -249,16 +250,14 @@ fn void Compiler.build(Compiler* c,
     // add output dir as first libdir, unless --showlibs
     if (!opts.show_libs) c.libdirs.add(c.auxPool.addStr(output_base, true));
 
+    const char* target_str = opts.target_triple;
     if (c.build_info) {
         const string_list.List* dirs = c.build_info.getLibDirs();
         for (u32 i=0; i<dirs.length(); i++) {
             c.libdirs.add(dirs.get_idx(i));
         }
-        const char* target_str = c.build_info.getTarget();
-        if (target_str) {
-            c.targetInfo.fromString(target_str);
-        } else {
-            c.targetInfo.getNative();
+        if (target_str == nil) {
+            target_str = c.build_info.getTarget();
         }
     } else {
         if (c.is_image) {
@@ -267,11 +266,17 @@ fn void Compiler.build(Compiler* c,
             stdlib.exit(-1);
         }
         if (c.opts.libdir) c.libdirs.add(c.opts.libdir);
+    }
+    if (target_str) {
+        c.targetInfo.fromString(target_str);
+    } else {
         c.targetInfo.getNative();
     }
     console.debug("triple: %s", c.targetInfo.str());
-    // Add target define for C library implementation selection
-    target.addFeature(c.auxPool.addStr(c.targetInfo.define, true));
+    // Add target, system and arch defines for C library implementation selection
+    target.addFeature(c.auxPool.addStr(c.targetInfo.system_define, true));
+    target.addFeature(c.auxPool.addStr(c.targetInfo.arch_define, true));
+    target.addFeature(c.auxPool.addStr(c.targetInfo.target_define, true));
     ast.init(c.context, c.astPool, c.targetInfo.intWidth / 8, color.useColor());
 
     c.analyser = module_analyser.create(c.diags,

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -170,6 +170,7 @@ fn void usage(const char* me) {
     console.log("\t--showlibs        print available libraries");
     console.log("\t--showplugins     print available plugins");
     console.log("\t--targets         show available targets in recipe");
+    console.log("\t--target triple   cross compile for specific target");
     console.log("\t--test            test mode (dont check for main() function)");
     console.log("\t--version         print version");
     exit(EXIT_FAILURE);
@@ -198,6 +199,10 @@ fn i32 parse_long_opt(i32 i, i32 argc, char** argv, compiler.Options* opts, Opti
         opts.show_libs = true;
     case "showplugins":
         other.show_plugins = true;
+    case "target":
+        if (i==argc-1) usage(argv[0]);
+        i++;
+        opts.target_triple = argv[i];
     case "targets":
         other.show_targets = true;
     case "test":
@@ -235,7 +240,7 @@ fn void parse_opts(i32 argc, char** argv, compiler.Options* opts, Options* other
                     opts.print_external_symbols = true;
                     break;
                 case 'T':
-                    opts. print_ast_stats = true;
+                    opts.print_ast_stats = true;
                     break;
                 case 'a':
                     opts.print_ast = true;

--- a/compiler/plugin_mgr.c2
+++ b/compiler/plugin_mgr.c2
@@ -29,7 +29,7 @@ import stdio;
 import stdlib;
 import string local;
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const char *lib_ext = ".dylib";
 #else
 const char *lib_ext = ".so";

--- a/compiler/plugin_mgr.c2
+++ b/compiler/plugin_mgr.c2
@@ -29,6 +29,12 @@ import stdio;
 import stdlib;
 import string local;
 
+#if DARWIN_ARM64
+const char *lib_ext = ".dylib";
+#else
+const char *lib_ext = ".so";
+#endif
+
 type Plugin struct {
     u32 name; // in auxPool
     bool is_global;
@@ -99,7 +105,7 @@ fn bool is_plugin(const Dirent* entry) {
     if (filename[0] == '.') return false;
     usize len = strlen(filename);
     if (len < 5) return false;
-    if (strcmp(&filename[len-3], ".so") != 0) return false;
+    if (strcmp(&filename[len-3], lib_ext) != 0) return false;
 
     return true;
 }
@@ -140,8 +146,7 @@ fn bool Mgr.loadPlugin(Mgr* m, u32 name, u32 options, bool is_global) {
     const char* name_str = m.auxPool.idx2str(name);
 
     char[128] filename;
-    stdio.sprintf(filename, "lib%s.so", name_str);
-
+    stdio.sprintf(filename, "lib%s%s", name_str, lib_ext);
     char[constants.Max_path] fullname; // TODO use string_buffer?
 
     if (!m.find_file(fullname, filename)) {

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 echo 'setting C2 environment'
 export C2_LIBDIR=$PWD/../c2_libs
-export C2_PLUGINDIR=~/c2_plugins
+export C2_PLUGINDIR=$PWD/c2_plugins
 export CC=clang
 export CXX=clang++
 #complete -W '-a -A -b -c -C -d -f -h -m -q -Q -r -s -S -t -T -v --check --create --fast --help --help-recipe --showlibs --showplugins --targets --test' c2c

--- a/generator/c_generator.c2
+++ b/generator/c_generator.c2
@@ -86,11 +86,6 @@ type Generator struct {
 
     // to filter exceptions
     u32 stdargName;
-    bool isDarwinStdio;
-    u32 stdioName;
-    u32 stdinName;
-    u32 stdoutName;
-    u32 stderrName;
 
     Module* mod;
 
@@ -526,30 +521,6 @@ fn bool Generator.emitGlobalVarDecl(Generator* gen, string_buffer.Buf* out, Decl
     VarDecl* vd = cast<VarDecl*>(d);
 
     QualType qt = d.getType();
-
-    if (gen.isDarwinStdio) {
-        // Darwin workaround, since it defines stdin/out/err as #define stdin __stdinp, etc
-        u32 name = d.getNameIdx();
-        // FIXME: generate ifdefs for bootstrapping on macOS
-        if (name == gen.stdinName) {
-            out.add("#define stdin __stdinp\n");
-            out.add("extern FILE* __stdinp;\n");
-            out.newline();
-            return true;
-        }
-        if (name == gen.stdoutName) {
-            out.add("#define stdout __stdoutp\n");
-            out.add("extern FILE* __stdoutp;\n");
-            out.newline();
-            return true;
-        }
-        if (name == gen.stderrName) {
-            out.add("#define stderr __stderrp\n");
-            out.add("extern FILE* __stderrp;\n");
-            out.newline();
-            return true;
-        }
-    }
 
     // emit 'simple'-constants as a defines
     if (emitAsDefine(vd)) {
@@ -1103,8 +1074,6 @@ fn void Generator.on_module(void* arg, Module* m) {
         out.print("\n// --- module %s ---\n", gen.mod_name);
     }
 
-    gen.isDarwinStdio = (m.getNameIdx() == gen.stdioName) && gen.targetInfo.sys == target_info.System.Darwin;
-
     // Note: special case for stdarg.h va_list
     if (m.getNameIdx() == gen.stdargName) {
         if (gen.fast_build) out = gen.header;
@@ -1185,10 +1154,6 @@ fn void Generator.init(Generator* gen,
     gen.decls.init(16);
 
     gen.stdargName = astPool.addStr("stdarg", true);
-    gen.stdioName = astPool.addStr("stdio", true);
-    gen.stdinName = astPool.addStr("stdin", true);
-    gen.stdoutName = astPool.addStr("stdout", true);
-    gen.stderrName = astPool.addStr("stderr", true);
 }
 
 fn void Generator.free(Generator* gen) {

--- a/generator/c_generator.c2
+++ b/generator/c_generator.c2
@@ -530,6 +530,7 @@ fn bool Generator.emitGlobalVarDecl(Generator* gen, string_buffer.Buf* out, Decl
     if (gen.isDarwinStdio) {
         // Darwin workaround, since it defines stdin/out/err as #define stdin __stdinp, etc
         u32 name = d.getNameIdx();
+        // FIXME: generate ifdefs for bootstrapping on macOS
         if (name == gen.stdinName) {
             out.add("#define stdin __stdinp\n");
             out.add("extern FILE* __stdinp;\n");
@@ -1299,7 +1300,7 @@ public fn void build(const char* output_dir)
     i32 retval = process_utils.run_args(dir, "make", LogFile, "-j");
     if (retval != 0) {
         console.error("error during external C compilation");
-        console.log("see %s%s for defails", dir, LogFile);
+        console.log("see %s%s for details", dir, LogFile);
     }
 }
 

--- a/generator/c_generator_special.c2
+++ b/generator/c_generator_special.c2
@@ -25,6 +25,7 @@ import file_utils;
 import module_list;
 import string_buffer;
 import string_list;
+import target_info;
 
 import string;
 import stdio;
@@ -144,12 +145,20 @@ fn void Generator.createMakefile(Generator* gen,
         break;
     case DynamicLibrary:
         out.add("CFLAGS+=-fPIC\n");
-        stdio.sprintf(target_name, "lib%s.so", gen.target);
+        if (gen.targetInfo.sys == target_info.System.Darwin) {
+            stdio.sprintf(target_name, "lib%s.dylib", gen.target);
+        } else {
+            stdio.sprintf(target_name, "lib%s.so", gen.target);
+        }
         out.print("all: ../%s\n\n", target_name);
 
         out.print("../%s: $(objects) $(headers)\n", target_name);
-	    out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s -Wl,-soname,%s.1 -Wl,--version-script=exports.version $(LDFLAGS2)\n",
-            target_name, target_name);
+        if (gen.targetInfo.sys == target_info.System.Darwin) {
+            out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s $(LDFLAGS2)\n", target_name);
+        } else {
+            out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s -Wl,-soname,%s.1 -Wl,--version-script=exports.version $(LDFLAGS2)\n",
+                      target_name, target_name);
+        }
         break;
     }
 

--- a/generator/qbe_generator.c2
+++ b/generator/qbe_generator.c2
@@ -607,7 +607,7 @@ public fn void build(const char* output_dir)
     i32 retval = process_utils.run(dir, "/usr/bin/make", LogFile);
     if (retval != 0) {
         console.error("error during external QBE compilation");
-        console.log("see %s%s for defails", dir, LogFile);
+        console.log("see %s%s for details", dir, LogFile);
     }
 }
 

--- a/install_plugins.sh
+++ b/install_plugins.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
+if [ $(uname -s) = 'Darwin' ] ; then
+   LIB_EXT='.dylib'
+else
+   LIB_EXT='.so'
+fi
 set -e
 mkdir -p $C2_PLUGINDIR
-cp output/deps_generator/libdeps_generator.so $C2_PLUGINDIR
-cp output/git_version/libgit_version.so $C2_PLUGINDIR
-cp output/load_file/libload_file.so $C2_PLUGINDIR
-cp output/refs_generator/librefs_generator.so $C2_PLUGINDIR
-cp output/shell_cmd/libshell_cmd.so $C2_PLUGINDIR
-cp output/unit_test/libunit_test.so $C2_PLUGINDIR
-strip $C2_PLUGINDIR/*.so
+cp output/deps_generator/libdeps_generator$LIB_EXT $C2_PLUGINDIR
+cp output/git_version/libgit_version$LIB_EXT $C2_PLUGINDIR
+cp output/load_file/libload_file$LIB_EXT $C2_PLUGINDIR
+cp output/refs_generator/librefs_generator$LIB_EXT $C2_PLUGINDIR
+cp output/shell_cmd/libshell_cmd$LIB_EXT $C2_PLUGINDIR
+cp output/unit_test/libunit_test$LIB_EXT $C2_PLUGINDIR
+if [ $(uname -s) != 'Darwin' ] ; then
+   strip $C2_PLUGINDIR/*$LIB_EXT
+fi

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -1342,7 +1342,7 @@ fn bool Tokenizer.handle_if(Tokenizer* t, Token* result) {
     }
 
     //t.skip_whitespace();
-    t.cur++;    // just skip space
+    t.cur++;    // just skip space  // FIXME: handle comments
 
     bool enabled = false;
     Action act = Char_lookup[*t.cur];
@@ -1355,7 +1355,7 @@ fn bool Tokenizer.handle_if(Tokenizer* t, Token* result) {
         if (t.parse_feature(result, &enabled)) return true;
         break;
     case DIGIT:
-        if (*t.cur != '0') enabled = true;
+        if (*t.cur != '0') enabled = true;  // FIXME: should support expressions
         t.cur++;
         break;
     case EOF:

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -812,7 +812,7 @@ public fn void Db.testFile(Db* db) {
             return;
         }
         // check output
-        char[1024*1024] buffer;
+        char[128*1024] buffer;
         while (1) {
             isize count = read(pipe_stderr[0], buffer, sizeof(buffer)-1);
             if (count == -1) {
@@ -916,7 +916,8 @@ fn void Db.checkExpectedFiles(Db* db) {
     }
 }
 
-public fn void Db.printIssues(const Db* db) {
+public fn bool Db.printIssues(const Db* db) {
+    bool res = false;
     issues.Iter iter = db.errors.getIter();
     while (iter.more()) {
         db.output.color(colError);
@@ -924,6 +925,7 @@ public fn void Db.printIssues(const Db* db) {
                 iter.getMsg(), iter.getFilename(), iter.getLineNr());
         db.output.color(color.Normal);
         db.output.newline();
+        res = true;
         iter.next();
     }
 
@@ -934,6 +936,7 @@ public fn void Db.printIssues(const Db* db) {
                 iter.getMsg(), iter.getFilename(), iter.getLineNr());
         db.output.color(color.Normal);
         db.output.newline();
+        res = true;
         iter.next();
     }
 
@@ -944,7 +947,9 @@ public fn void Db.printIssues(const Db* db) {
                 iter.getMsg(), iter.getFilename(), iter.getLineNr());
         db.output.color(color.Normal);
         db.output.newline();
+        res = true;
         iter.next();
     }
+    return res;
 }
 

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -53,6 +53,7 @@ const u32 MAX_THREADS = 32;
 const char* c2c_cmd = "output/c2c/c2c";
 bool color_output = true;
 bool runSkipped;
+i32 verboseLevel = 1;
 
 // TODO move test + queue to own file
 type Test struct {
@@ -163,7 +164,8 @@ fn void handle_dir(TestQueue* queue, const char* path) {
     Dirent* dir2 = readdir(dir);
     char[test_db.MAX_LINE] temp;
     while (dir2 != nil) {
-        sprintf(temp, "%s/%s", path, dir2.d_name);
+        // FIXME: need string.makepath
+        snprintf(temp, sizeof(temp), "%s/%s", path, dir2.d_name);
         switch (dir2.d_type) {
         case DT_REG:
             handle_file(queue, temp);
@@ -205,7 +207,7 @@ fn Tester* Tester.create(u32 idx, TestQueue* q, const char* cwd) {
     t.index = idx;
     t.queue = q;
     t.cwd = cwd;
-    sprintf(t.tmp_dir, "/tmp/tester%d", idx);
+    snprintf(t.tmp_dir, sizeof(t.tmp_dir), "/tmp/tester%d", idx);
     pthread.create(&t.thread, nil, tester_thread_main, t);
     return t;
 }
@@ -230,7 +232,7 @@ fn void Tester.run_test(Tester* t, Test* test) {
     // setup dir
     // temp, just delete this way
     char[64] cmd;
-    sprintf(cmd, "rm -rf %s", t.tmp_dir);
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", t.tmp_dir);
     i32 err = system(cmd);
     if (err != 0 && *errno2() != 10) {
         i32 saved = *errno2();
@@ -258,27 +260,28 @@ fn void Tester.run_test(Tester* t, Test* test) {
 
     test_db.Db db;
     db.init(buf, &file, test.filename, test.kind, t.tmp_dir, c2c_cmd, t.cwd, runSkipped);
+    bool print = verboseLevel > 1;
     bool skip = db.parse();
     if (skip) {
         t.numskipped++;
         buf.clear();
         color_print2(buf, colSkip, "%s SKIPPED", test.filename);
-        printf("%s", buf.data());
+        if (verboseLevel >= 1) print = true;
     } else {
         buf.newline();
 
         if (!db.haveErrors()) {
             db.testFile();
-            db.printIssues();
+            if (db.printIssues()) print = true;
         }
-        printf("%s", buf.data());
-
-
         if (db.haveErrors()) {
+            print = true;
             test.failed = true;
             t.numerrors++;
         }
     }
+    if (print) printf("%s", buf.data());
+
     db.destroy();
     file.close();
     buf.free();
@@ -286,8 +289,11 @@ fn void Tester.run_test(Tester* t, Test* test) {
 
 fn void usage(const char* name) {
     printf("Usage: %s [file/dir] <options>\n", name);
-    printf("    -s    only run skipped tests\n");
+    printf("    -j    use multi-threading\n");
     printf("    -n    no multi-threading\n");
+    printf("    -s    only run skipped tests\n");
+    printf("    -t    terse output, only errors shown\n");
+    printf("    -v    verbose output\n");
     exit(EXIT_FAILURE);
 }
 
@@ -303,35 +309,46 @@ fn u64 now() {
 public fn i32 main(i32 argc, char** argv) {
     set_color_output(unistd.isatty(1));
 
-    u32 num_threads = online_cpus();
-    if (num_threads > MAX_THREADS) num_threads = MAX_THREADS;
+    u32 num_threads = 0;
+    char* target = nil;
 
-    if (argc == 1 || argc > 3) usage(argv[0]);
-    const char* target = argv[1];
-
-    if (argc == 3) {
-        if (strcmp(argv[2], "-s") == 0) {
-            runSkipped = true;
-        } else if (strcmp(argv[2], "-n") == 0) {
-            num_threads = 1;
+    for (i32 i = 1; i < argc; i++) {
+        char *arg = argv[i];
+        if (arg[0] == '-') {
+            if (strcmp(arg, "-s") == 0) {
+                runSkipped = true;
+            } else if (strcmp(arg, "-t") == 0) {
+                verboseLevel -= 1;
+            } else if (strcmp(arg, "-v") == 0) {
+                verboseLevel += 1;
+            } else if (strcmp(arg, "-n") == 0) {
+                num_threads = 1;
+            } else if (strncmp(arg, "-j", 2) == 0) {
+                num_threads = cast<u32>(atoi(arg + 2));
+            } else {
+                usage(argv[0]);
+            }
         } else {
-            usage(argv[0]);
+            if (target != nil) usage(argv[0]);
+            target = arg;
         }
     }
+    if (target == nil) usage(argv[0]);
+
+    if (num_threads == 0) num_threads = online_cpus();
+    if (num_threads > MAX_THREADS) num_threads = MAX_THREADS;
 
     color_output = unistd.isatty(1);
 
     Stat statbuf;
     if (stat(target, &statbuf)) {
-        fprintf(stderr, "errot stat-ing %s: %s\n", target, strerror(*errno2()));
+        fprintf(stderr, "error stat-ing %s: %s\n", target, strerror(*errno2()));
         return -1;
     }
 
     // strip off trailing '/'
-    if (target[strlen(target) -1] == '/') {
-        char* end = cast<char*>(&target[strlen(target) -1]);
-        *end = 0;
-    }
+    usize len = strlen(target);
+    if (len > 1 && target[len - 1] == '/') target[--len] = '\0';
 
     char* cwd = unistd.getcwd(nil, 0);
     if (cwd == nil) {
@@ -347,7 +364,6 @@ public fn i32 main(i32 argc, char** argv) {
         num_threads = 1;
         handle_file(queue, target);
     } else if (statbuf.st_mode & S_IFMT == S_IFDIR) {
-        // TODO strip off optional trailing '/'
         handle_dir(queue, target);
     } else {
         usage(argv[0]);
@@ -355,7 +371,7 @@ public fn i32 main(i32 argc, char** argv) {
 
     Tester*[MAX_THREADS] testers = { nil }
     for (u32 i=0; i<num_threads; i++) {
-        testers[i] = Tester.create(cast<u32>(i), queue, cwd);
+        testers[i] = Tester.create(i, queue, cwd);
     }
 
     // TODO handle Ctrl-C


### PR DESCRIPTION
bootstrap:
* keep intermediary target **c2c_bootstrap2**
* use dynamic compiler detection for gcc/clang and target architecture
* adjust warning flags for gcc/clang
* define `fallthrough` according to compiler version
* use `#ifdef` to select architecture dependent definitions
* fix `target_info_arch_names` name as `arm64` instead of `arm_64`
* add **globals** to generate C library constants and structures

common/target_info.c2:
* add `Info.define` for C library source preprocessing
* use `arm64` instead of `arm_64` in `arch_names`

generator/:
* generate `fallthrough` pseudo-statements instead of `__attribute__((fallthrough))` for portability
* generate `Makefile` with clang specific warning flags
* adjust dynamic library link command

compiler:
* add target architecture define for C library source preprocessing
* select library extension based on target architecture

tools/tester/test_db.c2:
* reduce read buffer size to 128k in `Db.testFile`, causes stack overflow
* make `Db.printIssues` return error status

tools/tester/tester.c2:
* use `snprintf` instead of `sprintf`
* control verbosity with `-t` and `-v`
* control threading with `-n` and `-j[#]` (with optional number of threads)
* more flexible options parser: accept multiple options before or after file/dir
* fix crash bug on empty filename arg, do not strip `/` from root directory