### PR TITLE
lexer: accept _ as digit separator in number literals

### DIFF
--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -24,7 +24,7 @@ import token local;
 
 import string;
 import stdlib;
-import c_errno local;
+import c2 local;
 import ctype local;
 import stdarg local;
 
@@ -845,16 +845,29 @@ fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf
 }
 
 // generate an error but keep parsing
-fn void Tokenizer.num_error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
+fn void Tokenizer.num_error(Tokenizer* t, Token* result, const char* p, const char* format @(printf_format), ...) {
     Va_list args;
     va_start(args, format);
     vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
     va_end(args);
 
-    result.loc = t.loc_start + cast<SrcLoc>(t.cur - t.input_start);
+    result.loc = t.loc_start + cast<SrcLoc>(p - t.input_start);
     result.has_error = true;
-    while ((*t.cur & 0x80) || isalnum(*t.cur) || (*t.cur == '_'))
-        t.cur++;
+    // read the rest of the pp-number token
+    for (;;) {
+        if ((*p == 'e' || *p == 'E' || *p == 'p' || *p == 'P') && (p[1] == '+' || p[1] == '-')) {
+            p += 2;
+        } else
+        if (*p == '\'' && isalnum(p[1])) {
+            p += 2;
+        } else
+        if (isalnum(*p) || *p == '_' || (*p == '.' && p[1] != '.')) {
+            p++;
+        } else {
+            break;
+        }
+    }
+    t.cur = p;
 }
 
 fn void Tokenizer.lex_identifier(Tokenizer* t, Token* result) {
@@ -876,8 +889,8 @@ fn void Tokenizer.lex_identifier(Tokenizer* t, Token* result) {
 
 fn u8 hex2val(char c) {
     if (c >= '0' && c <= '9') return cast<u8>(c - '0');
-    if (c >= 'a' && c <= 'f') return cast<u8>(c - 'a');
-    return cast<u8>(c - 'A');
+    if (c >= 'a' && c <= 'f') return cast<u8>(c - 'a' + 10);
+    return cast<u8>(c - 'A' + 10);
 }
 
 fn bool is_octal(char c) {
@@ -888,183 +901,258 @@ fn bool is_binary(char c) {
     return (c >= '0' && c <= '1');
 }
 
+fn void Tokenizer.lex_number_error(Tokenizer* t, Token* result, const char *p, const char *qual) {
+    if (isdigit(*p)) {
+        t.num_error(result, p, "invalid digit '%c' in %s constant", *p, qual);
+        return;
+    }
+    if (*p == '_') {
+        t.num_error(result, p, "digit separator '%c' not surrounded by digits", *p);
+        return;
+    }
+    if (isalpha(*p)) {
+        t.num_error(result, p, "invalid character '%c' in %s constant", *p, qual);
+        return;
+    }
+    t.num_error(result, p, "missing digits in %s constant", qual);
+}
+
 fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
-    // FIXME: handle embedded '_'
     result.kind = Kind.IntegerLiteral;
     result.radix = 10;
     result.int_value = 0;
     result.loc = t.loc_start + cast<SrcLoc>(t.cur - t.input_start);
     const char* start = t.cur;
+    const char* p = start;
+    u64 value = 0;
+    bool overflow = false;
 
-    if (t.cur[0] == '0') {
-        if (t.cur[1] == 'x') {  // hexadecimal
+    if (p[0] == '0') {
+        if (p[1] == 'x' || p[1] == 'X') {  // hexadecimal
             result.radix = 16;
-            t.cur += 2;
-            if (isxdigit(*t.cur)) {
-                t.cur++;
-                while (isxdigit(*t.cur)) t.cur++;
-                if (*t.cur == 'p' || (*t.cur == '.' && t.cur[1] != '.')) {
+            p += 2;
+            if (isxdigit(*p)) {
+                while (isxdigit(*p)) {
+                    if (value > max_u64 >> 4) {
+                        value = max_u64;
+                        overflow = true;
+                    } else {
+                        value = (value << 4) + hex2val(*p);
+                    }
+                    p++;
+                    if (*p == '_' && isxdigit(p[1]))
+                        p++;
+                }
+                if (*p == 'p' || *p == 'P' || (*p == '.' && p[1] != '.')) {
                     t.lex_floating_point_hex(result, start);
                     return;
                 }
             } else {
-                if (*t.cur == '.' && t.cur[1] != '.' && isxdigit(t.cur[1])) {
+                if (*p == '.' && p[1] != '.' && isxdigit(p[1])) {
                     t.lex_floating_point_hex(result, start);
                     return;
                 }
             }
-            if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
-                t.num_error(result, "invalid character '%c' in hexadecimal constant", *t.cur);
+            if (*p == '_' || isalpha(*p) || p == start + 2) {
+                t.lex_number_error(result, p, "hexadecimal");
                 return;
             }
-            if (t.cur == start + 2) {
-                t.num_error(result, "missing digits in hexadecimal constant");
-                return;
-            }
-            *errno2() = 0;
-            result.int_value = stdlib.strtoull(start + 2, nil, 16);
-            if (*errno2()) {
-                t.num_error(result, "integer literal is too large to be represented in any integer type");
-                return;
-            }
-            return;
+            goto check_overflow;
         }
-        if (t.cur[1] == 'b') {   // binary
+        if (p[1] == 'b' || p[1] == 'B') {   // binary
             result.radix = 2;
-            t.cur += 2;
-            while (is_binary(*t.cur)) t.cur++;
-            if (isdigit(*t.cur)) {
-                t.num_error(result, "invalid digit '%c' in binary constant", *t.cur);
+            p += 2;
+            while (is_binary(*p)) {
+                if (value > max_u64 >> 1) {
+                    value = max_u64;
+                    overflow = true;
+                } else {
+                    value = (value << 1) + (*p - '0');
+                }
+                p++;
+                if (*p == '_' && isdigit(p[1]))
+                    p++;
+            }
+            if (*p == '_' || isalnum(*p) || p == start + 2) {
+                t.lex_number_error(result, p, "binary");
                 return;
             }
-            if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
-                t.num_error(result, "invalid character '%c' in binary constant", *t.cur);
-                return;
-            }
-            if (t.cur == start + 2) {
-                t.num_error(result, "missing digits in binary constant");
-                return;
-            }
-            *errno2() = 0;
-            result.int_value = stdlib.strtoull(start + 2, nil, 2);
-            if (*errno2()) {
-                t.num_error(result, "integer literal is too large to be represented in any integer type");
-                return;
-            }
-            return;
+            goto check_overflow;
         }
         // FIXME: should support 0o1234
 
-        const char *non_octal = nil;
-        t.cur++;
-        while (is_octal(*t.cur)) t.cur++;
-        if (isdigit(*t.cur)) {
-            non_octal = t.cur;
-            while (isdigit(*t.cur)) t.cur++;
+        while (is_octal(*p)) {
+            if (value > max_u64 >> 3) {
+                value = max_u64;
+                overflow = true;
+            } else {
+                value = (value << 3) + (*p - '0');
+            }
+            p++;
+            if (*p == '_' && isdigit(p[1]))
+                p++;
         }
-        if (*t.cur == 'e' || (*t.cur == '.' && t.cur[1] != '.')) {
+        const char *p0 = p;
+        if (isdigit(*p)) {
+            // skip digits to check for floating point constant
+            while (isdigit(*p) || (*p == '_' && isdigit(p[1])))
+                p++;
+        }
+        if (*p == 'e' || *p == 'E' || (*p == '.' && p[1] != '.')) {
             t.lex_floating_point(result, start);
             return;
         }
-        if (non_octal) {
-            t.cur = non_octal;
-            t.num_error(result, "invalid digit '%c' in octal constant", *t.cur);
+        p = p0;
+        if (*p == '_' || isalnum(*p)) {
+            t.lex_number_error(result, p, "octal");
             return;
         }
-        if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
-            t.num_error(result, "invalid character '%c' in octal constant", *t.cur);
+        t.cur = p;
+        if (p == start + 1) {
+            // value is 0, radix = 10
             return;
         }
-        if (t.cur > start + 1) {
-            result.radix = 8;
-            *errno2() = 0;
-            result.int_value = stdlib.strtoull(start + 1, nil, 8);
-            if (*errno2()) {
-                t.num_error(result, "integer literal is too large to be represented in any integer type");
-                return;
-            }
-        }
-        // value is 0, radix = 10
-        return;
+        result.radix = 8;
+        goto check_overflow;
     }
 
-    while (isdigit(*t.cur)) t.cur++;
-
-    if (*t.cur == 'e' || (*t.cur == '.' && t.cur[1] != '.')) {
+    while (isdigit(*p)) {
+        // ugly cast because u8 digit = *p++ - '0'; generates an error
+        u32 digit = cast<u32>(*p++ - '0');
+        if (value >= max_u64 / 10 && (value > max_u64 / 10 || digit > max_u64 % 10)) {
+            value = max_u64;
+            overflow = true;
+        } else {
+            value = value * 10 + digit;
+        }
+        if (*p == '_' && isdigit(p[1]))
+            p++;
+    }
+    if (*p == 'e' || *p == 'E' || (*p == '.' && p[1] != '.')) {
         t.lex_floating_point(result, start);
         return;
     }
-
-    if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
-        t.num_error(result, "invalid character '%c' in decimal constant", *t.cur);
+    if (*p == '_' || isalpha(*p)) {
+        t.lex_number_error(result, p, "decimal");
         return;
     }
-
-    u32 len = cast<u32>(t.cur - start);
-    if (len >= 20) {
-        if (len > 20 || string.strncmp(start, "18446744073709551615", 20) > 0) {
-            t.cur -= len;
-            t.num_error(result, "integer literal is too large to be represented in any integer type");
-            return;
-        }
+check_overflow:
+    t.cur = p;
+    result.int_value = value;
+    if (overflow) {
+        t.num_error(result, p, "integer literal is too large to be represented in any integer type");
+        return;
     }
-    result.int_value = stdlib.strtoull(start, nil, 10);
 }
 
 fn void Tokenizer.lex_floating_point(Tokenizer* t, Token* result, const char* start) {
-    // FIXME: handle embedded '_'
+    char[4096] buf;
+    const char* p = start;
+    usize pos = 0;
+    u8 seen_dot = 0;
+    result.loc = t.loc_start + cast<SrcLoc>(start - t.input_start);
     result.kind = Kind.FloatLiteral;
     result.float_value = 0;
-    result.loc = t.loc_start + cast<SrcLoc>(start - t.input_start);
-    // Note: t.cur is on '.' or 'e', start points to start of entire float
-    t.cur += (*t.cur == '.');
-    while (isdigit(*t.cur)) t.cur++;
-    // FIXME: should check for 'E' and either accept it or reject explicitly
-    if (*t.cur == 'e') {
-        t.cur++;
-        if (*t.cur == '+' || *t.cur == '-')
-            t.cur++;
-        if (!isdigit(*t.cur)) {
-            t.num_error(result, "invalid exponent in floating point constant");
+    for (;;) {
+        if (!isdigit(*p)) {
+            if (*p == '_' && isdigit(p[1]))
+                p++;
+            else
+            if (*p != '.' || seen_dot++)
+                break;
+        }
+        buf[pos++] = *p++;
+        if (pos == elemsof(buf))
+            goto too_large;
+    }
+    if (*p == 'e' || *p == 'E') {
+        if (pos >= elemsof(buf) - 2)
+            goto too_large;
+        buf[pos++] = *p++;
+        if (*p == '+' || *p == '-')
+            buf[pos++] = *p++;
+        if (!isdigit(*p)) {
+            t.num_error(result, p, "invalid exponent in floating point constant");
             return;
         }
-        while (isdigit(*t.cur)) t.cur++;
+        while (isdigit(*p)) {
+            buf[pos++] = *p++;
+            if (pos == elemsof(buf))
+                goto too_large;
+            if (*p == '_' && isdigit(p[1]))
+                p++;
+        }
     }
-    if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
-        t.num_error(result, "invalid character '%c' in floating point constant", *t.cur);
+    if (*p == '_' || isalpha(*p)) {
+        t.lex_number_error(result, p, "floating point");
         return;
     }
-    result.float_value = stdlib.strtod(start, nil);
+    t.cur = p;
+    buf[pos] = '\0';
+    result.float_value = stdlib.strtod(buf, nil);
+    return;
+too_large:
+    t.num_error(result, p, "floating point constant too large");
+    return;
 }
 
 fn void Tokenizer.lex_floating_point_hex(Tokenizer* t, Token* result, const char* start) {
-    // FIXME: handle embedded '_'
+    char[4096] buf;
+    const char* p = start;
+    usize pos = 0;
+    u8 seen_dot = 0;
+    result.loc = t.loc_start + cast<SrcLoc>(start - t.input_start);
     result.kind = Kind.FloatLiteral;
     result.float_value = 0;
-    result.loc = t.loc_start + cast<SrcLoc>(start - t.input_start);
-    // Note: t.cur is on '.' or 'p', start points to start of entire float
-    t.cur += (*t.cur == '.');
-    while (isxdigit(*t.cur)) t.cur++;
-    // FIXME: should check for 'P' and either accept it or reject explicitly
-    if (*t.cur == 'p') {
-        t.cur++;
-        if (*t.cur == '+' || *t.cur == '-')
-            t.cur++;
-        if (!isdigit(*t.cur)) {
-            t.num_error(result, "invalid exponent in floating point constant");
+    if (*p == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        buf[pos++] = *p++;
+        buf[pos++] = *p++;
+    }
+    for (;;) {
+        if (!isxdigit(*p)) {
+            if (*p == '_' && isxdigit(p[1]))
+                p++;
+            else
+            if (*p != '.' || seen_dot++)
+                break;
+        }
+        buf[pos++] = *p++;
+        if (pos == elemsof(buf))
+            goto too_large;
+    }
+    if (*p == 'p' || *p == 'P') {
+        if (pos >= elemsof(buf) - 2)
+            goto too_large;
+        buf[pos++] = *p++;
+        if (*p == '+' || *p == '-')
+            buf[pos++] = *p++;
+        if (!isdigit(*p)) {
+            t.num_error(result, p, "invalid exponent in floating point constant");
             return;
         }
-        while (isdigit(*t.cur)) t.cur++;
+        while (isdigit(*p)) {
+            buf[pos++] = *p++;
+            if (pos == elemsof(buf))
+                goto too_large;
+            if (*p == '_' && isdigit(p[1]))
+                p++;
+        }
     } else {
-        t.num_error(result, "hexadecimal floating constant requires an exponent");
+        t.num_error(result, p, "hexadecimal floating constant requires an exponent");
         return;
     }
-    if ((*t.cur & 0x80) || isalpha(*t.cur) || *t.cur == '_') {
-        t.num_error(result, "invalid character '%c' in floating point constant", *t.cur);
+    if (*p == '_' || isalpha(*p)) {
+        t.lex_number_error(result, p, "floating point");
         return;
     }
+    t.cur = p;
+    buf[pos] = '\0';
     // FIXME: do not use strtod() on platforms that do not support the syntax
-    result.float_value = stdlib.strtod(start, nil);
+    result.float_value = stdlib.strtod(buf, nil);
+    return;
+too_large:
+    t.num_error(result, p, "floating point constant too large");
+    return;
 }
 
 // Returns how much to shift in source code (0 = error)

--- a/test/literals/invalid_numbers.c2
+++ b/test/literals/invalid_numbers.c2
@@ -5,14 +5,17 @@ u64[] a = {
     0b, // @error{missing digits in binary constant}
     0b2, // @error{invalid digit '2' in binary constant}
     0bz, // @error{invalid character 'z' in binary constant}
+    0b_, // @error{digit separator '_' not surrounded by digits}
     0b02, // @error{invalid digit '2' in binary constant}
     0b0z, // @error{invalid character 'z' in binary constant}
+    0b0_, // @error{digit separator '_' not surrounded by digits}
     0b1111111111111111111111111111111111111111111111111111111111111111,
     0b0000001111111111111111111111111111111111111111111111111111111111111111,
     0b10000000000000000000000000000000000000000000000000000000000000000, // @error{integer literal is too large to be represented in any integer type}
 
     1a, // @error{invalid character 'a' in decimal constant}
     1z, // @error{invalid character 'z' in decimal constant}
+    1_, // @error{digit separator '_' not surrounded by digits}
     18446744073709551615,
     18446744073709551616, // @error{integer literal is too large to be represented in any integer type}
     99999999999999999999, // @error{integer literal is too large to be represented in any integer type}
@@ -25,6 +28,8 @@ u64[] a = {
     00a, // @error{invalid character 'a' in octal constant}
     0z, // @error{invalid character 'z' in octal constant}
     00z, // @error{invalid character 'z' in octal constant}
+    0_, // @error{digit separator '_' not surrounded by digits}
+    00_, // @error{digit separator '_' not surrounded by digits}
     0800000000000000000000, // @error{invalid digit '8' in octal constant}
     01777777777777777777777,
     02000000000000000000000, // @error{integer literal is too large to be represented in any integer type}
@@ -32,11 +37,22 @@ u64[] a = {
     0x, // @error{missing digits in hexadecimal constant}
     0xg, // @error{invalid character 'g' in hexadecimal constant}
     0xz, // @error{invalid character 'z' in hexadecimal constant}
+    0x_, // @error{digit separator '_' not surrounded by digits}
     0x0g, // @error{invalid character 'g' in hexadecimal constant}
     0x0z, // @error{invalid character 'z' in hexadecimal constant}
+    0x0_, // @error{digit separator '_' not surrounded by digits}
     0xffffffffffffffff,
+    0x0000ffffffffffffffff,
     0x10000000000000000, // @error{integer literal is too large to be represented in any integer type}
 }
+
+static_assert(18446744073709551615, 0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111);
+static_assert(18446744073709551615, 0b000000_11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111);
+static_assert(18446744073709551615, 18_446_744_073_709_551_615);
+static_assert(18446744073709551615, 01_777_777_777_777_777_777_777);
+static_assert(18446744073709551615, 0_000_001_777_777_777_777_777_777_777);
+static_assert(18446744073709551615, 0xffff_ffff_ffff_ffff);
+static_assert(18446744073709551615, 0x00_00_ff_ff_ff_ff_ff_ff_ff_ff);
 
 f64[] ff = {
     0e1,
@@ -63,6 +79,8 @@ f64[] ff = {
     1.a,  // @error{invalid character 'a' in floating point constant}
     0.x,  // @error{invalid character 'x' in floating point constant}
     1.x,  // @error{invalid character 'x' in floating point constant}
+    0._,  // @error{digit separator '_' not surrounded by digits}
+    1._,  // @error{digit separator '_' not surrounded by digits}
     0.p,  // @error{invalid character 'p' in floating point constant}
     1.p,  // @error{invalid character 'p' in floating point constant}
     0.e,  // @error{invalid exponent in floating point constant}
@@ -70,12 +88,18 @@ f64[] ff = {
     0.e+,  // @error{invalid exponent in floating point constant}
     1.e-,  // @error{invalid exponent in floating point constant}
     0.ex,  // @error{invalid exponent in floating point constant}
+    0.e_,  // @error{invalid exponent in floating point constant}
     0.e+x,  // @error{invalid exponent in floating point constant}
+    0.e+_,  // @error{invalid exponent in floating point constant}
     1.e-x,  // @error{invalid exponent in floating point constant}
+    1.e-_,  // @error{invalid exponent in floating point constant}
     0.e1x,  // @error{invalid character 'x' in floating point constant}
+    0.e1_,  // @error{digit separator '_' not surrounded by digits}
     0.e+1x,  // @error{invalid character 'x' in floating point constant}
+    0.e+1_,  // @error{digit separator '_' not surrounded by digits}
     1.e-1x,  // @error{invalid character 'x' in floating point constant}
-#if 1
+    1.e-1_,  // @error{digit separator '_' not surrounded by digits}
+#if 1   // hexadecimal floats
     0x.1,  // @error{hexadecimal floating constant requires an exponent}
     0x.0,  // @error{hexadecimal floating constant requires an exponent}
     0x1.,  // @error{hexadecimal floating constant requires an exponent}
@@ -90,15 +114,20 @@ f64[] ff = {
     0x0.p+,  // @error{invalid exponent in floating point constant}
     0x0.p-,  // @error{invalid exponent in floating point constant}
     0x0.px,  // @error{invalid exponent in floating point constant}
+    0x0.p_,  // @error{invalid exponent in floating point constant}
     0x0.p+x,  // @error{invalid exponent in floating point constant}
+    0x0.p+_,  // @error{invalid exponent in floating point constant}
     0x0.p-x,  // @error{invalid exponent in floating point constant}
+    0x0.p-_,  // @error{invalid exponent in floating point constant}
     0x0.p1,
     0x0.p+1,
     0x0.p-1,
     0x0.p1x,  // @error{invalid character 'x' in floating point constant}
+    0x0.p1_,  // @error{digit separator '_' not surrounded by digits}
     0x0.p+1x,  // @error{invalid character 'x' in floating point constant}
+    0x0.p+1_,  // @error{digit separator '_' not surrounded by digits}
     0x0.p-1x,  // @error{invalid character 'x' in floating point constant}
-#endif
+    0x0.p-1_,  // @error{digit separator '_' not surrounded by digits}
     0x0p1,
     0x1p1,
     0x.0p1,
@@ -109,12 +138,17 @@ f64[] ff = {
     0x01p1,
     0x00.p1,
     0x01.p1,
-#if 1
+#endif
+#if 1   // floats with leading .
     .0e1,
     .1e1,
     .0e+1,
     .1e-1,
     .0,
     .1,
+#endif
+#if 1   // floats with embedded _
+    1_0.2_3_4e+1_0,
+    0x1_a.b_3_4p+1_0,
 #endif
 }


### PR DESCRIPTION
* fix `hex2val()` for alpha hex digits
* convert integer literals on the fly, no longer use `stdlib.strtoull`
* simplify number parsing, factorize error reporting
* add tests