### PR TITLE
compiler: improve printf format string support

### DIFF
--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -227,17 +227,30 @@ type FormatAnalyser struct {
     Expr** args;
 }
 
-fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, char letter) {
+fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, i32 stars, char c) {
     FormatAnalyser* fa = context;
     Analyser* ma = fa.ma;
     Expr** args = fa.args;
-    u32 idx = fa.idx;
 
-    if (idx >= fa.num_args) {
+    if (c == '\0') {
+        ma.error(fa.loc + offset, "missing conversion specifier at end of format string");
+        return false;
+    }
+    if (fa.idx + stars >= fa.num_args) {
         ma.error(fa.loc + offset, "too many format specifiers or not enough arguments");
         return false;
     }
-    Expr* arg = args[idx];
+    for (i32 i = 0; i < stars; i++) {
+        Expr* arg = args[fa.idx];
+        QualType qt = arg.getType();
+        qt = qt.getCanonicalType();
+        if (!qt.isInt32()) {
+            // TODO: add cast if other integer type?
+            ma.error(arg.getLoc(), "argument for '*' width/precision specifier must be an i32");
+        }
+        fa.idx++;
+    }
+    Expr* arg = args[fa.idx];
     QualType qt = arg.getType();
     qt = qt.getCanonicalType();
 
@@ -263,7 +276,6 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         }
         BuiltinType* bi = qt.getBuiltinTypeOrNil();
         if (!bi || !bi.isIntegerOrBool()) {
-            char c = fa.format[offset];
             ma.error(arg.getLoc(), "format '%%%c' expects an integer argument", c);
         }
         break;
@@ -271,7 +283,6 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         fa.change_format = true;
         BuiltinType* bi = qt.getBuiltinTypeOrNil();
         if (!bi || !bi.isFloatingPoint()) {
-            char c = fa.format[offset];
             ma.error(arg.getLoc(), "format '%%%c' expects a floating-point argument", c);
         }
         break;
@@ -281,13 +292,19 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         }
         break;
     case Invalid:
