### PR TITLE
Fix undefined behavior on UTF-8 contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+C2C:=output/c2c/c2c
+
+all: $(C2C)
+	@$(C2C)
+
+c2c: $(C2C)
+	@$(C2C) c2c
+
+$(C2C): bootstrap/bootstrap.c
+	make -B -C bootstrap
+
+output/tester/tester: tools/tester/*.c2 $(C2C)
+	@$(C2C) tester
+
+rebuild-bootstrap: $(C2C)
+	@$(C2C) --test c2c
+	mv -f output/c2c/cgen/build.c bootstrap/bootstrap.c
+
+test: output/tester/tester
+	@output/tester/tester -t test
+
+warnings:
+	grep -n '[[]-W' `find . -name build.log`
+
+clean:
+	make -C bootstrap clean
+	rm -rf output

--- a/ast_utils/string_pool.c2
+++ b/ast_utils/string_pool.c2
@@ -158,12 +158,13 @@ Case_I56:
 // 0 left
 // 1 right
 // 2 =
+// XXX: this comparison is inconsistent with strcmp
 fn u32 compare(const char* left, const char* right, usize rlen) {
     u32 i = 0;
     while (i < rlen) {
         char l = left[i];
         char r = right[i];
-        char c = l - r;
+        i32 c = l - r;
         if (c < 0) return 1;
         if (c > 0) return 0;
         i++;

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -1,7 +1,7 @@
 # This makefile is auto-generated, any modifications will be lost
 
 CC=gcc
-CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch -Wno-char-subscripts
+CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch
 CFLAGS+=-Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-zero-length
 CFLAGS+=-pipe -std=c99 -O0 -g
 

--- a/generator/c_generator_special.c2
+++ b/generator/c_generator_special.c2
@@ -58,7 +58,7 @@ fn void Generator.createMakefile(Generator* gen,
 
     out.print("CC=%s\n", cc);
 
-    out.add("CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch -Wno-char-subscripts\n");
+    out.add("CFLAGS=-Wall -Wextra -Wno-unused -Wno-switch\n");
     out.add("CFLAGS+=-Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-zero-length\n");
     out.add("CFLAGS+=-pipe -std=c99\n");
     if (gen.fast_build) out.add("CFLAGS+=-O0 -g\n");

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -223,7 +223,7 @@ type Action enum u8 {
     INVALID,
 }
 
-const Action[128] Char_lookup = {
+const Action[256] Char_lookup = {
 // 0 - 15
    [  0]  = Action.EOF,
    ['\t'] = Action.TABSPACE,
@@ -331,7 +331,7 @@ const Action[128] Char_lookup = {
     ['~'] = Action.TILDE,
 }
 
-const u8[128] Identifier_char = {
+const u8[256] Identifier_char = {
     ['0'] = 1,
     ['1'] = 1,
     ['2'] = 1,
@@ -408,7 +408,7 @@ fn const Keyword* check_keyword(const char* cp) {
             char a = kw[idx];
             char b = word[idx];
             if (a == 0) {
-                if (!Identifier_char[b]) return &table[i];
+                if (!Identifier_char[cast<u8>(b)]) return &table[i];
                 break;
             }
             if (a != b) {
@@ -487,11 +487,13 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
     // TODO if end/error stop (dont retry) (t.done = 1)
 
     while (1) {
-        if (t.cur[0] < 0) {
+        if (t.cur[0] & 0x80) {
+            // FIXME: should use higher slots of Char_lookup array
+            // FIXME: should accept BOM (EF BB BF) at start of file?
             t.error(result, "Unicode (UTF-8) is only allowed inside string literals or comments");
             return;
         }
-        Action act = Char_lookup[*t.cur];
+        Action act = Char_lookup[cast<u8>(*t.cur)];
         switch (act) {
         case TABSPACE:
             t.cur++;
@@ -841,7 +843,7 @@ fn void Tokenizer.lex_identifier(Tokenizer* t, Token* result) {
     result.loc = t.loc_start + cast<SrcLoc>(t.cur - t.input_start);
     const char* start = t.cur;
     const char* end = t.cur + 1;
-    while (Identifier_char[*end]) end++;
+    while (Identifier_char[cast<u8>(*end)]) end++;
 
     usize len = cast<usize>(end - start);
     if (len > constants.MaxIdentifierLen) {
@@ -1216,7 +1218,7 @@ fn bool compare_word(const char* cur, const char* expect) {
         cur++;
         expect++;
     }
-    return !Identifier_char[*cur];
+    return !Identifier_char[cast<u8>(*cur)];
 }
 
 // return true if we pass result
@@ -1345,7 +1347,7 @@ fn bool Tokenizer.handle_if(Tokenizer* t, Token* result) {
     t.cur++;    // just skip space
 
     bool enabled = false;
-    Action act = Char_lookup[*t.cur];
+    Action act = Char_lookup[cast<u8>(*t.cur)];
     switch (act) {
     case INVALID:
         t.error(result, "invalid char '%c'", *t.cur);
@@ -1376,7 +1378,7 @@ fn bool Tokenizer.handle_if(Tokenizer* t, Token* result) {
 
 fn bool Tokenizer.parse_feature(Tokenizer* t, Token* result, bool* enabled) {
     const char* start = t.cur;
-    while (Identifier_char[*t.cur]) t.cur++;
+    while (Identifier_char[cast<u8>(*t.cur)]) t.cur++;
 
     usize len = cast<usize>(t.cur - start);
     if (len > constants.MaxFeatureName) {
@@ -1429,7 +1431,7 @@ fn bool Tokenizer.handle_endif(Tokenizer* t, Token* result) {
 
 fn bool Tokenizer.skip_feature(Tokenizer* t, Token* result) {
     while (1) {
-        Action act = Char_lookup[*t.cur];
+        Action act = Char_lookup[cast<u8>(*t.cur)];
         switch (act) {
         case INVALID:
             t.cur++;

--- a/test/parser/utf8-2.c2
+++ b/test/parser/utf8-2.c2
@@ -1,0 +1,6 @@
+// @warnings{no-unused}
+module test;
+
+i32 Totoé = 1; // @error{Unicode (UTF-8) is only allowed inside string literals or comments}
+
+public i32 main() { return 0; }


### PR DESCRIPTION
* cast `char` index values as `u8` to avoid indexing with negative values on invalid UTF-8 contents
* extend `Identifier_char` and `Char_lookup` arrays to 256 entries
* enable C warning `-Wchar-subscript` (no effect on c2c operation but often an indication of a programming error
* add test for invalid UTF-8 contents in identifier