### PR TITLE
token: use Radix enum for clarity and efficiency

### DIFF
--- a/ast/char_literal.c2
+++ b/ast/char_literal.c2
@@ -18,18 +18,19 @@ module ast;
 import ast_context;
 import string_buffer;
 import src_loc local;
+import token local;
 
 type CharLiteralBits struct {
     u32 : NumExprBits;
     u32 value : 8;
-    u32 radix : 5;
+    u32 radix : 3;      // token.Radix enum
 }
 
 public type CharLiteral struct @(opaque) {
     Expr base;
 }
 
-public fn CharLiteral* CharLiteral.create(ast_context.Context* c, SrcLoc loc, u8 val, u8 radix) {
+public fn CharLiteral* CharLiteral.create(ast_context.Context* c, SrcLoc loc, u8 val, Radix radix) {
     CharLiteral* e = c.alloc(sizeof(CharLiteral));
     e.base.init(ExprKind.CharLiteral, loc, 1, 1, 0, ValType.RValue);
     e.base.base.charLiteralBits.value = val;
@@ -58,10 +59,10 @@ public fn void CharLiteral.printLiteral(const CharLiteral* e, string_buffer.Buf*
     u8 c = cast<u8>(e.base.base.charLiteralBits.value);
 
     switch (e.base.base.charLiteralBits.radix) {
-    case 8:
+    case Radix.Octal:
         out.print("'\\%o'", c);
         return;
-    case 16:
+    case Radix.Hex:
         out.print("'\\x%02x'", c);
         return;
     default:

--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -18,10 +18,11 @@ module ast;
 import ast_context;
 import string_buffer;
 import src_loc local;
+import token local;
 
 type IntegerLiteralBits struct {
     u32 : NumExprBits;
-    u32 radix : 5;      // in code
+    u32 radix : 3;      // token.Radix enum
     u32 is_signed : 1;
 }
 
@@ -30,7 +31,7 @@ public type IntegerLiteral struct @(opaque) {
     u64 val;
 }
 
-public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc loc, u8 radix, u64 val) {
+public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc loc, Radix radix, u64 val) {
     IntegerLiteral* i = c.alloc(sizeof(IntegerLiteral));
     i.base.init(ExprKind.IntegerLiteral, loc, 1, 1, 0, ValType.RValue);
     i.base.base.integerLiteralBits.radix = radix;
@@ -46,7 +47,7 @@ public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc l
 }
 
 public fn IntegerLiteral* IntegerLiteral.createUnsignedConstant(ast_context.Context* c, SrcLoc loc, u64 val, QualType qt) {
-    IntegerLiteral* i = IntegerLiteral.create(c, loc, 10, val);
+    IntegerLiteral* i = IntegerLiteral.create(c, loc, Radix.Default, val);
     i.base.setCtv();
     i.base.setCtc();
     i.base.setType(qt);
@@ -54,7 +55,7 @@ public fn IntegerLiteral* IntegerLiteral.createUnsignedConstant(ast_context.Cont
 }
 
 public fn IntegerLiteral* IntegerLiteral.createSignedConstant(ast_context.Context* c, SrcLoc loc, i64 val, QualType qt) {
-    IntegerLiteral* i = IntegerLiteral.create(c, loc, 10, cast<u64>(val));
+    IntegerLiteral* i = IntegerLiteral.create(c, loc, Radix.Default, cast<u64>(val));
     i.base.base.integerLiteralBits.is_signed = 1;
     i.base.setCtv();
     i.base.setCtc();
@@ -65,7 +66,7 @@ public fn IntegerLiteral* IntegerLiteral.createSignedConstant(ast_context.Contex
 public fn u64 IntegerLiteral.getValue(const IntegerLiteral* e) { return e.val; }
 
 public fn bool IntegerLiteral.isDecimal(const IntegerLiteral* e) {
-    return e.base.base.integerLiteralBits.radix == 10;
+    return e.base.base.integerLiteralBits.radix == Radix.Default;
 }
 
 public fn bool IntegerLiteral.isSigned(const IntegerLiteral* e) {
@@ -110,14 +111,7 @@ fn void IntegerLiteral.print(const IntegerLiteral* e, string_buffer.Buf* out, u3
 
 public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffer.Buf* out) {
     switch (e.base.base.integerLiteralBits.radix) {
-    case 2:
-        printBinary(out, e.val);
-        break;
-    case 8:
-        // FIXME: incorrect for negative values
-        printOctal(out, e.val);
-        break;
-    case 10:
+    case Radix.Default:
         if (e.base.base.integerLiteralBits.is_signed) {
             i64 sval = cast<i64>(e.val);
             if (sval >= -2147483647 && sval <= 2147483647)
@@ -137,8 +131,15 @@ public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffe
                 out.print("%d", e.val);
         }
         break;
-    case 16:
+    case Radix.Hex:
         out.print("0x%x", e.val);
+        break;
+    case Radix.Octal:
+        // FIXME: incorrect for negative values
+        printOctal(out, e.val);
+        break;
+    case Radix.Binary:
+        printBinary(out, e.val);
         break;
     }
 }

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -24,6 +24,7 @@ import diagnostics;
 import identifier_expr_list;
 import src_loc local;
 import string_pool;
+import token local;
 
 import stdlib local;
 import string;
@@ -883,7 +884,7 @@ public fn IdentifierExpr* Builder.actOnIdentifier(Builder* b, SrcLoc loc, u32 na
     return IdentifierExpr.create(b.context, loc, name);
 }
 
-public fn Expr* Builder.actOnIntegerLiteral(Builder* b, SrcLoc loc, u8 radix, u64 value) {
+public fn Expr* Builder.actOnIntegerLiteral(Builder* b, SrcLoc loc, Radix radix, u64 value) {
     return cast<Expr*>(IntegerLiteral.create(b.context, loc, radix, value));
 }
 
@@ -891,7 +892,7 @@ public fn Expr* Builder.actOnFloatLiteral(Builder* b, SrcLoc loc, f64 value) {
     return cast<Expr*>(FloatLiteral.create(b.context, loc, value));
 }
 
-public fn Expr* Builder.actOnCharLiteral(Builder* b, SrcLoc loc, u8 value, u8 radix) {
+public fn Expr* Builder.actOnCharLiteral(Builder* b, SrcLoc loc, u8 value, Radix radix) {
     return cast<Expr*>(CharLiteral.create(b.context, loc, value, radix));
 }
 

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -317,6 +317,7 @@ fn void Parser.parseOptionalAttributes(Parser* p) {
                 break;
             case IntegerLiteral:
                 a.value_kind = attr.ValueKind.Number;
+                // TODO: either check overflow or make it 64-bit
                 a.value.number = cast<u32>(p.tok.int_value);
                 p.consumeToken();
                 break;
@@ -706,6 +707,7 @@ fn void Parser.parseFullTypeIdentifier(Parser* p, TypeRefHolder* ref) {
     }
 }
 
+// TODO: should be a Tokenizer function
 fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
     if (is_keyword(tok.kind)) {
         printf("%s%12s%s  %6d %s",
@@ -720,24 +722,37 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
         break;
     case IntegerLiteral:
         switch (tok.radix) {
-        case 16:
-            printf("  (%d) %s0x%x%s", tok.radix, color.Cyan, tok.int_value, color.Normal);
+        case Hex:
+            printf("  %s0x%x%s", color.Cyan, tok.int_value, color.Normal);
+            break;
+        case Octal:
+            printf("  %s0%o%s", color.Cyan, tok.int_value, color.Normal);
+            break;
+        case Binary:
+            printf("  %s0b%b%s", color.Cyan, tok.int_value, color.Normal);
             break;
         default:
-            printf("  (%d) %s%d%s", tok.radix, color.Cyan, tok.int_value, color.Normal);
+            printf("  %s%d%s", color.Cyan, tok.int_value, color.Normal);
             break;
         }
         break;
     case FloatLiteral:
-        printf("  (%d) %s%f%s", tok.radix, color.Cyan, tok.float_value, color.Normal);
+        switch (tok.radix) {
+        case Hex:
+            printf("  %s%a%s", color.Cyan, tok.float_value, color.Normal);
+            break;
+        default:
+            printf("  %s%f%s", color.Cyan, tok.float_value, color.Normal);
+            break;
+        }
         break;
     case CharLiteral:
         switch (tok.radix) {
-        case 8:
-            printf("  %s'\\%o'%s", color.Cyan, tok.char_value, color.Normal);
-            break;
-        case 16:
+        case Hex:
             printf("  %s'\\x%02x'%s", color.Cyan, tok.char_value, color.Normal);
+            break;
+        case Octal:
+            printf("  %s'\\%o'%s", color.Cyan, tok.char_value, color.Normal);
             break;
         default:
             if (isprint(tok.char_value)) {

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -743,7 +743,7 @@ fn void Tokenizer.lex_number_error(Tokenizer* t, Token* result, const char *p, c
 
 fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
     result.kind = Kind.IntegerLiteral;
-    result.radix = 10;
+    result.radix = Radix.Default;
     result.int_value = 0;
     const char* start = t.cur;
     const char* p = start;
@@ -752,7 +752,7 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
 
     if (p[0] == '0') {
         if (p[1] == 'x' || p[1] == 'X') {  // hexadecimal
-            result.radix = 16;
+            result.radix = Radix.Hex;
             p += 2;
             if (isxdigit(*p)) {
                 while (isxdigit(*p)) {
@@ -783,7 +783,7 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
             goto check_overflow;
         }
         if (p[1] == 'b' || p[1] == 'B') {   // binary
-            result.radix = 2;
+            result.radix = Radix.Binary;
             p += 2;
             while (is_binary(*p)) {
                 if (value > max_u64 >> 1) {
@@ -832,10 +832,10 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
         }
         t.cur = p;
         if (p == start + 1) {
-            // value is 0, radix = 10
+            // value is 0, radix = Radix.Default
             return;
         }
-        result.radix = 8;
+        result.radix = Radix.Octal;
         goto check_overflow;
     }
 
@@ -1036,7 +1036,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result) {
             return 0;
         }
         result.char_value = hex2val(input[1]) * 16 + hex2val(input[2]);
-        result.radix = 16;
+        result.radix = Radix.Hex;
         return 3;
     default:
         if (is_octal(input[0])) {
@@ -1054,7 +1054,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result) {
                 return 0;
             }
             result.char_value = cast<u8>(value);
-            result.radix = 8;
+            result.radix = Radix.Octal;
             return offset;
         }
         t.cur++;
@@ -1066,7 +1066,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result) {
 
 fn void Tokenizer.lex_char_literal(Tokenizer* t, Token* result) {
     result.kind = Kind.CharLiteral;
-    result.radix = 10;
+    result.radix = Radix.Default;
 
     if (t.cur[1] == '\\') {
         t.cur++; // skip quote

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -291,12 +291,19 @@ public fn const char* Kind.str(Kind k) {
     return token_names[k];
 }
 
+public type Radix enum u8 {
+    Default,
+    Hex,
+    Octal,
+    Binary,
+}
+
 public type Token struct {
     SrcLoc loc;
     Kind kind;
     bool more;
     bool has_error;
-    u8 radix;   // for IntegerLiteral (2,8,10,16) and CharLiteral
+    Radix radix;   // Radix: for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
     union {
         const char* error_msg;  // ERROR
         struct {

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -149,7 +149,7 @@ fn void print_token(const Token* tok) {
         char[64] tmp;
         i32 len;
         switch (tok.radix) {
-        case 16:
+        case Hex:
             len = sprintf(tmp, "0x%x", tok.int_value);
             break;
         default:
@@ -171,11 +171,11 @@ fn void print_token(const Token* tok) {
         char[64] tmp;
         i32 len = 0;
         switch (tok.radix) {
-        case 8:
-            len = sprintf(tmp, "'\\%o'", tok.char_value);
-            break;
-        case 16:
+        case Hex:
             len = sprintf(tmp, "'\\x%02x'", tok.char_value);
+            break;
+        case Octal:
+            len = sprintf(tmp, "'\\%o'", tok.char_value);
             break;
         default:
             if (ctype.isprint(tok.char_value)) {


### PR DESCRIPTION
* use `Radix` enum instead of explicit radix value `None`, `Hex`, `Octal`, `Binary`