### PR TITLE
improve number parser

### DIFF
--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -73,29 +73,29 @@ public fn bool IntegerLiteral.isSigned(const IntegerLiteral* e) {
 }
 
 fn void printBinary(string_buffer.Buf* out, u64 value) {
-    char[64] tmp;
-    tmp[63] = 0;
-    char* cp = &tmp[62];
-    while (value) {
-        *cp = '0' + (value & 0x1);
-        cp--;
+    char[1+(64+2-1)/2+1] tmp;
+    char* cp = &tmp[elemsof(tmp) - 1];
+    *cp = '\0';
+    for (;;) {
+        *--cp = '0' + (value & 0x1);
         value /= 2;
+        if (value == 0)
+            break;
     }
-    *cp-- = 'b';
-    *cp = '0';
+    *--cp = 'b';
+    *--cp = '0';
     out.add(cp);
 }
 
 fn void printOctal(string_buffer.Buf* out, u64 value) {
-    char[32] tmp;
-    tmp[31] = 0;
-    char* cp = &tmp[30];
+    char[1+(64+3-1)/3+1] tmp;
+    char* cp = &tmp[elemsof(tmp) - 1];
+    *cp = '\0';
     while (value) {
-        *cp = '0' + (value & 0x7);
-        cp--;
+        *--cp = '0' + (value & 0x7);
         value /= 8;
     }
-    *cp = '0';
+    *--cp = '0';
     out.add(cp);
 }
 
@@ -114,6 +114,7 @@ public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffe
         printBinary(out, e.val);
         break;
     case 8:
+        // FIXME: incorrect for negative values
         printOctal(out, e.val);
         break;
     case 10:

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -126,7 +126,12 @@ fn void Parser.consumeToken(Parser* p) {
 
     // p.dump_token(&p.tok);
 
-    if (p.tok.kind == Kind.Error) p.error("%s", p.tok.error_msg);
+    if (p.tok.has_error) {
+        if (p.tok.kind == Kind.Error)
+            p.error("%s", p.tok.error_msg);
+        p.diags.error(p.tok.loc, "%s", p.tokenizer.error_msg);
+        p.tok.has_error = false;
+    }
 }
 
 fn void Parser.expectAndConsume(Parser* p, Kind kind) {

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -24,6 +24,7 @@ import token local;
 
 import string;
 import stdlib;
+import c_errno local;
 import ctype local;
 import stdarg local;
 
@@ -621,6 +622,8 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
                     t.cur++;
                     result.kind = Kind.Range;
                 }
+            } else if (isdigit(t.cur[0])) {
+                t.lex_number(result);
             } else {
                 result.kind = Kind.Dot;
             }
