### PR TITLE
Port to Darwin 64-bit, make bootstrap multiplatform

### DIFF
--- a/bootstrap/.gitignore
+++ b/bootstrap/.gitignore
@@ -1,1 +1,5 @@
 c2c_bootstrap
+c2c_bootstrap2
+globals.i
+globals
+bootstrap-darwin-arm64.c

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -4,22 +4,52 @@ CC=gcc
 CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch -Wno-char-subscripts
 CFLAGS+=-Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-zero-length
 CFLAGS+=-pipe -std=c99 -O0 -g
+TARGET_ARCH:=$(shell uname -s)-$(shell uname -m)
 
-all: ../output/c2c/c2c
+C2C:=../output/c2c/c2c
 
-c2c_bootstrap: bootstrap.c external.h
+ifeq (Darwin-arm64,$(TARGET_ARCH))
+BOOTSTRAP_FILE=bootstrap-darwin-arm64.c
+else
+BOOTSTRAP_FILE=bootstrap.c
+endif
+
+all: $(C2C)
+
+c2c_bootstrap: $(BOOTSTRAP_FILE) external.h
 		@echo "---- compiling bootstrap compiler ----"
-		@$(CC) $(CFLAGS) bootstrap.c -o c2c_bootstrap -ldl
+		@$(CC) $(CFLAGS) $(BOOTSTRAP_FILE) -o c2c_bootstrap -ldl
 
-../output/c2c/c2c: c2c_bootstrap
+c2c_bootstrap2: c2c_bootstrap bootstrap.c
 		@echo "---- running (bootstrapped) c2c ----"
 		@./c2c_bootstrap c2c --fast --noplugins
+		@mv -f ../output/c2c/c2c c2c_bootstrap2
+
+$(C2C): c2c_bootstrap2
 		@echo "---- running c2c (no plugins) ----"
-		@../output/c2c/c2c --noplugins
+		@./c2c_bootstrap2 --noplugins
 		@echo "---- running c2c (with plugins) ----"
-		@(cd .. && ./install_plugins.sh )
+		@( cd .. && ./install_plugins.sh )
 		@../output/c2c/c2c c2c
 
-clean:
-		@rm -rf c2c_bootstrap ../output/
+globals: globals.c
+		$(CC) -E - < globals.c > globals.i
+		$(CC) globals.c -o globals
+		./globals
 
+bootstrap-darwin-arm64.c: bootstrap-darwin-arm64.patch bootstrap.c
+		@patch -o $@ bootstrap.c $*.patch
+
+rebuild:
+		@echo "---- rebuilding bootstrap compiler ----"
+		$(C2C) --target x86_64-unknown-linux-gnu --test c2c
+		mv -f ../output/c2c/cgen/build.c bootstrap.c
+		$(C2C) --target arm64-apple-darwin-macho --test c2c
+		mv -f ../output/c2c/cgen/build.c bootstrap-darwin-arm64.c
+		( diff bootstrap.c bootstrap-darwin-arm64.c > bootstrap-darwin-arm64.patch ; true )
+		rm bootstrap-darwin-arm64.c
+
+clean:
+		@rm -f c2c_bootstrap c2c_bootstrap2 globals.i globals
+		@rm -f bootstrap-darwin-arm64.c
+		@rm -rf ../output/ c2c_bootstrap.dSYM

