### PR TITLE
libs: improve consistency of vprintf functions

### DIFF
--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -15,6 +15,7 @@
 
 module string_buffer;
 
+import stdio local;
 import stdarg local;
 import stdlib local;
 import string local;

--- a/generator/c_generator.c2
+++ b/generator/c_generator.c2
@@ -1079,10 +1079,6 @@ fn void Generator.on_module(void* arg, Module* m) {
         out.add("#define va_start __builtin_va_start\n");
         out.add("#define va_end __builtin_va_end\n");
         out.newline();
-        out.add("int32_t vdprintf(int32_t fd, const char* format, va_list ap);\n");
-        out.add("int32_t vsprintf(char* str, const char* format, va_list ap);\n");
-        out.add("int32_t vsnprintf(char* str, uint64_t size, const char* format, va_list ap);\n");
-        out.newline();
 
         // set all decls to generated
         m.visitASTs(Generator.ast_mark_generated, arg);

--- a/libs/libc/stdarg.c2i
+++ b/libs/libc/stdarg.c2i
@@ -1,7 +1,6 @@
 module stdarg;
 
 import c2 local;
-import stdio;
 
 // NOTE: because of va_list we generate the C file for this manually in C-generator!
 
@@ -11,10 +10,3 @@ type Va_list struct @(cname="va_list") {
 
 fn void va_start(Va_list ap, const c_char* last);
 fn void va_end(Va_list ap);
-
-fn c_int vprintf(const c_char *format, Va_list __ap);
-fn c_int vfprintf(stdio.FILE* stream, const c_char *format, Va_list __ap);
-
-fn c_int vdprintf(c_int __fd, const c_char* __fmt, Va_list __arg);
-fn c_int vsprintf(c_char* str, const c_char *format, Va_list __ap);
-fn c_int vsnprintf(c_char* str, c_size size, const c_char *format, Va_list __ap);

--- a/libs/libc/stdio.c2i
+++ b/libs/libc/stdio.c2i
@@ -1,6 +1,7 @@
 module stdio;
 
 import c2 local;
+import stdarg local;
 
 // possibilities for the third argument to 'setvbuf'
 const u8 _IOFBF = 0; // fully buffered
@@ -181,3 +182,8 @@ fn c_int fpurge(FILE *);
 //fn c_int vasprintf(c_char**, const c_char*, va_list);
 fn FILE *zopen(const c_char*, const c_char*, c_int);
 
+fn c_int vdprintf(c_int __fd, const c_char *format, Va_list ap);
+fn c_int vfprintf(FILE* stream, const c_char *format, Va_list ap);
+fn c_int vprintf(const c_char* format, Va_list ap);
+fn c_int vsprintf(c_char* str, const c_char *format, Va_list ap);
+fn c_int vsnprintf(c_char* str, c_size size, const c_char *format, Va_list ap);

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -27,7 +27,7 @@ import stdlib;
 import c2 local;
 import ctype local;
 import stdarg local;
-import stdio;
+import stdio local;
 
 public const u32 MaxLookahead = 64;  // must be multiple of 2
 


### PR DESCRIPTION
* move definitions for vdprintf/vsnprintf/vsprintf to stdio.c2i
* add vprintf/vfprintf
* simplify stdarg.c2i and special hack in C generator