### PR TITLE
string_pool: improve hash table handling

### DIFF
--- a/ast_utils/string_pool.c2
+++ b/ast_utils/string_pool.c2
@@ -19,7 +19,21 @@ import string;
 import stdlib;
 import stdio;
 
-const u32 HASH_TABLE_SIZE = 256;
+#if 1
+/* 32-bit pools can store up to 32K unique string for a combined length of 512KB */
+type HashEntry u32;
+const u32 NEXT_SHIFT = 17;
+const u32 INDEX_BITS = (1 << NEXT_SHIFT) - 1;
+const u32 INDEX_SHIFT = 2;
+const u32 DATA_ALIGN = 1 << INDEX_SHIFT;
+#else
+/* 64-bit pools can store up to 4G unique string for a combined length of 4GB */
+type HashEntry u64;
+const u32 NEXT_SHIFT = 32;
+const u64 INDEX_BITS = 0xffffffff;
+const u32 INDEX_SHIFT = 0;
+const u32 DATA_ALIGN = 1 << INDEX_SHIFT;
+#endif
 
 public type Pool struct @(opaque) {
     u32 data_size;      // number of bytes used
@@ -31,25 +45,36 @@ public type Pool struct @(opaque) {
     u32 total_size;     // total size that would have been allocated without filtering
 
     // Hashtable
-    u8[HASH_TABLE_SIZE] entry_count;    // Note: max 256 entries per hash
+    u32 hash_count;
+    u32 hash_mask;
+    u32 entry_size;     // index of the first available entry after hash table
     u32 entry_capacity;
-    // just make all entries the same size (entry_capacity)
-    u32* entries;   // can be nil, contain indexes of all strings, entry_capacity*HASH_TABLE_SIZE
+    HashEntry* entries; // contain hash table followed by collision lists
 }
-static_assert(296, sizeof(Pool));
+static_assert(48, sizeof(Pool));
 
-public fn Pool* create(u32 data_capacity, u32 hash_capacity) {
+public fn Pool* create(u32 data_capacity, u32 hash_size) {
     Pool* p = stdlib.calloc(1, sizeof(Pool));
     p.resize_data(data_capacity);
     p.data[0] = 0;
-    p.data_size = 1; // skip 1 (used to store empty strings)
+    p.data_size = DATA_ALIGN; // store empty string at index 0
 
-    p.entries = nil;
-    string.memset(p.entry_count, 0, sizeof(p.entry_count));
-    p.entry_capacity = hash_capacity;
-    if (hash_capacity) {
-        p.resize_hash(hash_capacity);
+    /* round hash_capacity to the next power of 2, at least 256 */
+    if (hash_size & (hash_size - 1)) {
+        hash_size |= hash_size >> 16;
+        hash_size |= hash_size >> 8;
+        hash_size |= hash_size >> 4;
+        hash_size |= hash_size >> 2;
+        hash_size |= hash_size >> 1;
+        hash_size += 1;
     }
+    if (hash_size < 256)
+        hash_size = 256;
+    /* allocate empty hash table with extra space for collision lists */
+    p.hash_mask = hash_size - 1;
+    p.entry_size = hash_size;
+    p.entry_capacity = hash_size * 2;
+    p.entries = stdlib.calloc(p.entry_capacity, sizeof(HashEntry));
 
     return p;
 }
@@ -70,7 +95,7 @@ fn u32 hash(const char* text, usize len) {
         result = result ^ text[i];
         result *= HASH_PRIME;
     }
-    return result % HASH_TABLE_SIZE;
+    return result;
 }
 
 public fn const char* Pool.getStart(const Pool* p) { return p.data; }
@@ -79,46 +104,48 @@ public fn const char* Pool.idx2str(const Pool* p, u32 idx) {
     return p.data + idx;
 }
 
-// NOTE: right is NOT 0-terminated!
-// 0 left
-// 1 right
-// 2 equal
-fn u32 compare(const char* left, const char* right, usize rlen) {
-    u32 i = 0;
-    while (i < rlen) {
-        char l = left[i];
-        char r = right[i];
-        i32 c = l - r;
-        if (c < 0) return 1;
-        if (c > 0) return 0;
-        i++;
+// NOTE: right might NOT be 0-terminated!
+fn bool same_string(const char* left, const char* right, usize rlen) {
+    // cannot use memcmp because rlen bytes might not be accessible from left
+    for (u32 i = 0; i < rlen; i++) {
+        if (left[i] != right[i])
+            return false;
     }
-    if (left[rlen] == 0) return 2;
-    return 0;
+    return (left[rlen] == '\0');
 }
-
 
 // NOTE: text is not 0-terminated!! len is strlen(text)
 public fn u32 Pool.add(Pool* p, const char* text, usize len, bool filter) {
     p.num_adds++;
-    p.total_size += len;
+    p.total_size += len + 1;
 
     if (filter) {
-        u32 hashcode = hash(text, len);
-        u8 count = p.entry_count[hashcode];
-        u32* indexes = &p.entries[hashcode * p.entry_capacity];
-        for (u32 i=0; i<count; i++) {
-            const char* word = p.data + indexes[i];
-            if (compare(word, text, len) == 2) {
-                return indexes[i];
+        usize i = hash(text, len) & p.hash_mask;
+        HashEntry v = p.entries[i];
+        if (v != 0) {
+            HashEntry next;
+            /* scan the list */
+            for (;;) {
+                u32 index = (v & INDEX_BITS) << INDEX_SHIFT;
+                const char* word = p.data + index;
+                if (same_string(word, text, len))
+                    return index;
+                next = v >> NEXT_SHIFT;
+                if (next == 0)
+                    break;
+                i = next;
+                v = p.entries[i];
             }
+            next = p.entry_size;
+            if (next == p.entry_capacity) {
+                p.resize_entries(p.entry_capacity * 2);
+            }
+            p.entries[i] = v | (next << NEXT_SHIFT);
+            p.entry_size++;
+            i = next;
         }
-        if (count == p.entry_capacity) {
-            p.resize_hash(p.entry_capacity * 2);
-            indexes = &p.entries[hashcode * p.entry_capacity];
-        }
-        indexes[count] = p.data_size; // will be inserted here
-        p.entry_count[hashcode]++;
+        p.entries[i] = (p.data_size >> INDEX_SHIFT);
+        p.hash_count++;
     }
 
     while (p.data_size + len + 1 > p.data_capacity) {
@@ -133,10 +160,10 @@ public fn u32 Pool.add(Pool* p, const char* text, usize len, bool filter) {
         }
     }
     u32 idx = p.data_size;
-    char* dest = p.data + p.data_size;
+    char* dest = p.data + idx;
     string.memcpy(dest, text, len);
     dest[len] = 0;
-    p.data_size += len + 1;
+    p.data_size += len / DATA_ALIGN * DATA_ALIGN + DATA_ALIGN;
     //assert(p.data_size <= p.data_capacity);
     return idx;
 }
@@ -155,12 +182,10 @@ fn void Pool.resize_data(Pool* p, u32 capacity) {
     p.data = data2;
 }
 
-fn void Pool.resize_hash(Pool* p, u32 capacity) {
-    u32* entries = stdlib.malloc(capacity * sizeof(u32) * HASH_TABLE_SIZE);
+fn void Pool.resize_entries(Pool* p, u32 capacity) {
+    HashEntry* entries = stdlib.malloc(capacity * sizeof(HashEntry));
     if (p.entries) {
-        for (u32 i=0; i<HASH_TABLE_SIZE; i++) {
-            string.memcpy(&entries[i*capacity], &p.entries[i*p.entry_capacity], p.entry_count[i]*sizeof(u32));
-        }
+        string.memcpy(entries, p.entries, p.entry_size * sizeof(HashEntry));
         stdlib.free(p.entries);
     }
     p.entry_capacity = capacity;
@@ -170,21 +195,38 @@ fn void Pool.resize_hash(Pool* p, u32 capacity) {
 public fn void Pool.report(const Pool* p) {
     u32 max = 0;
     u32 min = 999;
+    u32 hash_size = p.hash_mask + 1;
     u32 count = 0;
-    for (u32 i=0; i<HASH_TABLE_SIZE; i++) {
-        u32 num = p.entry_count[i];
-        count += num;
-        if (num) {
-            if (num > max) max = num;
-            if (num < min) min = num;
-            //stdio.printf("[%4d] %d\n", i, num);
+    u32[256] cc = {}
+    for (u32 i = 0; i < hash_size; i++) {
+        HashEntry v = p.entries[i];
+        if (v != 0) {
+            u32 num = 1;
+            while (v >> NEXT_SHIFT) {
+                num++;
+                v = p.entries[v >> NEXT_SHIFT];
+            }
+            count += num;
+            if (num < 256) cc[num]++;
+            if (num) {
+                if (num > max) max = num;
+                if (num < min) min = num;
+                //stdio.printf("[%4d] %d\n", i, num);
+            }
         }
     }
-    stdio.printf("pool: %d(%d) adds, data %d(%d)/%d bytes\n",
-        count, p.num_adds,
-        p.data_size, p.total_size, p.data_capacity);
+    stdio.printf("pool: count %d, adds %d, data %d/%d\n",
+                 p.hash_count, p.num_adds, p.data_size, p.data_capacity);
 
-    stdio.printf("  hash: %d entries, min %d max %d\n", HASH_TABLE_SIZE, min, max);
+    stdio.printf("  hash: entries: %d/%d/%d/%d, min %d, max %d, avg %.2f, memory %d\n",
+                 hash_size, count, p.entry_size, p.entry_capacity,
+                 min, max, count ? (count + 0.0) / (hash_size - cc[0]) : 0.0,
+                 p.entry_capacity * sizeof(HashEntry));
+    stdio.printf("  buckets: %d", cc[0]);
+    for (u32 i = 1; i <= max; i++)
+        stdio.printf(", %d", cc[i]);
+    stdio.printf("\n");
+
 #if 0
     const char* end = p.data + p.data_size;
     const char* cp = p.data;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -218,7 +218,7 @@ fn void Compiler.build(Compiler* c,
     c.diags.clear();
 
     c.context = ast_context.create(16*1024);
-    c.astPool = string_pool.create(128*1024, 32);
+    c.astPool = string_pool.create(128*1024, 4096);
 
     // Note: keywords must be added first
     c2_keywords.init(&c.kwinfo, c.astPool);

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -341,7 +341,7 @@ public fn i32 main(i32 argc, char** argv) {
     utils.PathInfo path_info = {}
 
     // note: auxPool is used by recipe, build-file and manifests
-    string_pool.Pool* auxPool = string_pool.create(32*1024, 2);
+    string_pool.Pool* auxPool = string_pool.create(32*1024, 256);
     source_mgr.SourceMgr* sm = source_mgr.create(auxPool, constants.Max_open_files);
     diagnostics.Diags* diags = diagnostics.create(sm, color.useColor(), parser_utils.getTokenEnd, &path_info);
     c2recipe.Recipe* recipe = c2recipe.create(sm, auxPool);

--- a/generator/qbe_generator.c2
+++ b/generator/qbe_generator.c2
@@ -507,7 +507,7 @@ fn void Generator.init(Generator* gen,
     gen.out = string_buffer.create(256*1024, false, 1);
     gen.start = string_buffer.create(1024, false, 1);
     gen.globals = string_buffer.create(4*1024, false, 1);
-    gen.names = string_pool.create(16*1024, 16);
+    gen.names = string_pool.create(16*1024, 2048);
     gen.labels.init();
     gen.target = target;
     gen.output_dir = output_dir;

--- a/parser/parser_utils.c2
+++ b/parser/parser_utils.c2
@@ -25,7 +25,7 @@ import token local;
 
 public fn SrcLoc getTokenEnd(const char* input, SrcLoc start) {
     c2_tokenizer.Tokenizer tokenizer;
-    string_pool.Pool* pool = string_pool.create(128, 4);
+    string_pool.Pool* pool = string_pool.create(128, 512);
     string_buffer.Buf* buf = string_buffer.create(1024, 0, false);
     string_list.List features;
     features.init(pool);

--- a/plugins/deps_generator.c2
+++ b/plugins/deps_generator.c2
@@ -372,7 +372,7 @@ public fn void generate(const char* title, const char* output_dir, component.Lis
     gen.imports.init(astPool);
     gen.root.init(0, 3);
     gen.deps_resize(64);
-    gen.pool = string_pool.create(4096, 8);
+    gen.pool = string_pool.create(4096, 1024);
 
     gen.out = gen.root.buf;
     string_buffer.Buf* out = gen.out;

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -226,7 +226,7 @@ public fn i32 main(i32 argc, const char** argv)
         return -1;
     }
 
-    pool = string_pool.create(16*1024, 8);
+    pool = string_pool.create(16*1024, 1024);
     c2_tokenizer.Tokenizer tokenizer;
     string_list.List features;
     input = file.char_data();

--- a/tools/c2loc.c2
+++ b/tools/c2loc.c2
@@ -120,7 +120,7 @@ public fn i32 main(i32 argc, const char** argv)
         }
     }
 
-    pool = string_pool.create(32*1024, 8);
+    pool = string_pool.create(32*1024, 1024);
     sm = source_mgr.create(pool, 8);
     c2recipe.Recipe* recipe = c2recipe.create(sm, pool);
 

--- a/tools/c2tags.c2
+++ b/tools/c2tags.c2
@@ -85,7 +85,7 @@ type Results struct {
 fn void Results.init(Results* r) {
     r.count = 0;
     r.resize(32);
-    r.pool = string_pool.create(4096, 8);
+    r.pool = string_pool.create(4096, 1024);
 }
 
 fn void Results.free(Results* r) {

--- a/tools/common/refs_finder.c2
+++ b/tools/common/refs_finder.c2
@@ -40,7 +40,7 @@ public fn Finder* create(const char* dirname, const char* filename) {
     f.filename = filename;
     f.count = 0;
     f.resize(4);
-    f.pool = string_pool.create(256, 4);
+    f.pool = string_pool.create(256, 512);
     return f;
 }
 


### PR DESCRIPTION
* make hash size configurable at create time
* Pass hash_table size to `string_pool.Pool.create`
* handle collisions using lists instead of flat arrays, this makes hashing more resilient to pathological collisions