@@ -828,13 +831,27 @@ public fn u32 Tokenizer.get_indent(const Tokenizer* t, const Token* tok) {
 fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
     Va_list args;
     va_start(args, format);
-    vsnprintf(t.error_msg, sizeof(t.error_msg)-1, format, args);
+    vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
     va_end(args);
 
     result.loc = t.loc_start + cast<SrcLoc>(t.cur - t.input_start);
     result.kind = Kind.Error;
     result.error_msg = t.error_msg;
     result.more = false;
+    result.has_error = true;
+}
+
+// generate an error but keep parsing
+fn void Tokenizer.num_error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
+    Va_list args;
+    va_start(args, format);
+    vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
+    va_end(args);
+
+    result.loc = t.loc_start + cast<SrcLoc>(t.cur - t.input_start);
+    result.has_error = true;
+    while ((*t.cur & 0x80) || isalnum(*t.cur) || (*t.cur == '_'))
+        t.cur++;
 }
 
 fn void Tokenizer.lex_identifier(Tokenizer* t, Token* result) {
@@ -869,83 +886,122 @@ fn bool is_binary(char c) {
 }
 
 fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
+    // FIXME: handle embedded '_'
     result.kind = Kind.IntegerLiteral;
+    result.radix = 10;
+    result.int_value = 0;
     result.loc = t.loc_start + cast<SrcLoc>(t.cur - t.input_start);
-    const char* start;
+    const char* start = t.cur;
 
     if (t.cur[0] == '0') {
         if (t.cur[1] == 'x') {  // hexadecimal
             result.radix = 16;
             t.cur += 2;
-            start = t.cur;
-            while (isxdigit(*t.cur)) t.cur++;
-            if (isalpha(*t.cur)) {
-                t.error(result, "invalid character '%c' in hexadecimal constant", *t.cur);
-                return;
-            }
-            // TODO check max length
-            result.int_value = stdlib.strtoull(start, nil, 16);
-            return;
-        }
-        if (is_octal(t.cur[1])) { // octal
-            result.radix = 8;
-            t.cur++;
-            start = t.cur;
-            while (is_octal(*t.cur)) t.cur++;
             if (isxdigit(*t.cur)) {
-                t.error(result, "invalid digit '%c' in octal constant", *t.cur);
+                t.cur++;
+                while (isxdigit(*t.cur)) t.cur++;
+                if (*t.cur == 'p' || (*t.cur == '.' && t.cur[1] != '.')) {
+                    t.lex_floating_point_hex(result, start);
+                    return;
+                }
+            } else {
+                if (*t.cur == '.' && t.cur[1] != '.' && isxdigit(t.cur[1])) {
+                    t.lex_floating_point_hex(result, start);
+                    return;
+                }
+            }
+            if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
+                t.num_error(result, "invalid character '%c' in hexadecimal constant", *t.cur);
                 return;
             }
-            result.int_value = stdlib.strtoull(start, nil, 8);
-            // TODO check max length
+            if (t.cur == start + 2) {
+                t.num_error(result, "missing digits in hexadecimal constant");
+                return;
+            }
+            *errno2() = 0;
+            result.int_value = stdlib.strtoull(start + 2, nil, 16);
+            if (*errno2()) {
+                t.num_error(result, "integer literal is too large to be represented in any integer type");
+                return;
+            }
             return;
         }
         if (t.cur[1] == 'b') {   // binary
             result.radix = 2;
             t.cur += 2;
-            start = t.cur;
             while (is_binary(*t.cur)) t.cur++;
             if (isdigit(*t.cur)) {
-                t.error(result, "invalid digit '%c' in binary constant", *t.cur);
+                t.num_error(result, "invalid digit '%c' in binary constant", *t.cur);
                 return;
             }
-            result.int_value = stdlib.strtoull(start, nil, 2);
-            // TODO check max length
+            if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
+                t.num_error(result, "invalid character '%c' in binary constant", *t.cur);
+                return;
+            }
+            if (t.cur == start + 2) {
+                t.num_error(result, "missing digits in binary constant");
+                return;
+            }
+            *errno2() = 0;
+            result.int_value = stdlib.strtoull(start + 2, nil, 2);
+            if (*errno2()) {
+                t.num_error(result, "integer literal is too large to be represented in any integer type");
+                return;
+            }
             return;
         }
+        // FIXME: should support 0o1234
 
-        if (t.cur[1] == '.' && t.cur[2] != '.') {  // floating point, handle 'case 1..2:'
-            t.cur++;    // skip until .
-            t.lex_floating_point(result, t.cur);
-            return;
-        }
-
-        // case for decimal 0
-        if (isdigit(t.cur[1])) {
-            t.error(result, "decimal numbers may not start with a 0");
-            return;
-        }
-
+        const char *non_octal = nil;
         t.cur++;
