### PR TITLE
Control color output with C2_COLORS environment variable

### DIFF
--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -114,6 +114,7 @@ public type Globals struct @(opaque) {
 #if AstStatistics
     Stats stats;
 #endif
+    Color[15] colors;
 }
 
 // The only globals for AST are here, since they must be set explicitly for plugins!!
@@ -123,7 +124,24 @@ Globals* globals;
 public fn Globals* getGlobals() { return globals; }
 
 // only used by plugins
-public fn void setGlobals(Globals* g) @(unused) { globals = g; }
+public fn void setGlobals(Globals* g) @(unused) {
+    globals = g;
+    col_Normal     = g.colors[0];
+    col_Error      = g.colors[1];
+    col_Warning    = g.colors[2];
+    col_Keyword    = g.colors[3];
+    col_Identifier = g.colors[4];
+    col_Literal    = g.colors[5];
+    col_Comment    = g.colors[6];
+    col_Stmt       = g.colors[7];
+    col_Decl       = g.colors[8];
+    col_Expr       = g.colors[9];
+    col_Attr       = g.colors[10];
+    col_Template   = g.colors[11];
+    col_Type       = g.colors[12];
+    col_Value      = g.colors[13];
+    col_Calc       = g.colors[14];
+}
 
 // wordsize in bytes, must NOT be called from Plugin!
 public fn void initialize(Context* c, string_pool.Pool* astPool, bool use_color) {
@@ -139,7 +157,9 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, bool use_color)
 #if AstStatistics
     g.stats.reset();
 #endif
-    globals = g;  // must be set here because BuiltinType.create calls Stats.addType
+
+    // must be set here because BuiltinType.create calls Stats.addType
+    globals = g;
 
     g.addAST(nil);  // ensure idx2ast(0) is nil
 
@@ -153,6 +173,24 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, bool use_color)
     Type* void_ptr = g.pointers.getPointer(g.void_type);
     g.void_ptr_type.set(void_ptr);
     void_ptr.setCanonicalType(g.void_ptr_type);