--- a/bootstrap/bootstrap-darwin-arm64.patch
+++ b/bootstrap/bootstrap-darwin-arm64.patch
@@ -1,0 +1,318 @@
+131c131
+< int32_t* __errno_location(void);
+---
+> int32_t* __error(void);
+173c173
+<    int64_t d_off;
+---
+>    uint64_t d_seekoff;
+174a175
+>    uint16_t d_namlen;
+176c177
+<    char d_name[256];
+---
+>    char d_name[1024];
+190,195c191,196
+< #define O_CREAT 0100
+< #define O_NOCTTY 0400
+< #define O_TRUNC 01000
+< #define O_NONBLOCK 04000
+< #define O_DIRECTORY 0200000
+< #define O_NOFOLLOW 0400000
+---
+> #define O_CREAT 01000
+> #define O_NOCTTY 0400000
+> #define O_TRUNC 02000
+> #define O_NONBLOCK 04
+> #define O_DIRECTORY 04000000
+> #define O_NOFOLLOW 0400
+197c198
+< #define AT_FDCWD -100
+---
+> #define AT_FDCWD -2
+219c220
+< extern FILE* stdout;
+---
+> extern FILE* __stdoutp;
+221c222
+< extern FILE* stderr;
+---
+> extern FILE* __stderrp;
+296a298,302
+> struct timespec {
+>    int64_t tv_sec;
+>    int64_t tv_nsec;
+> };
+> 
+298c304,306
+<    uint64_t st_dev;
+---
+>    int32_t st_dev;
+>    uint16_t st_mode;
+>    uint16_t st_nlink;
+300,301d307
+<    uint64_t st_nlink;
+<    uint32_t st_mode;
+304,316c310,321
+<    uint64_t st_rdev;
+<    int64_t st_size;
+<    int64_t st_blksize;
+<    int64_t st_blocks;
+<    int64_t st_atime;
+<    uint64_t st_atime_nsec;
+<    uint64_t st_mtime;
+<    uint64_t st_mtime_nsec;
+<    uint64_t st_ctime;
+<    uint64_t st_ctime_nsec;
+<    uint32_t __unused4;
+<    uint32_t __unused5;
+<    int64_t reserved[2];
+---
+>    uint32_t st_rdev;
+>    struct timespec st_atimespec;
+>    struct timespec st_mtimespec;
+>    struct timespec st_ctimespec;
+>    struct timespec st_birthtimespec;
+>    uint64_t st_size;
+>    uint64_t st_blocks;
+>    uint32_t st_blksize;
+>    uint32_t st_flags;
+>    uint32_t st_gen;
+>    int32_t st_lspare;
+>    int64_t st_qspare[2];
+352c357
+< #define NAME_LEN 65
+---
+> #define NAME_LEN 256
+354,359c359,364
+<    char sysname[65];
+<    char nodename[65];
+<    char release[65];
+<    char version[65];
+<    char machine[65];
+<    char domainname[65];
+---
+>    char sysname[256];
+>    char nodename[256];
+>    char release[256];
+>    char version[256];
+>    char machine[256];
+>    char domainname[256];
+449c454
+<       file->errno = *__errno_location();
+---
+>       file->errno = *__error();
+455c460
+<       file->errno = *__errno_location();
+---
+>       file->errno = *__error();
+522c527
+<    if ((err && (*__errno_location() != EEXIST))) return -1;
+---
+>    if ((err && (*__error() != EEXIST))) return -1;
+527c532
+<    if ((fd == -1)) return *__errno_location();
+---
+>    if ((fd == -1)) return *__error();
+539c544
+<    if ((fd == -1)) return *__errno_location();
+---
+>    if ((fd == -1)) return *__error();
+560c565
+<    if (err) errno_ = *__errno_location();
+---
+>    if (err) errno_ = *__error();
+577c582
+<       sprintf(writer->msg, "error opening %s: %s", filename, strerror(*__errno_location()));
+---
+>       sprintf(writer->msg, "error opening %s: %s", filename, strerror(*__error()));
+582c587
+<       sprintf(writer->msg, "error writing %s: %s", filename, strerror(*__errno_location()));
+---
+>       sprintf(writer->msg, "error writing %s: %s", filename, strerror(*__error()));
+1931,1932c1936,1937
+<    fprintf(stderr, "[exec] %s\n", msg);
+<    fflush(stderr);
+---
+>    fprintf(__stderrp, "[exec] %s\n", msg);
+>    fflush(__stderrp);
+1940c1945
+<       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
+1944c1949
+<       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
+1948c1953
+<       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
+1959c1964
+<       fflush(stdout);
+---
+>       fflush(__stdoutp);
+1963c1968
+<          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
+1968c1973
+<          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "dup(): %s", strerror(*__error()));
+1973c1978
+<          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
+1983,1984c1988,1989
+<       int32_t lasterr = *__errno_location();
+<       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
+---
+>       int32_t lasterr = *__error();
+>       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
+1995c2000
+<          fprintf(stderr, "Error reading pipe\n");
+---
+>          fprintf(__stderrp, "Error reading pipe\n");
+2005c2010
+<          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
+---
+>          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
+2064c2069
+<       fprintf(stderr, "pipe() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "pipe() failed: %s\n", strerror(*__error()));
+2068c2073
+<       fprintf(stderr, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC() failed: %s\n", strerror(*__error()));
+2072c2077
+<       fprintf(stderr, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__errno_location()));
+---
+>       fprintf(__stderrp, "fcncl(FD_CLOEXEC) failed: %s\n", strerror(*__error()));
+2083c2088
+<       fflush(stdout);
+---
+>       fflush(__stdoutp);
+2087c2092
+<          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot open output '%s': %s", output, strerror(*__error()));
+2092c2097
+<          sprintf(errmsg, "dup(): %s", strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "dup(): %s", strerror(*__error()));
+2097c2102
+<          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__errno_location()));
+---
+>          sprintf(errmsg, "cannot change to dir '%s': %s", path, strerror(*__error()));
+2110,2111c2115,2116
+<       int32_t lasterr = *__errno_location();
+<       fprintf(stderr, "failed to start %s: %s\n", cmd, strerror(lasterr));
+---
+>       int32_t lasterr = *__error();
+>       fprintf(__stderrp, "failed to start %s: %s\n", cmd, strerror(lasterr));
+2122c2127
+<          fprintf(stderr, "Error reading pipe\n");
+---
+>          fprintf(__stderrp, "Error reading pipe\n");
+2132c2137
+<          fprintf(stderr, "Error waiting for pid: %s\n", strerror(*__errno_location()));
+---
+>          fprintf(__stderrp, "Error waiting for pid: %s\n", strerror(*__error()));
+2308c2313
+<          if ((*__errno_location() != ENOENT)) {
+---
+>          if ((*__error() != ENOENT)) {
+3240c3245
+<       fprintf(stderr, "%swarning: %s%s\n", color_Yellow, buf, color_Normal);
+---
+>       fprintf(__stderrp, "%swarning: %s%s\n", color_Yellow, buf, color_Normal);
+3242c3247
+<       fprintf(stderr, "warning: %s\n", buf);
+---
+>       fprintf(__stderrp, "warning: %s\n", buf);
+3255c3260
+<       fprintf(stderr, "%serror: %s%s\n", color_Red, buf, color_Normal);
+---
+>       fprintf(__stderrp, "%serror: %s%s\n", color_Red, buf, color_Normal);
+3257c3262
+<       fprintf(stderr, "error: %s\n", buf);
+---
+>       fprintf(__stderrp, "error: %s\n", buf);
+3494c3499
+<          fprintf(stderr, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(sm, loc), color_Red, color_Normal, error_msg);
+---
+>          fprintf(__stderrp, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(sm, loc), color_Red, color_Normal, error_msg);
+3496c3501
+<          fprintf(stderr, "%serror%s: %s\n", color_Red, color_Normal, error_msg);
+---
+>          fprintf(__stderrp, "%serror%s: %s\n", color_Red, color_Normal, error_msg);
+3549c3554
+<          fprintf(stderr, "%serror%s: too many files open\n", color_Red, color_Normal);
+---
+>          fprintf(__stderrp, "%serror%s: too many files open\n", color_Red, color_Normal);
+3593c3598
+<          fprintf(stderr, "%serror%s: too many files open\n", color_Red, color_Normal);
+---
+>          fprintf(__stderrp, "%serror%s: too many files open\n", color_Red, color_Normal);
+3947c3952
+<       console_error("error getting system info: %s", strerror(*__errno_location()));
+---
+>       console_error("error getting system info: %s", strerror(*__error()));
+4912c4917
+<          fprintf(stderr, "[build-file] warning: environment variable '%s' not set!\n", (raw + 1));
+---
+>          fprintf(__stderrp, "[build-file] warning: environment variable '%s' not set!\n", (raw + 1));
+4959c4964
+<             fprintf(stderr, "[build-file] missing options for %s\n", name);
+---
+>             fprintf(__stderrp, "[build-file] missing options for %s\n", name);
+4976c4981
+<       fprintf(stderr, "Error: %s\n", yaml_Parser_getMessage(parser));
+---
+>       fprintf(__stderrp, "Error: %s\n", yaml_Parser_getMessage(parser));
+5600c5605
+<    fprintf(stderr, "%s\n", string_buffer_Buf_data(out));
+---
+>    fprintf(__stderrp, "%s\n", string_buffer_Buf_data(out));
+5631c5636
+<       fputs(string_buffer_Buf_data(out), stderr);
+---
+>       fputs(string_buffer_Buf_data(out), __stderrp);
+19335c19340
+<       fprintf(stderr, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), color_Red, color_Normal, msg);
+---
+>       fprintf(__stderrp, "%s: %serror:%s %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), color_Red, color_Normal, msg);
+19337c19342
+<       fprintf(stderr, "%s: error: %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), msg);
+---
+>       fprintf(__stderrp, "%s: error: %s\n", source_mgr_SourceMgr_loc2str(p->sm, p->token.loc), msg);
+31533c31538
+<       fprintf(stderr, "error: missing node %s\n", path);
+---
+>       fprintf(__stderrp, "error: missing node %s\n", path);
+31557c31562
+<             fprintf(stderr, "error in manifest: invalid library kind '%s'\n", kind);
+---
+>             fprintf(__stderrp, "error in manifest: invalid library kind '%s'\n", kind);
+31564c31569
+<       fprintf(stderr, "error in manifest: a library must be dynamic and/or static\n");
+---
+>       fprintf(__stderrp, "error in manifest: a library must be dynamic and/or static\n");
+31628c31633
+< static const char* plugin_mgr_lib_ext = ".so";
+---
+> static const char* plugin_mgr_lib_ext = ".dylib";
+31711c31716
+<          console_warn("cannot read '%s': %s", path, strerror(*__errno_location()));
+---
+>          console_warn("cannot read '%s': %s", path, strerror(*__error()));
+36804c36809
+<       console_error("cannot open library dir '%s': %s", dirname, strerror(*__errno_location()));
+---
+>       console_error("cannot open library dir '%s': %s", dirname, strerror(*__error()));
+37171c37176
+<          console_error("cannot chdir to %s: %s", opts.other_dir, strerror(*__errno_location()));
+---
+>          console_error("cannot chdir to %s: %s", opts.other_dir, strerror(*__error()));

--- a/bootstrap/globals.c
+++ b/bootstrap/globals.c
@@ -1,0 +1,630 @@
+#include <errno.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/dir.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+typedef unsigned int u32;
+
+int pf(const char *fmt, ...) {
+    int res;
+    va_list ap;
+    va_start(ap, fmt);
+    res = va_arg(ap, int);
+    va_end(ap);
+    return res;
+}
+
+void nothing(void *p) {
+}
+
+int main() {
+    FILE *stdin_ = stdin;
+    FILE *stdout_ = stdout;
+    FILE *stderr_ = stderr;
+    jmp_buf buf;
+    setjmp(buf);
+
+    nothing(stdin_);
+    nothing(stdout_);
+    nothing(stderr_);
+
+    printf("// libc/c_errno.c2i\n\n");
+#ifdef EPERM
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EPERM", EPERM, "Operation not permitted");
+#endif
+#ifdef ENOENT
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOENT", ENOENT, "No such file or directory");
+#endif
+#ifdef ESRCH
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ESRCH", ESRCH, "No such process");
+#endif
+#ifdef EINTR
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EINTR", EINTR, "Interrupted system call");
+#endif
+#ifdef EIO
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EIO", EIO, "I/O error");
+#endif
+#ifdef ENXIO
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENXIO", ENXIO, "No such device or address");
+#endif
+#ifdef E2BIG
+    printf("const i32 %-13s= %3d;  /* %s */\n", "E2BIG", E2BIG, "Argument list too long");
+#endif
+#ifdef ENOEXEC
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOEXEC", ENOEXEC, "Exec format error");
+#endif
+#ifdef EBADF
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EBADF", EBADF, "Bad file number");
+#endif
+#ifdef ECHILD
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ECHILD", ECHILD, "No child processes");
+#endif
+#ifdef EAGAIN
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EAGAIN", EAGAIN, "Try again");
+#endif
+#ifdef ENOMEM
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOMEM", ENOMEM, "Out of memory");
+#endif
+#ifdef EACCES
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EACCES", EACCES, "Permission denied");
+#endif
+#ifdef EFAULT
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EFAULT", EFAULT, "Bad address");
+#endif
+#ifdef ENOTBLK
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOTBLK", ENOTBLK, "Block device required");
+#endif
+#ifdef EBUSY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EBUSY", EBUSY, "Device or resource busy");
+#endif
+#ifdef EEXIST
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EEXIST", EEXIST, "File exists");
+#endif
+#ifdef EXDEV
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EXDEV", EXDEV, "Cross-device link");
+#endif
+#ifdef ENODEV
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENODEV", ENODEV, "No such device");
+#endif
+#ifdef ENOTDIR
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOTDIR", ENOTDIR, "Not a directory");
+#endif
+#ifdef EISDIR
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EISDIR", EISDIR, "Is a directory");
+#endif
+#ifdef EINVAL
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EINVAL", EINVAL, "Invalid argument");
+#endif
+#ifdef ENFILE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENFILE", ENFILE, "File table overflow");
+#endif
+#ifdef EMFILE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EMFILE", EMFILE, "Too many open files");
+#endif
+#ifdef ENOTTY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOTTY", ENOTTY, "Not a typewriter");
+#endif
+#ifdef ETXTBSY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ETXTBSY", ETXTBSY, "Text file busy");
+#endif
+#ifdef EFBIG
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EFBIG", EFBIG, "File too large");
+#endif
+#ifdef ENOSPC
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ENOSPC", ENOSPC, "No space left on device");
+#endif
+#ifdef ESPIPE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ESPIPE", ESPIPE, "Illegal seek");
+#endif
+#ifdef EROFS
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EROFS", EROFS, "Read-only file system");
+#endif
+#ifdef EMLINK
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EMLINK", EMLINK, "Too many links");
+#endif
+#ifdef EPIPE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EPIPE", EPIPE, "Broken pipe");
+#endif
+#ifdef EDOM
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EDOM", EDOM, "Math argument out of domain of func");
+#endif
+#ifdef ERANGE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ERANGE", ERANGE, "Math result not representable");
+#endif
+#ifdef EALREADY
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EALREADY", EALREADY, "Operation already in progress");
+#endif
+#ifdef EINPROGRESS
+    printf("const i32 %-13s= %3d;  /* %s */\n", "EINPROGRESS", EINPROGRESS, "Operation now in progress");
+#endif
+#ifdef ESTALE
+    printf("const i32 %-13s= %3d;  /* %s */\n", "ESTALE", ESTALE, "Stale file handle");
+#endif
+
+    printf("\n");
+    printf("// libc/fcntl.c2i\n\n");
+#ifdef O_RDONLY
+    printf("const u32 O_RDONLY    =%#9o;\n",  O_RDONLY);
+#endif
+#ifdef O_WRONLY
+    printf("const u32 O_WRONLY    =%#9o;\n",  O_WRONLY);
+#endif
+#ifdef O_RDWR
+    printf("const u32 O_RDWR      =%#9o;\n",  O_RDWR);
+#endif
+#ifdef O_CREAT
+    printf("const u32 O_CREAT     =%#9o;\n",  O_CREAT);
+#endif
+#ifdef O_EXCL
+    printf("const u32 O_EXCL      =%#9o;\n",  O_EXCL);
+#endif
+#ifdef O_NOCTTY
+    printf("const u32 O_NOCTTY    =%#9o;\n",  O_NOCTTY);
+#endif
+#ifdef O_TRUNC
+    printf("const u32 O_TRUNC     =%#9o;\n",  O_TRUNC);
+#endif
+#ifdef O_APPEND
+    printf("const u32 O_APPEND    =%#9o;\n",  O_APPEND);
+#endif
+#ifdef O_NONBLOCK
+    printf("const u32 O_NONBLOCK  =%#9o;\n",  O_NONBLOCK);
+#endif
+#ifdef O_DIRECT
+    printf("const u32 O_DIRECT    =%#9o;\n",  O_DIRECT);
+#endif
+#ifdef O_LARGEFILE
+    printf("const u32 O_LARGEFILE =%#9o;\n",  O_LARGEFILE);
+#endif
+#ifdef O_DIRECTORY
+    printf("const u32 O_DIRECTORY =%#9o;\n",  O_DIRECTORY);
+#endif
+#ifdef O_NOFOLLOW
+    printf("const u32 O_NOFOLLOW  =%#9o;\n",  O_NOFOLLOW);
+#endif
+#ifdef O_SYNC
+    printf("const u32 O_SYNC      =%#9o;\n",  O_SYNC);
+#endif
+#ifdef O_NOATIME
+    printf("const u32 O_NOATIME   =%#9o;\n",  O_NOATIME);
+#endif
+#ifdef O_CLOEXEC
+    printf("const u32 O_CLOEXEC   =%#9o;\n",  O_CLOEXEC);
+#endif
+#ifdef O_PATH
+    printf("const u32 O_PATH      =%#9o;\n",  O_PATH);
+#endif
+#ifdef O_TMPFILE
+    printf("const u32 O_TMPFILE   =%#9o;\n",  O_TMPFILE);
+#endif
+    printf("\n");
+#ifdef F_DUPFD
+    printf("const u32 F_DUPFD = %d;\n",  F_DUPFD);
+#endif
+#ifdef F_GETFD
+    printf("const u32 F_GETFD = %d;\n",  F_GETFD);
+#endif
+#ifdef F_SETFD
+    printf("const u32 F_SETFD = %d;\n",  F_SETFD);
+#endif
+#ifdef F_GETFL
+    printf("const u32 F_GETFL = %d;\n",  F_GETFL);
+#endif
+#ifdef F_SETFL
+    printf("const u32 F_SETFL = %d;\n",  F_SETFL);
+#endif
+    printf("\n");
+#ifdef AT_FDCWD
+    printf("const i32 AT_FDCWD = %d;\n",  AT_FDCWD);
+#endif
+#ifdef FD_CLOEXEC
+    printf("const u32 FD_CLOEXEC = %u;\n",  FD_CLOEXEC);
+#endif
+    printf("\n");
+    printf("// libc/dirent.c2i\n\n");
+#ifdef DT_UNKNOWN
+    printf("const c_uint DT_UNKNOWN = %d;\n", DT_UNKNOWN);
+#endif
+#ifdef DT_FIFO
+    printf("const c_uint DT_FIFO = %d;\n", DT_FIFO);
+#endif
+#ifdef DT_CHR
+    printf("const c_uint DT_CHR = %d;\n", DT_CHR);
+#endif
+#ifdef DT_DIR
+    printf("const c_uint DT_DIR = %d;\n", DT_DIR);
+#endif
+#ifdef DT_BLK
+    printf("const c_uint DT_BLK = %d;\n", DT_BLK);
+#endif
+#ifdef DT_REG
+    printf("const c_uint DT_REG = %d;\n", DT_REG);
+#endif
+#ifdef DT_LNK
+    printf("const c_uint DT_LNK = %d;\n", DT_LNK);
+#endif
+#ifdef DT_SOCK
+    printf("const c_uint DT_SOCK = %d;\n", DT_SOCK);
+#endif
+#ifdef DT_WHT
+    printf("const c_uint DT_WHT = %d;\n", DT_WHT);
+#endif
+    printf("\n");
+
+    printf("// libc/unistd.c2i\n\n");
+#ifdef R_OK
+    printf("const u8 R_OK = %d;\n", R_OK);
+#endif
+#ifdef W_OK
+    printf("const u8 W_OK = %d;\n", W_OK);
+#endif
+#ifdef X_OK
+    printf("const u8 X_OK = %d;\n", X_OK);
+#endif
+#ifdef F_OK
+    printf("const u8 F_OK = %d;\n", F_OK);
+#endif
+    printf("\n");
+
+#ifdef _SC_ARG_MAX
+    printf("u32 _SC_ARG_MAX = %d;\n", _SC_ARG_MAX);
+#endif
+#ifdef _SC_CHILD_MAX
+    printf("u32 _SC_CHILD_MAX = %d;\n", _SC_CHILD_MAX);
+#endif
+#ifdef _SC_CLK_TCK
+    printf("u32 _SC_CLK_TCK = %d;\n", _SC_CLK_TCK);
+#endif
+#ifdef _SC_NGROUPS_MAX
+    printf("u32 _SC_NGROUPS_MAX = %d;\n", _SC_NGROUPS_MAX);
+#endif
+#ifdef _SC_OPEN_MAX
+    printf("u32 _SC_OPEN_MAX = %d;\n", _SC_OPEN_MAX);
+#endif
+#ifdef _SC_JOB_CONTROL
+    printf("u32 _SC_JOB_CONTROL = %d;\n", _SC_JOB_CONTROL);
+#endif
+#ifdef _SC_SAVED_IDS
+    printf("u32 _SC_SAVED_IDS = %d;\n", _SC_SAVED_IDS);
+#endif
+#ifdef _SC_VERSION
+    printf("u32 _SC_VERSION = %d;\n", _SC_VERSION);
+#endif
+#ifdef _SC_PAGESIZE
+    printf("u32 _SC_PAGESIZE = %d;\n", _SC_PAGESIZE);
+#endif
+#ifdef _SC_PAGE_SIZE
+    printf("u32 _SC_PAGE_SIZE = %d;\n", _SC_PAGE_SIZE);
+#endif
+#ifdef _SC_NPROCESSORS_CONF
+    printf("u32 _SC_NPROCESSORS_CONF = %d;\n", _SC_NPROCESSORS_CONF);
+#endif
+#ifdef _SC_NPROCESSORS_ONLN
+    printf("u32 _SC_NPROCESSORS_ONLN = %d;\n", _SC_NPROCESSORS_ONLN);
+#endif
+#ifdef _SC_PHYS_PAGES
+    printf("u32 _SC_PHYS_PAGES = %d;\n", _SC_PHYS_PAGES);
+#endif
+#ifdef _SC_AVPHYS_PAGES
+    printf("u32 _SC_AVPHYS_PAGES = %d;\n", _SC_AVPHYS_PAGES);
+#endif
+#ifdef _SC_MQ_OPEN_MAX
+    printf("u32 _SC_MQ_OPEN_MAX = %d;\n", _SC_MQ_OPEN_MAX);
+#endif
+#ifdef _SC_MQ_PRIO_MAX
+    printf("u32 _SC_MQ_PRIO_MAX = %d;\n", _SC_MQ_PRIO_MAX);
+#endif
+#ifdef _SC_RTSIG_MAX
+    printf("u32 _SC_RTSIG_MAX = %d;\n", _SC_RTSIG_MAX);
+#endif
+#ifdef _SC_SEM_NSEMS_MAX
+    printf("u32 _SC_SEM_NSEMS_MAX = %d;\n", _SC_SEM_NSEMS_MAX);
+#endif
+#ifdef _SC_SEM_VALUE_MAX
+    printf("u32 _SC_SEM_VALUE_MAX = %d;\n", _SC_SEM_VALUE_MAX);
+#endif
+#ifdef _SC_SIGQUEUE_MAX
+    printf("u32 _SC_SIGQUEUE_MAX = %d;\n", _SC_SIGQUEUE_MAX);
+#endif
+#ifdef _SC_TIMER_MAX
+    printf("u32 _SC_TIMER_MAX = %d;\n", _SC_TIMER_MAX);
+#endif
+#ifdef _SC_TZNAME_MAX
+    printf("u32 _SC_TZNAME_MAX = %d;\n", _SC_TZNAME_MAX);
+#endif
+#ifdef _SC_ASYNCHRONOUS_IO
+    printf("u32 _SC_ASYNCHRONOUS_IO = %d;\n", _SC_ASYNCHRONOUS_IO);
+#endif
+#ifdef _SC_FSYNC
+    printf("u32 _SC_FSYNC = %d;\n", _SC_FSYNC);
+#endif
+#ifdef _SC_MAPPED_FILES
+    printf("u32 _SC_MAPPED_FILES = %d;\n", _SC_MAPPED_FILES);
+#endif
+#ifdef _SC_MEMLOCK
+    printf("u32 _SC_MEMLOCK = %d;\n", _SC_MEMLOCK);
+#endif
+#ifdef _SC_MEMLOCK_RANGE
+    printf("u32 _SC_MEMLOCK_RANGE = %d;\n", _SC_MEMLOCK_RANGE);
+#endif
+#ifdef _SC_MEMORY_PROTECTION
+    printf("u32 _SC_MEMORY_PROTECTION = %d;\n", _SC_MEMORY_PROTECTION);
+#endif
+#ifdef _SC_MESSAGE_PASSING
+    printf("u32 _SC_MESSAGE_PASSING = %d;\n", _SC_MESSAGE_PASSING);
+#endif
+#ifdef _SC_PRIORITIZED_IO
+    printf("u32 _SC_PRIORITIZED_IO = %d;\n", _SC_PRIORITIZED_IO);
+#endif
+#ifdef _SC_REALTIME_SIGNALS
+    printf("u32 _SC_REALTIME_SIGNALS = %d;\n", _SC_REALTIME_SIGNALS);
+#endif
+#ifdef _SC_SEMAPHORES
+    printf("u32 _SC_SEMAPHORES = %d;\n", _SC_SEMAPHORES);
+#endif
+#ifdef _SC_SHARED_MEMORY_OBJECTS
+    printf("u32 _SC_SHARED_MEMORY_OBJECTS = %d;\n", _SC_SHARED_MEMORY_OBJECTS);
+#endif
+#ifdef _SC_SYNCHRONIZED_IO
+    printf("u32 _SC_SYNCHRONIZED_IO = %d;\n", _SC_SYNCHRONIZED_IO);
+#endif
+#ifdef _SC_TIMERS
+    printf("u32 _SC_TIMERS = %d;\n", _SC_TIMERS);
+#endif
+#ifdef _SC_AIO_LISTIO_MAX
+    printf("u32 _SC_AIO_LISTIO_MAX = %d;\n", _SC_AIO_LISTIO_MAX);
+#endif
+#ifdef _SC_AIO_MAX
+    printf("u32 _SC_AIO_MAX = %d;\n", _SC_AIO_MAX);
+#endif
+#ifdef _SC_AIO_PRIO_DELTA_MAX
+    printf("u32 _SC_AIO_PRIO_DELTA_MAX = %d;\n", _SC_AIO_PRIO_DELTA_MAX);
+#endif
+#ifdef _SC_DELAYTIMER_MAX
+    printf("u32 _SC_DELAYTIMER_MAX = %d;\n", _SC_DELAYTIMER_MAX);
+#endif
+#ifdef _SC_THREAD_KEYS_MAX
+    printf("u32 _SC_THREAD_KEYS_MAX = %d;\n", _SC_THREAD_KEYS_MAX);
+#endif
+#ifdef _SC_THREAD_STACK_MIN
+    printf("u32 _SC_THREAD_STACK_MIN = %d;\n", _SC_THREAD_STACK_MIN);
+#endif
+#ifdef _SC_THREAD_THREADS_MAX
+    printf("u32 _SC_THREAD_THREADS_MAX = %d;\n", _SC_THREAD_THREADS_MAX);
+#endif
+#ifdef _SC_TTY_NAME_MAX
+    printf("u32 _SC_TTY_NAME_MAX = %d;\n", _SC_TTY_NAME_MAX);
+#endif
+#ifdef _SC_THREADS
+    printf("u32 _SC_THREADS = %d;\n", _SC_THREADS);
+#endif
+#ifdef _SC_THREAD_ATTR_STACKADDR
+    printf("u32 _SC_THREAD_ATTR_STACKADDR = %d;\n", _SC_THREAD_ATTR_STACKADDR);
+#endif
+#ifdef _SC_THREAD_ATTR_STACKSIZE
+    printf("u32 _SC_THREAD_ATTR_STACKSIZE = %d;\n", _SC_THREAD_ATTR_STACKSIZE);
+#endif
+#ifdef _SC_THREAD_PRIORITY_SCHEDULING
+    printf("u32 _SC_THREAD_PRIORITY_SCHEDULING = %d;\n", _SC_THREAD_PRIORITY_SCHEDULING);
+#endif
+#ifdef _SC_THREAD_PRIO_INHERIT
+    printf("u32 _SC_THREAD_PRIO_INHERIT = %d;\n", _SC_THREAD_PRIO_INHERIT);
+#endif
+#ifdef _SC_THREAD_PRIO_PROTECT
+    printf("u32 _SC_THREAD_PRIO_PROTECT = %d;\n", _SC_THREAD_PRIO_PROTECT);
+#endif
+#ifdef _SC_THREAD_PRIO_CEILING
+    printf("u32 _SC_THREAD_PRIO_CEILING = %d;\n", _SC_THREAD_PRIO_CEILING);
+#endif
+#ifdef _SC_THREAD_PROCESS_SHARED
+    printf("u32 _SC_THREAD_PROCESS_SHARED = %d;\n", _SC_THREAD_PROCESS_SHARED);
+#endif
+#ifdef _SC_THREAD_SAFE_FUNCTIONS
+    printf("u32 _SC_THREAD_SAFE_FUNCTIONS = %d;\n", _SC_THREAD_SAFE_FUNCTIONS);
+#endif
+#ifdef _SC_GETGR_R_SIZE_MAX
+    printf("u32 _SC_GETGR_R_SIZE_MAX = %d;\n", _SC_GETGR_R_SIZE_MAX);
+#endif
+#ifdef _SC_GETPW_R_SIZE_MAX
+    printf("u32 _SC_GETPW_R_SIZE_MAX = %d;\n", _SC_GETPW_R_SIZE_MAX);
+#endif
+#ifdef _SC_LOGIN_NAME_MAX
+    printf("u32 _SC_LOGIN_NAME_MAX = %d;\n", _SC_LOGIN_NAME_MAX);
+#endif
+#ifdef SC_THREAD_DESTRUCTOR_ITERATIONS
+    printf("u32 SC_THREAD_DESTRUCTOR_ITERATIONS = %d;\n", SC_THREAD_DESTRUCTOR_ITERATIONS);
+#endif
+#ifdef _SC_ADVISORY_INFO
+    printf("u32 _SC_ADVISORY_INFO = %d;\n", _SC_ADVISORY_INFO);
+#endif
+#ifdef _SC_ATEXIT_MAX
+    printf("u32 _SC_ATEXIT_MAX = %d;\n", _SC_ATEXIT_MAX);
+#endif
+#ifdef _SC_BARRIERS
+    printf("u32 _SC_BARRIERS = %d;\n", _SC_BARRIERS);
+#endif
+#ifdef _SC_BC_BASE_MAX
+    printf("u32 _SC_BC_BASE_MAX = %d;\n", _SC_BC_BASE_MAX);
+#endif
+#ifdef _SC_BC_DIM_MAX
+    printf("u32 _SC_BC_DIM_MAX = %d;\n", _SC_BC_DIM_MAX);
+#endif
+#ifdef _SC_BC_SCALE_MAX
+    printf("u32 _SC_BC_SCALE_MAX = %d;\n", _SC_BC_SCALE_MAX);
+#endif
+#ifdef _SC_BC_STRING_MAX
+    printf("u32 _SC_BC_STRING_MAX = %d;\n", _SC_BC_STRING_MAX);
+#endif
+#ifdef _SC_CLOCK_SELECTION
+    printf("u32 _SC_CLOCK_SELECTION = %d;\n", _SC_CLOCK_SELECTION);
+#endif
+#ifdef _SC_COLL_WEIGHTS_MAX
+    printf("u32 _SC_COLL_WEIGHTS_MAX = %d;\n", _SC_COLL_WEIGHTS_MAX);
+#endif
+#ifdef _SC_CPUTIME
+    printf("u32 _SC_CPUTIME = %d;\n", _SC_CPUTIME);
+#endif
+#ifdef _SC_EXPR_NEST_MAX
+    printf("u32 _SC_EXPR_NEST_MAX = %d;\n", _SC_EXPR_NEST_MAX);
+#endif
+#ifdef _SC_HOST_NAME_MAX
+    printf("u32 _SC_HOST_NAME_MAX = %d;\n", _SC_HOST_NAME_MAX);
+#endif
+#ifdef _SC_IOV_MAX
+    printf("u32 _SC_IOV_MAX = %d;\n", _SC_IOV_MAX);
+#endif
+#ifdef _SC_IPV6
+    printf("u32 _SC_IPV6 = %d;\n", _SC_IPV6);
+#endif
+#ifdef _SC_LINE_MAX
+    printf("u32 _SC_LINE_MAX = %d;\n", _SC_LINE_MAX);
+#endif
+#ifdef _SC_MONOTONIC_CLOCK
+    printf("u32 _SC_MONOTONIC_CLOCK = %d;\n", _SC_MONOTONIC_CLOCK);
+#endif
+#ifdef _SC_RAW_SOCKETS
+    printf("u32 _SC_RAW_SOCKETS = %d;\n", _SC_RAW_SOCKETS);
+#endif
+#ifdef _SC_READER_WRITER_LOCKS
+    printf("u32 _SC_READER_WRITER_LOCKS = %d;\n", _SC_READER_WRITER_LOCKS);
+#endif
+#ifdef _SC_REGEXP
+    printf("u32 _SC_REGEXP = %d;\n", _SC_REGEXP);
+#endif
+#ifdef _SC_RE_DUP_MAX
+    printf("u32 _SC_RE_DUP_MAX = %d;\n", _SC_RE_DUP_MAX);
+#endif
+#ifdef _SC_SHELL
+    printf("u32 _SC_SHELL = %d;\n", _SC_SHELL);
+#endif
+#ifdef _SC_SPAWN
+    printf("u32 _SC_SPAWN = %d;\n", _SC_SPAWN);
+#endif
+#ifdef _SC_SPIN_LOCKS
+    printf("u32 _SC_SPIN_LOCKS = %d;\n", _SC_SPIN_LOCKS);
+#endif
+#ifdef _SC_SPORADIC_SERVER
+    printf("u32 _SC_SPORADIC_SERVER = %d;\n", _SC_SPORADIC_SERVER);
+#endif
+#ifdef _SC_SS_REPL_MAX
+    printf("u32 _SC_SS_REPL_MAX = %d;\n", _SC_SS_REPL_MAX);
+#endif
+#ifdef _SC_SYMLOOP_MAX
+    printf("u32 _SC_SYMLOOP_MAX = %d;\n", _SC_SYMLOOP_MAX);
+#endif
+#ifdef _SC_THREAD_CPUTIME
+    printf("u32 _SC_THREAD_CPUTIME = %d;\n", _SC_THREAD_CPUTIME);
+#endif
+#ifdef _SC_THREAD_SPORADIC_SERVER
+    printf("u32 _SC_THREAD_SPORADIC_SERVER = %d;\n", _SC_THREAD_SPORADIC_SERVER);
+#endif
+#ifdef _SC_TIMEOUTS
+    printf("u32 _SC_TIMEOUTS = %d;\n", _SC_TIMEOUTS);
+#endif
+#ifdef _SC_TRACE
+    printf("u32 _SC_TRACE = %d;\n", _SC_TRACE);
+#endif
+#ifdef _SC_TRACE_EVENT_FILTER
+    printf("u32 _SC_TRACE_EVENT_FILTER = %d;\n", _SC_TRACE_EVENT_FILTER);
+#endif
+#ifdef _SC_TRACE_EVENT_NAME_MAX
+    printf("u32 _SC_TRACE_EVENT_NAME_MAX = %d;\n", _SC_TRACE_EVENT_NAME_MAX);
+#endif
+#ifdef _SC_TRACE_INHERIT
+    printf("u32 _SC_TRACE_INHERIT = %d;\n", _SC_TRACE_INHERIT);
+#endif
+#ifdef _SC_TRACE_LOG
+    printf("u32 _SC_TRACE_LOG = %d;\n", _SC_TRACE_LOG);
+#endif
+#ifdef _SC_TRACE_NAME_MAX
+    printf("u32 _SC_TRACE_NAME_MAX = %d;\n", _SC_TRACE_NAME_MAX);
+#endif
+#ifdef _SC_TRACE_SYS_MAX
+    printf("u32 _SC_TRACE_SYS_MAX = %d;\n", _SC_TRACE_SYS_MAX);
+#endif
+#ifdef _SC_TRACE_USER_EVENT_MAX
+    printf("u32 _SC_TRACE_USER_EVENT_MAX = %d;\n", _SC_TRACE_USER_EVENT_MAX);
+#endif
+#ifdef _SC_TYPED_MEMORY_OBJECTS
+    printf("u32 _SC_TYPED_MEMORY_OBJECTS = %d;\n", _SC_TYPED_MEMORY_OBJECTS);
+#endif
+#ifdef _SC_V7_ILP32_OFF32
+    printf("u32 _SC_V7_ILP32_OFF32 = %d;\n", _SC_V7_ILP32_OFF32);
+#endif
+    printf("\n");
+
+    printf("// libc/sys_mman.c2i\n\n");
+#ifdef PROT_NONE
+    printf("const u32 PROT_NONE = %d;\n", PROT_NONE);
+#endif
+#ifdef PROT_READ
+    printf("const u32 PROT_READ = %d;\n", PROT_READ);
+#endif
+#ifdef PROT_WRITE
+    printf("const u32 PROT_WRITE = %d;\n", PROT_WRITE);
+#endif
+#ifdef PROT_EXEC
+    printf("const u32 PROT_EXEC = %d;\n", PROT_EXEC);
+#endif
+    printf("\n");
+#ifdef MAP_SHARED
+    printf("const u32 MAP_SHARED = 0x%02x;\n", MAP_SHARED);
+#endif
+#ifdef MAP_PRIVATE
+    printf("const u32 MAP_PRIVATE = 0x%02x;\n", MAP_PRIVATE);
+#endif
+#ifdef MAP_FIXED
+    printf("const u32 MAP_FIXED = 0x%02x;\n", MAP_FIXED);
+#endif
+#ifdef MAP_ANONYMOUS
+    printf("const u32 MAP_ANONYMOUS = 0x%02x;\n", MAP_ANONYMOUS);
+#endif
+#ifdef MAP_POPULATE
+    printf("const u32 MAP_POPULATE = 0x%02x;\n", MAP_POPULATE);
+#endif
+#ifdef MAP_FAILED
+    printf("const usize MAP_FAILED = %lld;\n", (long long)MAP_FAILED);
+#endif
+    printf("\n");
+
+    printf("// libc/sys_ioctl.c2i\n\n");
+#ifdef TCGETS
+    printf("const c_uint TCGETS = %d;\n", TCGETS);
+#endif
+#ifdef TCSETS
+    printf("const c_uint TCSETS = %d;\n", TCSETS);
+#endif
+#ifdef TCSETSW
+    printf("const c_uint TCSETSW = %d;\n", TCSETSW);
+#endif
+#ifdef TCSETSF
+    printf("const c_uint TCSETSF = %d;\n", TCSETSF);
+#endif
+#ifdef TCGETA
+    printf("const c_uint TCGETA = %d;\n", TCGETA);
+#endif
+#ifdef TCSETA
+    printf("const c_uint TCSETA = %d;\n", TCSETA);
+#endif
+    printf("\n");
+
+    printf("// pthread/pthread.c2i\n\n");
+    printf("const u32 SIZEOF_ATTR_T = %zu;\n", sizeof(pthread_attr_t));
+    printf("const u32 SIZEOF_MUTEX_T = %zu;\n", sizeof(pthread_mutex_t));
+    printf("const u32 SIZEOF_MUTEXATTR_T = %zu;\n", sizeof(pthread_mutexattr_t));
+    printf("const u32 SIZEOF_COND_T = %zu;\n", sizeof(pthread_cond_t));
+    printf("const u32 SIZEOF_CONDATTR_T = %zu;\n", sizeof(pthread_condattr_t));
+    printf("\n");
+
+    return errno;
+}

--- a/common/target_info.c2
+++ b/common/target_info.c2
@@ -17,6 +17,7 @@ module target_info;
 
 import console;
 
+import ctype;
 import c_errno local;
 import stdio;
 import stdlib local;
@@ -31,7 +32,7 @@ public type Abi enum u8 { Unknown, GNU, GNU_EABI, MACHO, WIN32, Rv32G }
 const char*[] system_names = { "unknown", "linux", "darwin", "cygwin" }
 static_assert(elemsof(System), elemsof(system_names));
 
-const char*[] arch_names = { "unknown", "i686", "arm", "x86_64", "arm_64", "riscv32" }
+const char*[] arch_names = { "unknown", "i686", "arm", "x86_64", "arm64", "riscv32" }
 static_assert(elemsof(Arch), elemsof(arch_names));
 
 const char*[] vendor_names = { "unknown", "apple" }
@@ -77,6 +78,9 @@ public type Info struct {
     u32 intWidth;
 
     char[80] triple;
+    char[32] system_define;
+    char[32] arch_define;
+    char[32] target_define;
 }
 
 public fn void Info.getNative(Info* info) {
@@ -115,6 +119,18 @@ public fn void Info.getNative(Info* info) {
     info.init();
 }
 
+fn void make_define(char *s, const char *s1, const char *s2, const char *s3) {
+    if (s3 == nil) {
+        stdio.snprintf(s, 32, "%s_%s", s1, s2);
+    } else {
+        stdio.snprintf(s, 32, "%s_%s_%s", s1, s2, s3);
+    }
+    for (usize i = 0; s[i]; i++) {
+        u8 c = cast<u8>(s[i]);
+        s[i] = (c == '-') ? '_' : cast<char>(ctype.toupper(c));
+    }
+}
+
 fn void Info.init(Info* info) {
     switch (info.arch) {
     case Unknown:
@@ -138,6 +154,9 @@ fn void Info.init(Info* info) {
         vendor_names[info.vendor],
         system_names[info.sys],
         abi_names[info.abi]);
+    make_define(info.system_define, "SYSTEM", system_names[info.sys], nil);
+    make_define(info.arch_define, "ARCH", arch_names[info.arch], nil);
+    make_define(info.target_define, "TARGET", system_names[info.sys], arch_names[info.arch]);
 }
 
 public fn bool Info.fromString(Info* info, const char* triple) {

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -74,6 +74,7 @@ public type Options struct {
     bool show_libs;
     bool print_qbe;
     u32 libdir; // from environment varible C2_LIBDIR, into auxPool
+    const char *target_triple;
 }
 
 public fn void build(string_pool.Pool* auxPool,
@@ -249,16 +250,14 @@ fn void Compiler.build(Compiler* c,
     // add output dir as first libdir, unless --showlibs
     if (!opts.show_libs) c.libdirs.add(c.auxPool.addStr(output_base, true));
 
+    const char* target_str = opts.target_triple;
     if (c.build_info) {
         const string_list.List* dirs = c.build_info.getLibDirs();
         for (u32 i=0; i<dirs.length(); i++) {
             c.libdirs.add(dirs.get_idx(i));
         }
-        const char* target_str = c.build_info.getTarget();
-        if (target_str) {
-            c.targetInfo.fromString(target_str);
-        } else {
-            c.targetInfo.getNative();
+        if (target_str == nil) {
+            target_str = c.build_info.getTarget();
         }
     } else {
         if (c.is_image) {
@@ -267,9 +266,18 @@ fn void Compiler.build(Compiler* c,
             stdlib.exit(-1);
         }
         if (c.opts.libdir) c.libdirs.add(c.opts.libdir);
+    }
+    if (target_str) {
+        c.targetInfo.fromString(target_str);
+    } else {
         c.targetInfo.getNative();
     }
     console.debug("triple: %s", c.targetInfo.str());
+
+    // Add target, system and arch defines for C library implementation selection
+    target.addFeature(c.auxPool.addStr(c.targetInfo.system_define, true));
+    target.addFeature(c.auxPool.addStr(c.targetInfo.arch_define, true));
+    target.addFeature(c.auxPool.addStr(c.targetInfo.target_define, true));
 
     ast.init(c.context, c.astPool, c.targetInfo.intWidth / 8, color.useColor());
 

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -170,6 +170,7 @@ fn void usage(const char* me) {
     console.log("\t--showlibs        print available libraries");
     console.log("\t--showplugins     print available plugins");
     console.log("\t--targets         show available targets in recipe");
+    console.log("\t--target triple   cross compile for specific target");
     console.log("\t--test            test mode (dont check for main() function)");
     console.log("\t--version         print version");
     exit(EXIT_FAILURE);
@@ -198,6 +199,10 @@ fn i32 parse_long_opt(i32 i, i32 argc, char** argv, compiler.Options* opts, Opti
         opts.show_libs = true;
     case "showplugins":
         other.show_plugins = true;
+    case "target":
+        if (i==argc-1) usage(argv[0]);
+        i++;
+        opts.target_triple = argv[i];
     case "targets":
         other.show_targets = true;
     case "test":

--- a/compiler/plugin_mgr.c2
+++ b/compiler/plugin_mgr.c2
@@ -29,6 +29,12 @@ import stdio;
 import stdlib;
 import string local;
 
+#if SYSTEM_DARWIN
+const char *lib_ext = ".dylib";
+#else
+const char *lib_ext = ".so";
+#endif
+
 type Plugin struct {
     u32 name; // in auxPool
     bool is_global;
@@ -99,7 +105,7 @@ fn bool is_plugin(const Dirent* entry) {
     if (filename[0] == '.') return false;
     usize len = strlen(filename);
     if (len < 5) return false;
-    if (strcmp(&filename[len-3], ".so") != 0) return false;
+    if (strcmp(&filename[len-3], lib_ext) != 0) return false;
 
     return true;
 }
@@ -140,8 +146,7 @@ fn bool Mgr.loadPlugin(Mgr* m, u32 name, u32 options, bool is_global) {
     const char* name_str = m.auxPool.idx2str(name);
 
     char[128] filename;
-    stdio.sprintf(filename, "lib%s.so", name_str);
-
+    stdio.sprintf(filename, "lib%s%s", name_str, lib_ext);
     char[constants.Max_path] fullname; // TODO use string_buffer?
 
     if (!m.find_file(fullname, filename)) {

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,5 @@
 echo 'setting C2 environment'
-export C2_LIBDIR=~/c2_libs
-export C2_PLUGINDIR=~/c2_plugins
+export C2_LIBDIR=$PWD/c2_libs
+export C2_PLUGINDIR=$PWD/c2_plugins
 export CC=clang
-export CXX=clang++
 #complete -W '-a -A -b -c -C -d -f -h -m -q -Q -r -s -S -t -T -v --check --create --fast --help --help-recipe --showlibs --showplugins --targets --test' c2c

--- a/generator/c_generator.c2
+++ b/generator/c_generator.c2
@@ -86,11 +86,6 @@ type Generator struct {
 
     // to filter exceptions
     u32 stdargName;
-    bool isDarwinStdio;
-    u32 stdioName;
-    u32 stdinName;
-    u32 stdoutName;
-    u32 stderrName;
 
     Module* mod;
 
@@ -526,29 +521,6 @@ fn bool Generator.emitGlobalVarDecl(Generator* gen, string_buffer.Buf* out, Decl
     VarDecl* vd = cast<VarDecl*>(d);
 
     QualType qt = d.getType();
-
-    if (gen.isDarwinStdio) {
-        // Darwin workaround, since it defines stdin/out/err as #define stdin __stdinp, etc
-        u32 name = d.getNameIdx();
-        if (name == gen.stdinName) {
-            out.add("#define stdin __stdinp\n");
-            out.add("extern FILE* __stdinp;\n");
-            out.newline();
-            return true;
-        }
-        if (name == gen.stdoutName) {
-            out.add("#define stdout __stdoutp\n");
-            out.add("extern FILE* __stdoutp;\n");
-            out.newline();
-            return true;
-        }
-        if (name == gen.stderrName) {
-            out.add("#define stderr __stderrp\n");
-            out.add("extern FILE* __stderrp;\n");
-            out.newline();
-            return true;
-        }
-    }
 
     // emit 'simple'-constants as a defines
     if (emitAsDefine(vd)) {
@@ -1102,8 +1074,6 @@ fn void Generator.on_module(void* arg, Module* m) {
         out.print("\n// --- module %s ---\n", gen.mod_name);
     }
 
-    gen.isDarwinStdio = (m.getNameIdx() == gen.stdioName) && gen.targetInfo.sys == target_info.System.Darwin;
-
     // Note: special case for stdarg.h va_list
     if (m.getNameIdx() == gen.stdargName) {
         if (gen.fast_build) out = gen.header;
@@ -1184,10 +1154,6 @@ fn void Generator.init(Generator* gen,
     gen.decls.init(16);
 
     gen.stdargName = astPool.addStr("stdarg", true);
-    gen.stdioName = astPool.addStr("stdio", true);
-    gen.stdinName = astPool.addStr("stdin", true);
-    gen.stdoutName = astPool.addStr("stdout", true);
-    gen.stderrName = astPool.addStr("stderr", true);
 }
 
 fn void Generator.free(Generator* gen) {
@@ -1299,7 +1265,7 @@ public fn void build(const char* output_dir)
     i32 retval = process_utils.run_args(dir, "make", LogFile, "-j");
     if (retval != 0) {
         console.error("error during external C compilation");
-        console.log("see %s%s for defails", dir, LogFile);
+        console.log("see %s%s for details", dir, LogFile);
     }
 }
 

--- a/generator/c_generator_special.c2
+++ b/generator/c_generator_special.c2
@@ -25,6 +25,7 @@ import file_utils;
 import module_list;
 import string_buffer;
 import string_list;
+import target_info;
 
 import string;
 import stdio;
@@ -144,12 +145,20 @@ fn void Generator.createMakefile(Generator* gen,
         break;
     case DynamicLibrary:
         out.add("CFLAGS+=-fPIC\n");
-        stdio.sprintf(target_name, "lib%s.so", gen.target);
+        if (gen.targetInfo.sys == target_info.System.Darwin) {
+            stdio.sprintf(target_name, "lib%s.dylib", gen.target);
+        } else {
+            stdio.sprintf(target_name, "lib%s.so", gen.target);
+        }
         out.print("all: ../%s\n\n", target_name);
 
         out.print("../%s: $(objects) $(headers)\n", target_name);
-	    out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s -Wl,-soname,%s.1 -Wl,--version-script=exports.version $(LDFLAGS2)\n",
-            target_name, target_name);
+        if (gen.targetInfo.sys == target_info.System.Darwin) {
+            out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s $(LDFLAGS2)\n", target_name);
+        } else {
+            out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s -Wl,-soname,%s.1 -Wl,--version-script=exports.version $(LDFLAGS2)\n",
+                      target_name, target_name);
+        }
         break;
     }
 

--- a/install_plugins.sh
+++ b/install_plugins.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
+if [ $(uname -s) = 'Darwin' ] ; then
+   LIB_EXT='.dylib'
+else
+   LIB_EXT='.so'
+fi
 set -e
 mkdir -p $C2_PLUGINDIR
-cp output/deps_generator/libdeps_generator.so $C2_PLUGINDIR
-cp output/git_version/libgit_version.so $C2_PLUGINDIR
-cp output/load_file/libload_file.so $C2_PLUGINDIR
-cp output/refs_generator/librefs_generator.so $C2_PLUGINDIR
-cp output/shell_cmd/libshell_cmd.so $C2_PLUGINDIR
-cp output/unit_test/libunit_test.so $C2_PLUGINDIR
-strip $C2_PLUGINDIR/*.so
+cp output/deps_generator/libdeps_generator$LIB_EXT $C2_PLUGINDIR
+cp output/git_version/libgit_version$LIB_EXT $C2_PLUGINDIR
+cp output/load_file/libload_file$LIB_EXT $C2_PLUGINDIR
+cp output/refs_generator/librefs_generator$LIB_EXT $C2_PLUGINDIR
+cp output/shell_cmd/libshell_cmd$LIB_EXT $C2_PLUGINDIR
+cp output/unit_test/libunit_test$LIB_EXT $C2_PLUGINDIR
+if [ $(uname -s) != 'Darwin' ] ; then
+   strip $C2_PLUGINDIR/*$LIB_EXT
+fi


### PR DESCRIPTION
bootstrap:
* keep intermediary target **c2c_bootstrap2**
* add **globals.c** to help port C library constants and structures
* add patch file for Darwin arm64 target
* add rebuild **Makefile** target to update **bootstrap.c** and patch files

common/target_info.c2:
* use `"arm64"` instead of `"arm_64"` in `Info.arch_names`
* add `Info.system_define`, `arch_define`, and `target_define` for C library source preprocessing.

generator/:
* adjust dynamic library link command
* remove `darwinStdio` hack

compiler:
* add target architecture defines for C library source preprocessing:
 - `SYSTEM_DARWIN` / `SYSTEM_LINUX`...
 - `ARCH_ARM64` / `ARCH_X86_64`...
 - `TARGET_DARWIN_ARM64` / `TARGET_LINUX_X86_64`...
* select library file extension based on target architecture
* add `char* target_triple` in `Option struct`
* add `--target` option to override recipe target configuration

* update bootstrap/bootstrap.c

closes #127