-        result.radix = 10;
-        result.int_value = 0;
+        while (is_octal(*t.cur)) t.cur++;
+        if (isdigit(*t.cur)) {
+            non_octal = t.cur;
+            while (isdigit(*t.cur)) t.cur++;
+        }
+        if (*t.cur == 'e' || (*t.cur == '.' && t.cur[1] != '.')) {
+            t.lex_floating_point(result, start);
+            return;
+        }
+        if (non_octal) {
+            t.cur = non_octal;
+            t.num_error(result, "invalid digit '%c' in octal constant", *t.cur);
+            return;
+        }
+        if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
+            t.num_error(result, "invalid character '%c' in octal constant", *t.cur);
+            return;
+        }
+        if (t.cur > start + 1) {
+            result.radix = 8;
+            *errno2() = 0;
+            result.int_value = stdlib.strtoull(start + 1, nil, 8);
+            if (*errno2()) {
+                t.num_error(result, "integer literal is too large to be represented in any integer type");
+                return;
+            }
+        }
+        // value is 0, radix = 10
         return;
     }
-    result.radix = 10;
-    start = t.cur;
+
     while (isdigit(*t.cur)) t.cur++;
 
-    if (t.cur[0] == '.' && t.cur[1] != '.') {   // handle 'case 1..2:'
+    if (*t.cur == 'e' || (*t.cur == '.' && t.cur[1] != '.')) {
         t.lex_floating_point(result, start);
         return;
     }
-    // TODO could be float
+
+    if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
+        t.num_error(result, "invalid character '%c' in decimal constant", *t.cur);
+        return;
+    }
 
     u32 len = cast<u32>(t.cur - start);
     if (len >= 20) {
         if (len > 20 || string.strncmp(start, "18446744073709551615", 20) > 0) {
             t.cur -= len;
-            t.error(result, "integer literal is too large to be represented in any integer type");
+            t.num_error(result, "integer literal is too large to be represented in any integer type");
             return;
         }
     }