+
+    g.colors[0]  = color.getConfigColor("normal",       color.Normal);
+    g.colors[1]  = color.getConfigColor("error",        color.Red);
+    g.colors[2]  = color.getConfigColor("warning",      color.Yellow);
+    g.colors[3]  = color.getConfigColor("keyword",      color.Green);
+    g.colors[4]  = color.getConfigColor("identifier",   color.Cyan);
+    g.colors[5]  = color.getConfigColor("literal",      color.Cyan);
+    g.colors[6]  = color.getConfigColor("comment",      color.Cyan);
+    g.colors[7]  = color.getConfigColor("ast.stmt",     color.Bmagenta);
+    g.colors[8]  = color.getConfigColor("ast.decl",     color.Bgreen);
+    g.colors[9]  = color.getConfigColor("ast.expr",     color.Bmagenta);
+    g.colors[10] = color.getConfigColor("ast.attr",     color.Blue);
+    g.colors[11] = color.getConfigColor("ast.template", color.Green);
+    g.colors[12] = color.getConfigColor("ast.type",     color.Green);
+    g.colors[13] = color.getConfigColor("ast.value",    color.Bcyan);
+    g.colors[14] = color.getConfigColor("ast.calc",     color.Yellow);    // all calculated values
+
+    setGlobals(g);
 }
 
 public fn void report() {
@@ -178,6 +216,7 @@ public fn void deinit() {
     g.dump_buf.free();
     stdlib.free(g);
     globals = nil;
+    color.freeConfigColors();
 }
 
 public fn bool useColor() @(unused) {
@@ -252,9 +291,14 @@ Color col_Template = Color.Green;
 //Color col_Cast = Color.Red;
 Color col_Type = Color.Green;
 Color col_Value = Color.Bcyan;
-Color col_Error = Color.Red;
+public Color col_Error = Color.Red;
 Color col_Calc = Color.Yellow;    // all calculated value
-Color col_Normal = Color.Normal;
+public Color col_Normal = Color.Normal;
+public Color col_Warning = color.Yellow;
+public Color col_Keyword = color.Green;
+public Color col_Identifier = color.Cyan;
+public Color col_Literal = color.Cyan;
+public Color col_Comment = color.Cyan;
 
 public type AttrHandlerFn fn bool (void* arg, Decl* d, const Attr* a);
 

--- a/ast_utils/color.c2
+++ b/ast_utils/color.c2
@@ -14,7 +14,10 @@
  */
 
 module color;
-import unistd;
+
+import stdlib local;
+import string local;
+import unistd local;
 
 public type Color enum u8 {
     None,
@@ -35,6 +38,9 @@ public type Color enum u8 {
     Bcyan,
     White,
     Normal,
+
+    CustomStart,
+    CustomEnd = Color.CustomStart + 15,
 }
 
 public const Color Black    = Black;
@@ -55,7 +61,7 @@ public const Color Bcyan    = Bcyan;
 public const Color White    = White;
 public const Color Normal   = Normal;
 
-const char*[elemsof(Color)] defaultColors = {
+const char*[] standardColors = {
     [Color.None]     = "",
     [Color.Black]    = "\033[0;30m",
     [Color.Red]      = "\033[0;31m",
@@ -76,8 +82,27 @@ const char*[elemsof(Color)] defaultColors = {
     [Color.Normal]   = "\033[0m",
 }
 
+i8 use_color = -1;
+const char* c2_colors;
+char[elemsof(Color)][32] defaultColors;
+
 public fn bool useColor() {
-    return unistd.isatty(1);
+    if (use_color < 0) {
+        use_color = isatty(1) != 0;
+        if (use_color) {
+            c2_colors = getenv("C2_COLORS");
+            if (c2_colors && !strcmp(c2_colors, "none")) {
+                use_color = 0;
+                c2_colors = nil;
+            } else {
+                for (u32 i = 0; i < elemsof(standardColors); i++) {
+                    strcpy(defaultColors[i], standardColors[i]);
+                }
+                if (c2_colors) customizeStandardColors(c2_colors);
+            }
+        }
+    }
+    return use_color;
 }
 
 public fn const char* Color.str(Color col) {

--- a/ast_utils/color_config.c2
+++ b/ast_utils/color_config.c2
@@ -1,0 +1,212 @@
+/* Copyright 2022-2025 Bas van den Berg, Charlie Gordon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module color;
+
+import ctype local;
+import stdio local;
+import stdlib local;
+import string local;
+
+const char*[] standardColorNames = {
+    [Color.Black]    = "black",
+    [Color.Red]      = "red",
+    [Color.Green]    = "green",
+    [Color.Yellow]   = "yellow",
+    [Color.Blue]     = "blue",
+    [Color.Magenta]  = "magenta",
+    [Color.Cyan]     = "cyan",
+    [Color.Grey]     = "grey",
+    [Color.Darkgrey] = "darkgrey",
+    [Color.Bred]     = "bred",
+    [Color.Bgreen]   = "bgreen",
+    [Color.Byellow]  = "byellow",
+    [Color.Bblue]    = "bblue",
+    [Color.Bmagenta] = "bmagenta",
+    [Color.Bcyan]    = "bcyan",
+    [Color.White]    = "white",
+    [Color.Normal]   = "normal",
+}
+
+fn Color findStandardColor(const char* name, bool use_custom = false) {
+    if (!name) return Color.None;
+    for (u32 i = 0; i < elemsof(standardColorNames); i++) {
+        if (!strcmp(name, standardColorNames[i]))
+            return (Color)i;
+    }
+    if (use_custom && !strncmp(name, "custom", 6)) {
+        i32 n = atoi(name + 6);
+        if (n > 0 && n <= Color.CustomEnd - Color.CustomStart + 1)
+            return (Color)(Color.CustomStart + n - 1);
+    }
+    return Color.None;
+}
+
+fn bool setPaletteColor(Color col, const char *val) {
+    u32 pal;
+    if (sscanf(val, "%*1[pP]%u", &pal) == 1) {
+        snprintf(defaultColors[col], elemsof(defaultColors[col]), "\033[38;5;%dm", pal);
+        return true;
+    }
+    u32 r, g, b;
+    if (sscanf(val, "#%2x%2x%2x", &r, &g, &b) == 3
+    ||  sscanf(val, "rgb(%u,%u,%u)", &r, &g, &b) == 3) {
+        snprintf(defaultColors[col], elemsof(defaultColors[col]), "\033[38;2;%d;%d;%dm", r, g, b);
+        return true;
+    }
+    return false;
+}
+
+fn bool setColorString(Color col, const char *val) {
+    if (!val || *val == '\0') {
+        *defaultColors[col] = '\0';
+        return true;
+    }
+    if (!strcmp(val, "default")) {
+        *defaultColors[col] = '\0';
+        if (col < elemsof(standardColors) && standardColors[col])
+            strcpy(defaultColors[col], standardColors[col]);
+        return true;
+    }
+    if (Color col1 = findStandardColor(val)) {
+        strcpy(defaultColors[col], standardColors[col1]);
+        return true;
+    }
+    return setPaletteColor(col, val);
+}
+
+// Normalize a color name into array dest.
+// s and dest can point to the same array
+fn char* normalizeColor(char *dest, u32 size, const char* s) {
+    if (!size) return nil;
+    u32 len = size - 1;
+    u32 i = 0;
+    if (s) {
+        for (const char* p = s; *p && i < len; p++) {
+            char c = (char)tolower(*p);
+            if (c != '-' && c != '_') {
+                if (i < len) dest[i++] = c;
+            }
+        }
+    }
+    dest[i] = '\0';
+    if (*dest == 'b' && !strncmp(dest + 1, "right", 5)) {
+        memmove(dest + 1, dest + 6, i + 1 - 6);
+    }
+    return dest;
+}
+
+fn void customizeStandardColors(const char *p) {
+    if (!p) return;
+
+    char[16] name;
+    char[16] val;
+    while (getConfigEntry(name, elemsof(name), val, elemsof(val), &p)) {
+        // check for standard color customisation
+        if (Color col = findStandardColor(normalizeColor(name, elemsof(name), name), true)) {
+            setColorString(col, normalizeColor(val, elemsof(val), val));
+        }
+    }
+}
+
+fn bool getConfigEntry(char* buf1, u32 size1, char* buf2, u32 size2, const char** pp) {
+    const char *p = *pp;
+    for (;;) {
+        while (isspace(*p))
+            p++;
+        if (*p == '\0' || *p == '[')
+            return false;
+        if (*p != '#')
+            break;
+        while (*p && *p++ != '\n')
+            continue;
+    }
+    u32 i = 0;
+    u32 j = 0;
+    while (*p && *p != '=' && *p != ':' && *p != ';' && !isspace(*p)) {
+        char c = *p++;
+        if (i + 1 < size1)
+            buf1[i++] = c;
+        if (j + 1 < size2)
+            buf2[j++] = c;
+    }
+    if (size1) buf1[i] = '\0';
+    if (size2) buf2[j] = '\0';
+    while (*p == ' ') p++;
+    if (*p == '=' || *p == ':') {
+        p++;
+        while (*p == ' ') p++;
+        j = 0;
+        while (*p && *p != ';' && *p != '\n') {
+            char c = *p++;
+            if (j + 1 < size2) buf2[j++] = c;
+        }
+        if (size2) buf2[j] = '\0';
+    }
+    while (*p) {
+        char c = *p++;
+        if (c == '\n' || c == ';')
+            break;
+    }
+    *pp = p;
+    return true;
+}
+
+fn Color convertColor(const char *val, Color def) {
+    if (!val || *val == '\0')
+        return None;
+
+    if (Color col = findStandardColor(val))
+        return col;
+
+    //if (!strcmp(val, "default"))
+    //    return def;
+
+    for (u32 i = Color.CustomStart; i <= Color.CustomEnd; i++) {
+        if (!defaultColors[i]) {
+            Color col = (Color)i;
+            if (setPaletteColor(col, val)) return col;
+            // TODO: complain about unknown color
+            return def;
+        }
+    }
+    // TODO: complain about out of custom colors
+    return def;
+}
+
+public fn Color getConfigColor(const char* cat, Color def) {
+    if (!use_color)
+        return None;
+    if (c2_colors) {
+        const char *p = c2_colors;
+        char[16] cat1;
+        char[16] style;
+        char[16] val;
+        if (!strcmp(p, "none"))
+            return None;
+        normalizeColor(cat1, elemsof(cat1), cat);
+        while (getConfigEntry(style, elemsof(style), val, elemsof(val), &p)) {
+            if (!strcmp(normalizeColor(style, elemsof(style), style), cat1))
+                return convertColor(normalizeColor(val, elemsof(val), val), def);
+        }
+    }
+    return def;
+}
+
+public fn void freeConfigColors() {
+    for (u32 i = Color.CustomStart; i <= Color.CustomEnd; i++) {
+        *defaultColors[i] = '\0';
+    }
+}

--- a/common/console.c2
+++ b/common/console.c2
@@ -26,8 +26,19 @@ bool show_timing = false;
 
 const u32 BUF_SIZE = 4096;
 
+Color col_normal  = color.Normal;
+Color col_error   = color.Red;
+Color col_warning = color.Yellow;
+Color col_debug   = color.Blue;
+Color col_timing  = color.Blue;
+
 public fn void init() {
     use_color = color.useColor();
+    col_normal  = color.getConfigColor("normal",  color.Normal);
+    col_error   = color.getConfigColor("error",   color.Red);
+    col_warning = color.getConfigColor("warning", color.Yellow);
+    col_debug   = color.getConfigColor("debug",   color.Blue);
+    col_timing  = color.getConfigColor("timing",  color.Blue);
 }
 
 public fn void setDebug(bool enable) {
@@ -47,7 +58,7 @@ public fn void debug(const char* format @(printf_format), ...) {
     vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
-        printf("%s%s%s\n", color.Blue.str(), buf, color.Normal.str());
+        printf("%s%s%s\n", col_debug.str(), buf, col_normal.str());
     } else {
         printf("%s\n", buf);
     }
@@ -69,7 +80,7 @@ public fn void warn(const char* format @(printf_format), ...) {
     vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
-        fprintf(stderr, "%swarning: %s%s\n", color.Yellow.str(), buf, color.Normal.str());
+        fprintf(stderr, "%swarning: %s%s\n", col_warning.str(), buf, col_normal.str());
     } else {
         fprintf(stderr, "warning: %s\n", buf);
     }
@@ -82,29 +93,37 @@ public fn void error(const char* format @(printf_format), ...) {
     vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
-        fprintf(stderr, "%serror: %s%s\n", color.Red.str(), buf, color.Normal.str());
+        fprintf(stderr, "%serror: %s%s\n", col_error.str(), buf, col_normal.str());
     } else {
         fprintf(stderr, "error: %s\n", buf);
     }
 }
 
-public fn void error_diag(const char* loc, const char* format @(printf_format), ...) {
+public fn void diag(bool err, const char* loc, const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
     va_list args;
     va_start(args, format);
     vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
-    if (use_color) {
-        fprintf(stderr, "%s%s: error: %s%s\n", color.Red.str(), loc, buf, color.Normal.str());
+    if (err) {
+        if (use_color) {
+            fprintf(stderr, "%s%s: error: %s%s\n", col_error.str(), loc, buf, col_normal.str());
+        } else {
+            fprintf(stderr, "%s: error: %s\n", loc, buf);
+        }
     } else {
-        fprintf(stderr, "%s: error: %s\n", loc, buf);
+        if (use_color) {
+            fprintf(stderr, "%s%s: warning: %s%s\n", col_warning.str(), loc, buf, col_normal.str());
+        } else {
+            fprintf(stderr, "%s: warning: %s\n", loc, buf);
+        }
     }
 }
 
 public fn void log_time(const char* item, u64 duration) {
     if (!show_timing) return;
     if (use_color) {
-        printf("%s%s took %d usec%s\n", color.Blue.str(), item, duration, color.Normal.str());
+        printf("%s%s took %d usec%s\n", col_timing.str(), item, duration, col_normal.str());
     } else {
         printf("%s took %d usec\n", item, duration);
     }

--- a/common/diagnostics.c2
+++ b/common/diagnostics.c2
@@ -40,6 +40,13 @@ public fn Diags* create(source_mgr.SourceMgr* sm, bool use_color, const utils.Pa
     diags.sm = sm;
     diags.out = string_buffer.create(512, use_color, 1);
     diags.path_info = path_info;
+    if (use_color) {
+        for (Category i = Category.min; i <= Category.max; i++) {
+            i.color = color.getConfigColor(i.name, i.color);
+        }
+        col_Normal = getConfigColor("normal", color.Normal);
+        col_Range = getConfigColor("range", color.Bgreen);
+    }
     return diags;
 }
 
@@ -57,11 +64,14 @@ public fn void Diags.setWarningAsError(Diags* diags, bool are_errors) {
     diags.promote_warnings = are_errors;
 }
 
-type Category enum u8 (const char* const name, const Color color) {
+type Category enum u8 (const char* const name, Color color) {
     Note    : { "note",    Color.Grey },
     Warning : { "warning", Color.Bmagenta },
     Error   : { "error",   Color.Bred },
 }
+
+Color col_Normal = Color.Normal;
+Color col_Range = Color.Bgreen;
 
 public fn void Diags.error(Diags* diags, SrcLoc loc, const char* format @(printf_format), ...) {
     va_list args;
@@ -159,7 +169,7 @@ fn void Diags.internal(Diags* diags,
     out.color(category.color);
     out.add(category.name);
     out.add(": ");
-    out.color(color.Normal);
+    out.color(col_Normal);
 
     out.vprintf(format, args);
     out.newline();
@@ -226,12 +236,12 @@ fn void Diags.internal(Diags* diags,
             char c = ' ';
             if (text[col - 1] == '\t')  // if a TAB was output in the soure
                 c = '\t';               // output a TAB at the same position
-            if (col == range_start_col) out.color(color.Bgreen);
+            if (col == range_start_col) out.color(col_Range);
             if (col >= range_start_col && col < range_end_col) c = '~';
             if (col == loc_col) c = '^';
             out.add1(c);
         }
-        out.color(color.Normal);
+        out.color(col_Normal);
         out.newline();
     }
     fputs(out.data(), stderr);

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -15,7 +15,7 @@
 
 module source_mgr;
 
-import color;
+import console;
 import file_utils;
 import string_pool;
 import src_loc local;
@@ -175,20 +175,12 @@ public fn i32 SourceMgr.addResource(SourceMgr* sm, const char* name, const void*
 public fn i32 SourceMgr.loadFile(SourceMgr* sm, const char* filename, SrcLoc sloc) {
     file_utils.File file.init(filename);
     if (!file.load()) {
-        char[256] tmp;
-        *tmp = '\0';
         if (sloc) {
-            Location loc = sm.locate(sloc);
-            if (loc.line_start) {
-                stdio.snprintf(tmp, elemsof(tmp), "%s:%d:%d: ", loc.filename, loc.line, loc.column);
-            }
-        }
-        // Cannot use console since we need source loc first
-        if (color.useColor()) {
-            stdio.fprintf(stdio.stderr, "%s%serror:%s cannot open %s: %s\n",
-                          tmp, color.Red.str(), color.Normal.str(), filename, file.getError());
+            char[256] locstr;
+            sm.loc2str(sloc, locstr, elemsof(locstr));
+            console.diag(true, locstr, "cannot open %s: %s", filename, file.getError());
         } else {
-            stdio.fprintf(stdio.stderr, "%serror: cannot open %s: %s\n", tmp, filename, file.getError());
+            console.error("cannot open %s: %s", filename, file.getError());
         }
         return -1;
     }

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -16,7 +16,7 @@
 module c2recipe;
 
 import build_target;
-import color;
+import console;
 import ctype;
 import file_list local;
 import source_mgr;
@@ -159,12 +159,8 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(nore
 
     char[256] locstr;
     p.sm.loc2str(p.token.loc, locstr, elemsof(locstr));
+    console.diag(true, locstr, "%s", msg);
 
-    if (color.useColor()) {
-        fprintf(stderr, "%s: %serror:%s %s\n", locstr, color.Red.str(), color.Normal.str(), msg);
-    } else {
-        fprintf(stderr, "%s: error: %s\n", locstr, msg);
-    }
     longjmp(&p.jmpbuf, 1);
 }
 
@@ -177,12 +173,7 @@ fn void Parser.warning(Parser* p, const char* format @(printf_format), ...) {
 
     char[256] locstr;
     p.sm.loc2str(p.token.loc, locstr, elemsof(locstr));
-
-    if (color.useColor()) {
-        fprintf(stderr, "%s: %swarning:%s %s\n", locstr, color.Red.str(), color.Normal.str(), msg);
-    } else {
-        fprintf(stderr, "%s: warning: %s\n", locstr, msg);
-    }
+    console.diag(false, locstr, "%s", msg);
 }
 
 fn void Parser.consumeToken(Parser* p) {

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -552,7 +552,7 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
                     source_mgr.Location loc = c.sm.locate(p.loc);
                     char[256] loc_str;
                     snprintf(loc_str, elemsof(loc_str), "%s:%d:%d", loc.filename, loc.line, loc.column);
-                    console.error_diag(loc_str, "%s", c.plugins.getError());
+                    console.diag(true, loc_str, "%s", c.plugins.getError());
                     exit(EXIT_FAILURE);
                 }
             }
@@ -588,7 +588,7 @@ fn void Context.handle_plugins(Context* c) {
             source_mgr.Location loc = c.sm.locate(p.loc);
             char[256] loc_str;
             snprintf(loc_str, elemsof(loc_str), "%s:%d:%d", loc.filename, loc.line, loc.column);
-            console.error_diag(loc_str, "%s", c.plugins.getError());
+            console.diag(true, loc_str, "%s", c.plugins.getError());
             exit(EXIT_FAILURE);
         }
     }
@@ -634,7 +634,7 @@ fn bool Context.build_target(Context* c,
             source_mgr.Location loc = c.sm.locate(p.loc);
             char[256] loc_str;
             snprintf(loc_str, elemsof(loc_str), "%s:%d:%d", loc.filename, loc.line, loc.column);
-            console.error_diag(loc_str, "%s", c.plugins.getError());
+            console.diag(true, loc_str, "%s", c.plugins.getError());
             continue;
         }
     }

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -19,7 +19,6 @@ import ast_builder local;
 import ast local;
 import attr local;
 import c2_tokenizer;
-import color;
 import constants;
 import diagnostics;
 import keywords;
@@ -955,15 +954,15 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
     out.clear();
 
     if (tok.kind.isKeyword())
-        out.color(color.Green);
+        out.color(col_Keyword);
     out.print("%12s", tok.kind.name);
     if (tok.kind.isKeyword())
-        out.color(color.Normal);
+        out.color(col_Normal);
     char[256] locstr;
     p.sm.loc2str(tok.loc, locstr, elemsof(locstr));
     out.print("  %6d %s  ", tok.loc, locstr);
 
-    out.color(color.Cyan);
+    out.color(col_Literal);
     switch (tok.kind) {
     case Identifier:
         out.add(p.pool.idx2str(tok.name_idx));
@@ -1012,7 +1011,7 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
         break;
     case StringLiteral:
         out.encodeBytes(p.pool.idx2str(tok.text_idx), tok.text_len, '"');
-        out.color(color.Normal);
+        out.color(col_Normal);
         out.print(" (len %d)", tok.text_len);
         break;
     case LineComment:
@@ -1025,14 +1024,14 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
         out.add("*/");
         break;
     case Error:
-        out.color(color.Red);
+        out.color(col_Error);
         out.add(p.tokenizer.error_msg);
         break;
     default:
         break;
     }
     // TODO use callback
-    out.color(color.Normal);
+    out.color(col_Normal);
     out.newline();
     fputs(out.data(), stdout);
 }

--- a/recipe.txt
+++ b/recipe.txt
@@ -32,6 +32,7 @@ set ast
     ast_utils/attr.c2
     ast_utils/attr_table.c2
     ast_utils/color.c2
+    ast_utils/color_config.c2
     ast_utils/constants.c2
     ast_utils/context.c2
     ast_utils/number_radix.c2
@@ -380,9 +381,11 @@ executable tester
 #    $config TesterDebug
 
     ast_utils/color.c2
+    ast_utils/color_config.c2
     ast_utils/constants.c2
     ast_utils/string_buffer.c2
 
+    common/console.c2
     common/file/file_utils.c2
     common/file/reader.c2
     common/file/writer.c2
@@ -402,6 +405,7 @@ executable c2cat
 
     ast_utils/attr.c2
     ast_utils/color.c2
+    ast_utils/color_config.c2
     ast_utils/constants.c2
     ast_utils/number_radix.c2
     ast_utils/src_loc.c2
@@ -409,6 +413,7 @@ executable c2cat
     ast_utils/string_pool.c2
     ast_utils/value_type.c2
 
+    common/console.c2
     common/file/file_utils.c2
     common/file/reader.c2
     common/string_list.c2
@@ -434,6 +439,7 @@ executable c2loc
 	$backend c
 
     ast_utils/color.c2
+    ast_utils/color_config.c2
     ast_utils/constants.c2
     ast_utils/src_loc.c2
     ast_utils/string_buffer.c2
@@ -441,6 +447,7 @@ executable c2loc
 
     common/build_target.c2
     common/file_list.c2
+    common/console.c2
     common/file/file_utils.c2
     common/file/reader.c2
     common/library_list.c2

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -61,6 +61,23 @@ type C2cat struct {
     u32 in_attributes; // 0 no, 1 seen @, 2 (, ) -> 0
 }
 
+fn void init_colors() {
+    color.useColor();
+    col_keyword = color.getConfigColor("keyword", color.Byellow);
+    col_type = color.getConfigColor("type", color.Green);
+    col_feature = color.getConfigColor("feature", color.Blue);
+    col_attr = color.getConfigColor("attr", color.Blue);
+    col_identifier = color.getConfigColor("identifier", Color.None);
+    col_integer = color.getConfigColor("integer", color.Magenta);
+    col_float = color.getConfigColor("float", color.Magenta);
+    col_charconst = color.getConfigColor("charconst", color.Magenta);
+    col_string = color.getConfigColor("string", color.Magenta);
+    col_comment = color.getConfigColor("comment", color.Bcyan);
+    col_invalid = color.getConfigColor("invalid", color.Bred);
+    col_error = color.getConfigColor("error", color.Bred);
+    col_normal = color.getConfigColor("normal", color.Normal);
+}
+
 fn bool C2cat.is_attribute(C2cat* ctx, u32 name_idx) {
     return ctx.attr_registry.find(name_idx) != Unknown;
 }
@@ -299,6 +316,7 @@ public fn i32 main(i32 argc, const char** argv)
 {
     bool use_color = color.useColor();
     if (argc == 1) usage(argv[0]);
+    init_colors();
     for (i32 i = 1; i < argc; i++) {
         if (argc > 2)
             printf("==> %s <==\n", argv[i]);

--- a/tools/c2loc.c2
+++ b/tools/c2loc.c2
@@ -17,6 +17,7 @@ module c2loc_main;
 
 import build_target;
 import c2recipe;
+import console;
 import constants;
 import file_list;
 import source_mgr;
@@ -106,6 +107,7 @@ fn void handle_target(build_target.Target* t, const char* name) {
 
 public fn i32 main(i32 argc, const char** argv)
 {
+    console.init();
     parse_opts(argc, argv);
 
     if (other_dir) {

--- a/tools/tester/test_utils.c2
+++ b/tools/tester/test_utils.c2
@@ -26,10 +26,11 @@ import string_buffer;
 public bool color_output;
 const char* proc_name = "";
 
-public Color colError = Bred;
-public Color colSkip  = Bcyan;
-public Color colOk    = Green;
-public Color colDebug = Bmagenta;
+public Color colError  = Bred;
+public Color colSkip   = Bcyan;
+public Color colOk     = Green;
+public Color colDebug  = Bmagenta;
+public Color colNormal = Normal;
 
 // NOTE: end must point AFTER last valid char (could be 0-terminator)
 
@@ -45,9 +46,15 @@ public fn void skipTrailingWhitespace(const char* start, const char** end) {
     *end = cp;
 }
 
-public fn void set_color_output(const char *name, bool enable) {
+public fn void set_color_output(const char *name) {
     proc_name = name;
-    color_output = enable;
+    color_output = color.useColor();
+    // customize colors
+    colError = color.getConfigColor("test.error", color.Bred);
+    colSkip = color.getConfigColor("test.skip", color.Bcyan);
+    colOk = color.getConfigColor("test.ok", color.Green);
+    colDebug = color.getConfigColor("test.debug", color.Bmagenta);
+    colNormal = color.getConfigColor("test.normal", color.Normal);
 }
 
 public fn void color_print(Color col, const char* format @(printf_format), ...) {
@@ -57,7 +64,7 @@ public fn void color_print(Color col, const char* format @(printf_format), ...) 
     vsnprintf(buffer, elemsof(buffer), format, args);
     va_end(args);
 
-    if (color_output) printf("%s%s%s\n", col.str(), buffer, color.Normal.str());
+    if (color_output) printf("%s%s%s\n", col.str(), buffer, colNormal.str());
     else printf("%s\n", buffer);
 }
 
@@ -68,7 +75,7 @@ public fn void print_error(const char* format @(printf_format), ...) {
     vsnprintf(buffer, elemsof(buffer), format, args);
     va_end(args);
 
-    if (color_output) fprintf(stderr, "%s: %s%s%s\n", proc_name, color.Byellow.str(), buffer, color.Normal.str());
+    if (color_output) fprintf(stderr, "%s: %s%s%s\n", proc_name, colError.str(), buffer, colNormal.str());
     else fprintf(stderr, "%s: %s\n", proc_name, buffer);
 }
 
@@ -85,7 +92,7 @@ public fn void color_print2(string_buffer.Buf* output,
 
     output.color(col);
     output.add(buffer);
-    output.color(color.Normal);
+    output.color(colNormal);
     output.newline();
 }
 

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -25,7 +25,6 @@ import sys_stat local;
 import sys_time;
 import unistd;
 
-import color;
 import test_utils local;
 import test_db local;
 import string_buffer;
@@ -311,7 +310,7 @@ public fn i32 main(i32 argc, char** argv) {
 
     u64 t1 = now();
 
-    set_color_output(argv[0], color.useColor());
+    set_color_output(argv[0]);
 
     for (i32 i = 1; i < argc; i++) {
         char *arg = argv[i];


### PR DESCRIPTION
* use style names instead of hard-coded color names
* customize color output via environment variable `C2_COLORS`: eg: `C2_COLORS=none`, `C2_COLORS="error:bright-blue`, `C2_COLORS="error:#d0d0d0`
* use cache to multiple calls to `unix.isatty()` and `stdib.getenv()`
* simplify error formating in **source_mgr.c2**