### PR TITLE
parser: fix declaration detection in for initial clause

### DIFF
--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -584,6 +584,7 @@ fn bool Parser.isDeclaration(Parser* p) {
     if (kind == Kind.Identifier) return p.isTypeSpec();
     if (kind >= Kind.KW_bool && kind <= Kind.KW_void) return true;
     if (kind == Kind.KW_local) return true;
+    if (kind == Kind.KW_const || kind == Kind.KW_volatile) return true;
     return false;
 }
 

--- a/test/stmt/for_const.c2
+++ b/test/stmt/for_const.c2
@@ -1,0 +1,7 @@
+module test;
+
+public fn i32 main() {
+    for (const char *p = "abc"; *p; p++) {}
+    for (volatile char *p = "abc"; *p; p++) {}
+    return 0;
+}


### PR DESCRIPTION
* Allow local definition to start with `const` or `volatile` keyword
* add tests