@@ -953,14 +1009,59 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
 }
 
 fn void Tokenizer.lex_floating_point(Tokenizer* t, Token* result, const char* start) {
-    // Note: t.cur is on '.', start points to start of entire float
-    t.cur++; // skip '.'
+    // FIXME: handle embedded '_'
     result.kind = Kind.FloatLiteral;
+    result.float_value = 0;
     result.loc = t.loc_start + cast<SrcLoc>(start - t.input_start);
-    result.float_value = stdlib.strtod(start, nil);
-
-    // TODO also handle exponent (eg. 1234e+4)
+    // Note: t.cur is on '.' or 'e', start points to start of entire float
+    t.cur += (*t.cur == '.');
     while (isdigit(*t.cur)) t.cur++;
+    // FIXME: should check for 'E' and either accept it or reject explicitly
+    if (*t.cur == 'e') {
+        t.cur++;
+        if (*t.cur == '+' || *t.cur == '-')
+            t.cur++;
+        if (!isdigit(*t.cur)) {
+            t.num_error(result, "invalid exponent in floating point constant");
+            return;
+        }
+        while (isdigit(*t.cur)) t.cur++;
+    }
+    if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
+        t.num_error(result, "invalid character '%c' in floating point constant", *t.cur);
+        return;
+    }
+    result.float_value = stdlib.strtod(start, nil);
+}
+
+fn void Tokenizer.lex_floating_point_hex(Tokenizer* t, Token* result, const char* start) {
+    // FIXME: handle embedded '_'
+    result.kind = Kind.FloatLiteral;
+    result.float_value = 0;
+    result.loc = t.loc_start + cast<SrcLoc>(start - t.input_start);
+    // Note: t.cur is on '.' or 'p', start points to start of entire float
+    t.cur += (*t.cur == '.');
+    while (isxdigit(*t.cur)) t.cur++;
+    // FIXME: should check for 'P' and either accept it or reject explicitly
+    if (*t.cur == 'p') {
+        t.cur++;
+        if (*t.cur == '+' || *t.cur == '-')
+            t.cur++;
+        if (!isdigit(*t.cur)) {
+            t.num_error(result, "invalid exponent in floating point constant");
+            return;
+        }
+        while (isdigit(*t.cur)) t.cur++;
+    } else {
+        t.num_error(result, "hexadecimal floating constant requires an exponent");
+        return;
+    }
+    if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
+        t.num_error(result, "invalid character '%c' in floating point constant", *t.cur);
+        return;
+    }
+    // FIXME: do not use strtod() on platforms that do not support the syntax
+    result.float_value = stdlib.strtod(start, nil);
 }
 
 // Returns how much to shift in source code (0 = error)

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -279,6 +279,7 @@ public type Token struct {
     SrcLoc loc;
     Kind kind;
     bool more;
+    bool has_error;
     u8 radix;   // for IntegerLiteral (2,8,10,16) and CharLiteral
     union {
         const char* error_msg;  // ERROR

--- a/test/literals/init_int8.c2
+++ b/test/literals/init_int8.c2
@@ -1,11 +1,71 @@
 // @warnings{no-unused}
 module test;
 
-i8 a =  127;
-i8 b = -128;
-i8 c =  128;   // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
-i8 d = -129;   // @error{constant value -129 out-of-bounds for type 'i8', range [-128, 127]}
-i8 e = -(-128); // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
-i8 f = 'z';
-i8 g = 'z' + 10; // @error{constant value 132 out-of-bounds for type 'i8', range [-128, 127]}
+i8[] dd = {
+    127,
+    -128,
+    128,   // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
+    -129,   // @error{constant value -129 out-of-bounds for type 'i8', range [-128, 127]}
+    -(-128), // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
+    'z',
+    'z' + 10, // @error{constant value 132 out-of-bounds for type 'i8', range [-128, 127]}
+}
 
+i8[] bb = {
+    0b0,
+    0b1,
+    0b1111111,
+    0b10000000, // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
+    0b10000001, // @error{constant value 129 out-of-bounds for type 'i8', range [-128, 127]}
+    0b1111111111111111111111111111111111111111111111111111111111111111, // @error{constant value 18446744073709551615 out-of-bounds for type 'i8', range [-128, 127]}
+    -0b0,
+    -0b1,
+    -0b1111111,
+    -0b10000000,
+    -0b10000001, // @error{constant value -129 out-of-bounds for type 'i8', range [-128, 127]}
+    -0b1111111111111111111111111111111111111111111111111111111111111111, // &error{constant value -18446744073709551615 out-of-bounds for type 'i8', range [-128, 127]}
+}
+
+i8[] oo = {
+    0,
+    00,
+    000,
+    01,
+    001,
+    07,
+    007,
+    0177,
+    0200, // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
+    0377, // @error{constant value 255 out-of-bounds for type 'i8', range [-128, 127]}
+    0777777777777777777777, // @error{constant value 9223372036854775807 out-of-bounds for type 'i8', range [-128, 127]}
+    01000000000000000000000, // @error{constant value 9223372036854775808 out-of-bounds for type 'i8', range [-128, 127]}
+    01777777777777777777777, // @error{constant value 18446744073709551615 out-of-bounds for type 'i8', range [-128, 127]}
+    -0,
+    -00,
+    -000,
+    -01,
+    -001,
+    -07,
+    -007,
+    -0177,
+    -0200,
+    -0377, // @error{constant value -255 out-of-bounds for type 'i8', range [-128, 127]}
+    -0777777777777777777777, // @error{constant value -9223372036854775807 out-of-bounds for type 'i8', range [-128, 127]}
+    -01000000000000000000000, // @error{constant value -9223372036854775808 out-of-bounds for type 'i8', range [-128, 127]}
+    -01777777777777777777777, // &error{constant value -18446744073709551615 out-of-bounds for type 'i8', range [-128, 127]}
+}
+
+i8[] xx = {
+    0x0,
+    0x1,
+    0x7f,
+    0x80, // @error{constant value 128 out-of-bounds for type 'i8', range [-128, 127]}
+    0x81, // @error{constant value 129 out-of-bounds for type 'i8', range [-128, 127]}
+    0xffffffffffffffff, // @error{constant value 18446744073709551615 out-of-bounds for type 'i8', range [-128, 127]}
+    -0x0,
+    -0x1,
+    -0x7f,
+    -0x80,
+    -0x81, // @error{constant value -129 out-of-bounds for type 'i8', range [-128, 127]}
+    -0xffffffffffffffff, // &error{constant value -18446744073709551615 out-of-bounds for type 'i8', range [-128, 127]}
+}

--- a/test/literals/invalid_numbers.c2
+++ b/test/literals/invalid_numbers.c2
@@ -1,0 +1,120 @@
+// @warnings{no-unused}
+module test;
+
+u64[] a = {
+    0b, // @error{missing digits in binary constant}
+    0b2, // @error{invalid digit '2' in binary constant}
+    0bz, // @error{invalid character 'z' in binary constant}
+    0b02, // @error{invalid digit '2' in binary constant}
+    0b0z, // @error{invalid character 'z' in binary constant}
+    0b1111111111111111111111111111111111111111111111111111111111111111,
+    0b0000001111111111111111111111111111111111111111111111111111111111111111,
+    0b10000000000000000000000000000000000000000000000000000000000000000, // @error{integer literal is too large to be represented in any integer type}
+
+    1a, // @error{invalid character 'a' in decimal constant}
+    1z, // @error{invalid character 'z' in decimal constant}
+    18446744073709551615,
+    18446744073709551616, // @error{integer literal is too large to be represented in any integer type}
+    99999999999999999999, // @error{integer literal is too large to be represented in any integer type}
+
+    08, // @error{invalid digit '8' in octal constant}
+    008, // @error{invalid digit '8' in octal constant}
+    09, // @error{invalid digit '9' in octal constant}
+    009, // @error{invalid digit '9' in octal constant}
+    0a, // @error{invalid character 'a' in octal constant}
+    00a, // @error{invalid character 'a' in octal constant}
+    0z, // @error{invalid character 'z' in octal constant}
+    00z, // @error{invalid character 'z' in octal constant}
+    0800000000000000000000, // @error{invalid digit '8' in octal constant}
+    01777777777777777777777,
+    02000000000000000000000, // @error{integer literal is too large to be represented in any integer type}
+
+    0x, // @error{missing digits in hexadecimal constant}
+    0xg, // @error{invalid character 'g' in hexadecimal constant}
+    0xz, // @error{invalid character 'z' in hexadecimal constant}
+    0x0g, // @error{invalid character 'g' in hexadecimal constant}
+    0x0z, // @error{invalid character 'z' in hexadecimal constant}
+    0xffffffffffffffff,
+    0x10000000000000000, // @error{integer literal is too large to be represented in any integer type}
+}
+
+f64[] ff = {
+    0e1,
+    1e1,
+    0e+1,
+    1e-1,
+    0.e1,
+    1.e1,
+    0.e+1,
+    1.e-1,
+    00e1,
+    01e1,
+    00e+1,
+    01e-1,
+    00.e1,
+    01.e1,
+    00.e-1,
+    01.e+1,
+    0.,
+    1.,
+    00.,
+    01.,
+    0.a,  // @error{invalid character 'a' in floating point constant}
+    1.a,  // @error{invalid character 'a' in floating point constant}
+    0.x,  // @error{invalid character 'x' in floating point constant}
+    1.x,  // @error{invalid character 'x' in floating point constant}
+    0.p,  // @error{invalid character 'p' in floating point constant}
+    1.p,  // @error{invalid character 'p' in floating point constant}
+    0.e,  // @error{invalid exponent in floating point constant}
+    1.e,  // @error{invalid exponent in floating point constant}
+    0.e+,  // @error{invalid exponent in floating point constant}
+    1.e-,  // @error{invalid exponent in floating point constant}
+    0.ex,  // @error{invalid exponent in floating point constant}
+    0.e+x,  // @error{invalid exponent in floating point constant}
+    1.e-x,  // @error{invalid exponent in floating point constant}
+    0.e1x,  // @error{invalid character 'x' in floating point constant}
+    0.e+1x,  // @error{invalid character 'x' in floating point constant}
+    1.e-1x,  // @error{invalid character 'x' in floating point constant}
+#if 1
+    0x.1,  // @error{hexadecimal floating constant requires an exponent}
+    0x.0,  // @error{hexadecimal floating constant requires an exponent}
+    0x1.,  // @error{hexadecimal floating constant requires an exponent}
+    0x0.,  // @error{hexadecimal floating constant requires an exponent}
+    0xp1,  // @error{invalid character 'p' in hexadecimal constant}
+    0xp0,  // @error{invalid character 'p' in hexadecimal constant}
+    0x.p1, // @error{missing digits in hexadecimal constant}
+    0x.p0, // @error{missing digits in hexadecimal constant}
+    0x1.p0,
+    0x0.p1,
+    0x0.p,  // @error{invalid exponent in floating point constant}
+    0x0.p+,  // @error{invalid exponent in floating point constant}
+    0x0.p-,  // @error{invalid exponent in floating point constant}
+    0x0.px,  // @error{invalid exponent in floating point constant}
+    0x0.p+x,  // @error{invalid exponent in floating point constant}
+    0x0.p-x,  // @error{invalid exponent in floating point constant}
+    0x0.p1,
+    0x0.p+1,
+    0x0.p-1,
+    0x0.p1x,  // @error{invalid character 'x' in floating point constant}
+    0x0.p+1x,  // @error{invalid character 'x' in floating point constant}
+    0x0.p-1x,  // @error{invalid character 'x' in floating point constant}
+#endif
+    0x0p1,
+    0x1p1,
+    0x.0p1,
+    0x.1p1,
+    0x0.p1,
+    0x1.p1,
+    0x00p1,
+    0x01p1,
+    0x00.p1,
+    0x01.p1,
+#if 1
+    .0e1,
+    .1e1,
+    .0e+1,
+    .1e-1,
+    .0,
+    .1,
+#endif
+}

--- a/tools/tester/issues.c2
+++ b/tools/tester/issues.c2
@@ -31,7 +31,7 @@ public type Iter struct {
     u32 idx;
 }
 
-fn const char* relativeFilename(const char *name) {
+public fn const char* relativeFilename(const char *name) {
     char[512] buffer;
     char* path = unistd.getcwd(buffer, sizeof(buffer));
     if (path && path[1]) {

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -197,16 +197,15 @@ fn void Db.matchError(Db* db, const char* filename, i32 linenr, const char* msg)
     const char* match = db.errors.find(filename, linenr);
     if (match) {
         if (!same_string(match, msg)) {
-            color_print2(db.output, colError, "  wrong error at %s:%d:", filename, linenr);
+            color_print2(db.output, colError, "%s:%d: wrong error: %s", relativeFilename(filename), linenr, msg);
             color_print2(db.output, colError, "     expected: %s", match);
-            color_print2(db.output, colError, "     got: %s", msg);
             db.hasErrors = true;
         }
         db.errors.erase(filename, linenr);
         return;
     }
     // not expected
-    color_print2(db.output, colError, "  unexpected error on line %d: %s", linenr, msg);
+    color_print2(db.output, colError, "%s:%d: unexpected error: %s", relativeFilename(filename), linenr, msg);
     db.hasErrors = true;
 }
 


### PR DESCRIPTION
tester:
output standard error messages
add invalid number tests
add more conversion tests

compiler:
fix `printBinary` output for `0b0`
fix buffer lengths in `printBinary` and `printOctal` add support for hex floats
add missing float syntax
detect invalid syntax for integers and floating point constants detect values beyond 64-bit range for all integer syntaxes