-        char c = fa.format[offset];
-        //u32 offset = cast<u32>(cp - format_text) -1;
         switch (c) {
-        case 'i':
+        case 'h':
+        case 'j':
         case 'l':
+        case 't':
+        case 'w':
+        case 'z':
+        case 'L':
+            ma.error(fa.loc + offset, "format length modifier '%c' should be omitted", c);
+            break;
+        case 'i':
         case 'u':
-            ma.error(fa.loc + offset, "invalid format specifier '%%%c', did you mean '%%d'?", c);
+            ma.error(fa.loc + offset, "invalid format specifier '%%%c', should use '%%d'", c);
             break;
         default:
             ma.error(fa.loc + offset, "invalid format specifier '%%%c'", c);

--- a/analyser_utils/printf_utils.c2
+++ b/analyser_utils/printf_utils.c2
@@ -72,79 +72,102 @@ public type Specifier enum u8 {
     Invalid,        // other
 }
 
-// cp points after first %, len is length after first % (so '%d' -> len 1)
-fn Specifier getSpecifier(const char* specifier, u32* len, char* c) {
-    const char* cp = specifier;
-    while (1) {
+// cp points after first %, len is # of characters between % and conversion specifier (so '%d' -> len 0)
+fn Specifier getSpecifier(const char* format, u32* len, i32 *pstars, char* c) {
+    const char* cp = format;
+    Specifier spec = Specifier.Invalid;
+    i32 stars = 0;
+
+    for (;;) {
+        /* skip optional flags */
         switch (*cp) {
-        case '*':
-            // TODO support %*d -> * is extra arg specifying width
-            assert(0);
-            break;
-        case '%':
-            // only if it is first char
+        case ' ':
+        case '+':
+        case '-':
+        case '#':
+        case '\'':  // non-standard extension
+        case '0':
             cp++;
-            *len = cast<u32>(cp - specifier);
-            if (*len == 1) return Specifier.Other;
-            return Specifier.Invalid;
-        case 'c':
-            *c = *cp;
-            cp++;
-            *len = cast<u32>(cp - specifier);
-            return Specifier.Char;
-        case 'f':
-            *c = *cp;
-            cp++;
-            *len = cast<u32>(cp - specifier);
-            return Specifier.FloatingPoint;
-        case 'p':
-            *c = *cp;
-            cp++;
-            *len = cast<u32>(cp - specifier);
-            return Specifier.Pointer;
-        case 's':
-            *c = *cp;
-            cp++;
-            *len = cast<u32>(cp - specifier);
-            return Specifier.String;
-        case 'd':
-        case 'o':
-        case 'x':
-        case 'X':
-            *c = *cp;
-            cp++;
-            *len = cast<u32>(cp - specifier);
-            return Specifier.Integer;
-        default:
-            if (ctype.isalpha(*cp)) {
-                cp++;
-                *len = cast<u32>(cp - specifier);
-                return Specifier.Invalid;
-            }
-            break;
+            continue;
         }
-        cp++;
+        break;
     }
-    return Specifier.Other;
+    if (*cp == '*') {
+        stars++;
+        cp++;
+    } else {
+        while (ctype.isdigit(*cp)) {
+            cp++;
+        }
+    }
+    if (*cp == '.') {
+        cp++;
+        if (*cp == '*') {
+            stars++;
+            cp++;
+        } else {
+            while (ctype.isdigit(*cp)) {
+                cp++;
+            }
+        }
+    }
+    switch (*c = *cp) {
+    case '%':
+        // only if it is first char
+        if (cp == format)
+            spec = Specifier.Other;
+        break;
+    case 'c':
+        spec = Specifier.Char;
+        break;
+    case 'a':
+    case 'e':
+    case 'f':
+    case 'g':
+    case 'A':
+    case 'E':
+    case 'F':
+    case 'G':
+        spec = Specifier.FloatingPoint;
+        break;
+    case 'p':
+        spec = Specifier.Pointer;
+        break;
+    case 's':
+        spec = Specifier.String;
+        break;
+    case 'b':
+    case 'B':
+    case 'd':
+    case 'o':
+    case 'x':
+    case 'X':
+        spec = Specifier.Integer;
+        break;
+    }
+    *pstars = stars;
+    *len = cast<u32>(cp - format);
+    return spec;
 }
 
-// return whether parseFormat should continue. Letter only for numbers
-public type FormatHandler fn bool (void* arg, Specifier specifier, u32 offset, char letter);
+// return whether parseFormat should continue.
+public type FormatHandler fn bool (void* arg, Specifier specifier, u32 offset, i32 stars, char letter);
 
 public fn bool parseFormat(const char* format, FormatHandler handler, void* arg) {
     const char* cp = format;
     while (*cp) {
-        if (*cp == '%') {
+        if (*cp++ == '%') {
             u32 len = 0;
-            cp++;
+            i32 stars = 0;
             char c = 0;
-            printf_utils.Specifier s = getSpecifier(cp, &len, &c);
-            cp += len -1;
+            Specifier s = getSpecifier(cp, &len, &stars, &c);
+            cp += len;
             if (s != Specifier.Other) {
-                if (!handler(arg, s, cast<u32>(cp - format), c)) return false;
+                if (!handler(arg, s, cast<u32>(cp - format), stars, c))
+                    return false;
             }
+            if (*cp) cp++;
         }
-        cp++;
     }
     return true;
 }

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -324,6 +324,13 @@ public fn bool QualType.isUInt8(const QualType* qt) {
     return bi.isUInt8();
 }
 
+public fn bool QualType.isInt32(const QualType* qt) {
+    const Type* t = qt.getTypeOrNil();
+    if (t.getKind() != TypeKind.Builtin) return false;
+    const BuiltinType* bi = cast<BuiltinType*>(t);
+    return bi.isInt32();
+}
+
 public fn bool QualType.needsCtvInit(const QualType* qt) {
     QualType canon = qt.getCanonicalType();
     const Type* t = canon.getTypeOrNil();

--- a/generator/c_generator_expr.c2
+++ b/generator/c_generator_expr.c2
@@ -355,7 +355,7 @@ const bool[] Size_prefix = {
 }
 
 fn void emitNumberFormat(BuiltinKind kind, char letter, string_buffer.Buf* out) {
-// TODO depends on arch
+    // TODO: use proper prefix depending on target
 #if 0
     if (kind == BuiltinKind.ISize) {
         return;
@@ -365,31 +365,20 @@ fn void emitNumberFormat(BuiltinKind kind, char letter, string_buffer.Buf* out) 
     }
 #endif
     if (Size_prefix[kind]) out.add1('l');
-    switch (letter) {
-    case 'd':
-        if (builtinKind2Signed(kind)) out.add1('d');
-        else out.add1('u');
-        break;
-    case 'f':
-        out.add1('f');
-        break;
-    case 'o':
-        out.add1('o');
-        break;
-    case 'x':
-        out.add1('x');
-        break;
-    case 'X':
-        out.add1('X');
-        break;
-    }
+    if (letter == 'd' && !builtinKind2Signed(kind))
+        letter = 'u';
+    // Assume all supported formats are implemented in the target libc
+    out.add1(letter);
 }
 
-fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, char letter) {
+// TODO: move to generator/c_generator_call.c2
+fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, i32 stars, char c) {
     FormatChanger* fc = context;
 
+    /* copy optional flags, width and precision */
     fc.out.add2(fc.format + fc.last_offset, offset - fc.last_offset);
 
+    fc.idx += stars;
     QualType qt = fc.args[fc.idx].getType();
     qt = qt.getCanonicalType();
     switch (specifier) {
@@ -405,10 +394,10 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
             fc.args[fc.idx].dump();
         }
         assert(bt);
-        emitNumberFormat(bt.getKind(), letter, fc.out);
+        emitNumberFormat(bt.getKind(), c, fc.out);
         break;
     default:
-        fc.out.add1(letter);
+        fc.out.add1(c);
         // no need to change
         break;
     }

--- a/test/attr/printf_integer.c2
+++ b/test/attr/printf_integer.c2
@@ -58,3 +58,54 @@ fn void test5(Enum e) {
     log("%d", Enum.A);
 }
 
+fn void test6(f32 f) {
+    log("%", f); // @error{missing conversion specifier at end of format string}
+}
+
+fn void test7(f32 f) {
+    log("%*f", f, f); // @error{argument for '*' width/precision specifier must be an i32}
+}
+
+fn void test8(i32 i) {
+    log("%hd", i);  // @error{format length modifier 'h' should be omitted}
+}
+
+fn void test9(i32 i) {
+    log("%hhd", i);  // @error{format length modifier 'h' should be omitted}
+}
+
+fn void test10(i32 i) {
+    log("%jd", i);  // @error{format length modifier 'j' should be omitted}
+}
+
+fn void test11(i32 i) {
+    log("%ld", i);  // @error{format length modifier 'l' should be omitted}
+}
+
+fn void test12(i32 i) {
+    log("%lld", i);  // @error{format length modifier 'l' should be omitted}
+}
+
+fn void test13(i32 i) {
+    log("%td", i);  // @error{format length modifier 't' should be omitted}
+}
+
+fn void test14(i32 i) {
+    log("%w32d", i);  // @error{format length modifier 'w' should be omitted}
+}
+
+fn void test15(i32 i) {
+    log("%zd", i);  // @error{format length modifier 'z' should be omitted}
+}
+
+fn void test16(i32 i) {
+    log("%Ld", i);  // @error{format length modifier 'L' should be omitted}
+}
+
+fn void test17(i32 i) {
+    log("%i", i); // @error{invalid format specifier '%i', should use '%d'}
+}
+
+fn void test18(i32 i) {
+    log("%u", i); // @error{invalid format specifier '%u', should use '%d'}
+}

--- a/test/attr/printf_ok.c2
+++ b/test/attr/printf_ok.c2
@@ -10,8 +10,14 @@ fn void test3(i32 a, char* format @(printf_format), ...) { }
 type Fn fn void(char* format @(printf_format), ...);
 
 fn void test4(const char* str, char c) {
+    f64 d = 1.0;
+    i64 i = 1;
+    i32 w = 1;
     test1("no format");
     test1("%s %c %p", str, c, nil);
     test1("test %% %%");
+    test1("%a %A %e %E %f %F %g %G", d, d, d, d, d, d, d, d);
+    test1("%b %B %d %o %x %X", i, i, i, i, i, i);
+    test1("%0#+-1.1d %0#+-*.1d %0#+-1.*d %0#+-*.*d", i, w, i, w, i, w, w, i);
 }
 

--- a/test/attr/printf_prefix.c2
+++ b/test/attr/printf_prefix.c2
@@ -8,7 +8,14 @@ type Foo struct {
 fn void Foo.log(Foo* x, const char* format @(printf_format), ...) { }
 
 fn void test1(Foo* f, const char* str, char c) {
+    f64 d = 1.0;
+    i64 i = 1;
+    i32 w = 1;
     f.log("no format");
     f.log("%s %c %p", str, c, nil);
+    f.log("test %% %%");
+    f.log("%a %A %e %E %f %F %g %G", d, d, d, d, d, d, d, d);
+    f.log("%b %B %d %o %x %X", i, i, i, i, i, i);
+    f.log("%0#+-1.1d %0#+-*.1d %0#+-1.*d %0#+-*.*d", i, w, i, w, i, w, w, i);
 }
 


### PR DESCRIPTION
* parse specifier syntax, including * width and/or precision
* check type `i32` for `*` arguments
* accept %b and %B integer conversion specifiers
* accept %e, %g, %a, %E, %F, %G, %A floatingpoint conversion specifiers
* pass extra info tp `FormatHandler`
* fix undefined behavior on incomplete trailing specifier
* more explicit error messages on invalid conversion specifications
* simplify `emitNumberFormat()`
* add tests