### PR TITLE
compiler: use converted strings from tokenizer

### DIFF
--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -21,6 +21,7 @@ import init_checker;
 import src_loc local;
 import scope;
 import string_buffer;
+import string;
 
 fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
     SwitchStmt* sw = cast<SwitchStmt*>(s);
@@ -58,6 +59,7 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
 
     init_checker.Checker checker = init_checker.Checker.create(numCases);
 
+    bool ok = true;
     for (u32 i=0; i<numCases; i++) {
         SwitchCase* c = cases[i];
         bool is_last = (i+1 == numCases);
@@ -79,10 +81,11 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
             }
         }
 
-        bool ok = ma.analyseCase(c, &checker, etd, is_string);
+        ok &= ma.analyseCase(c, &checker, etd, is_string);
         ma.scope.exit(ma.has_error);
-        if (!ok) return;
     }
+
+    if (!ok) return;
 
     ma.scope.exit(ma.has_error);
 
@@ -202,25 +205,44 @@ fn bool Analyser.analyseCaseCondition(Analyser* ma,
     } else {
         Expr* orig = c.getCond();
         QualType qt = ma.analyseExpr(c.getCond2(), true, RHS);
+
         if (qt.isInvalid()) return false;
         cond.setType(qt);
 
         if (is_string) {
+            u32 index;
             if (orig.isNil()) {
-                // TODO: check for duplicate nil
+                index = 0;
+                SrcLoc duplicate = checker.find(index);
+                if (duplicate) {
+                    ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case value nil");
+                    ma.note(duplicate, "previous case is here");
+                    return false;
+                }
             } else
             if (orig.isStringLiteral()) {
                 StringLiteral* lit = cast<StringLiteral*>(orig);
-                if (lit.getSize() > 255) {
-                    ma.error(cond.getLoc(), "string switch case string is loo long (max 254 bytes)");
+                u32 len = lit.getSize() - 1;
+                if (len > 255) {
+                    ma.error(cond.getLoc(), "string switch case string is loo long (max 255 bytes)");
                     return false;
                 }
-                // TODO: check for embedded null bytes
-                // TODO: check for duplicate string
+                if (string.memchr(lit.getText(), 0, len)) {
+                    ma.error(cond.getLoc(), "case string value has embedded null byte");
+                    return false;
+                }
+                index = lit.getTextIndex();
+                SrcLoc duplicate = checker.find(index);
+                if (duplicate) {
+                    ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case string");
+                    ma.note(duplicate, "previous case is here");
+                    return false;
+                }
             } else {
                 ma.error(cond.getLoc(), "string switch case can only have a string literal or nil as condition");
                 return false;
             }
+            checker.add(index, cond.getLoc());
         } else {
             if (!cond.isCtv()) {
                 ma.error(cond.getLoc(), "case condition is not compile-time constant");

--- a/ast/string_literal.c2
+++ b/ast/string_literal.c2
@@ -29,11 +29,11 @@ public fn StringLiteral* StringLiteral.create(ast_context.Context* c, SrcLoc loc
     StringLiteral* e = c.alloc(sizeof(StringLiteral));
     e.base.init(ExprKind.StringLiteral, loc, 0, 1, 0, ValType.LValue);
     e.value = value;
-    e.size = len;   // len includes the null terminator
+    e.size = len + 1;   // size includes the null terminator
 #if AstStatistics
     Stats.addExpr(ExprKind.StringLiteral, sizeof(StringLiteral));
 #endif
-    e.base.setType(getStringType(len));
+    e.base.setType(getStringType(len + 1));
     return e;
 }
 
@@ -41,12 +41,18 @@ public fn const char* StringLiteral.getText(const StringLiteral* e) {
     return idx2name(e.value);
 }
 
+public fn u32 StringLiteral.getTextIndex(const StringLiteral* e) {
+    return e.value;
+}
+
 public fn u32 StringLiteral.getSize(const StringLiteral* e) {
     return e.size;
 }
 
 public fn void StringLiteral.printLiteral(const StringLiteral* e, string_buffer.Buf* out) {
-    out.print("\"%s\"", idx2name(e.value));
+    out.add1('"');
+    out.encodeBytes(idx2name(e.value), e.size - 1, '"');
+    out.add1('"');
 }
 
 fn void StringLiteral.print(const StringLiteral* e, string_buffer.Buf* out, u32 indent) {

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -19,6 +19,7 @@ import stdio local;
 import stdarg local;
 import stdlib local;
 import string local;
+import utf8;
 
 public type Buf struct @(opaque) {
     u32 capacity;
@@ -78,10 +79,7 @@ public fn void Buf.clear(Buf* buf) {
 }
 
 public fn void Buf.color(Buf* buf, const char* color) {
-    if (!buf.colors) return;
-
-    u32 len = cast<u32>(strlen(color));
-    buf.add2(color, len);
+    if (buf.colors) buf.add(color);
 }
 
 public fn void Buf.add1(Buf* buf, char c) {
@@ -191,3 +189,59 @@ public fn void Buf.stripNewline(Buf* buf) {
     }
 }
 
+public fn u32 Buf.add_utf8(Buf* buf, u32 cc) {
+    char[4] tab;
+    u32 clen = utf8.encode(tab, elemsof(tab), cc);
+    buf.add2(tab, clen);
+    return clen;
+}
+
+public fn u32 Buf.encodeBytes(Buf* buf, const char *p, u32 len, char sep) {
+    u32 size = buf.size_;
+    u32 copy = 0;
+    const char* end = p + len;
+    while (p < end) {
+        u8 c = *p++;
+        switch (c) {
+        case '\a':  c = 'a'; goto add_char;
+        case '\b':  c = 'b'; goto add_char;
+        case '\f':  c = 'f'; goto add_char;
+        case '\n':  c = 'n'; goto add_char;
+        case '\r':  c = 'r'; goto add_char;
+        case '\t':  c = 't'; goto add_char;
+        case '\v':  c = 'v'; goto add_char;
+        case '"':
+        case '\'':
+            if (sep && sep != c) goto normal;
+            fallthrough;
+        case '\\':
+        add_char:
+            if (copy) buf.add2(p - copy - 1, copy);
+            buf.add1('\\');
+            buf.add1(c);
+            copy = 0;
+            break;
+        default:
+            if (c < ' ' || c >= 0x7F) {
+                char[4] arr;
+                if (copy) buf.add2(p - copy - 1, copy);
+                arr[0] = '\\';
+                arr[1] = '0' + ((c >> 6) & 7);
+                arr[2] = '0' + ((c >> 3) & 7);
+                arr[3] = '0' + (c & 7);
+                u32 esc_len = 4;
+                // special case \0 not followed by another digit
+                if (c == 0 && (p == end || !(*p >= '0' && *p <= '9')))
+                    esc_len = 2;
+                buf.add2(arr, esc_len);
+                copy = 0;
+                break;
+            }
+        normal:
+            copy++;
+            break;
+        }
+    }
+    if (copy) buf.add2(p - copy, copy);
+    return buf.size_ - size;
+}

--- a/common/utf8.c2
+++ b/common/utf8.c2
@@ -1,0 +1,97 @@
+/* Copyright 2022-2025 Charlie Gordon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module utf8;
+
+public const u32 MB_CUR_MAX = 6;    // UTF-8 uses just 4
+
+public fn u32 encode(char *dest, u32 max_len, u32 cc) {
+    if (cc < 0x80) {
+        if (max_len >= 1) {
+            dest[0] = cast<char>(cc);
+            return 1;
+        }
+    } else
+    if (cc < 0x800) {
+        if (max_len >= 2) {
+            dest[0] = cast<char>(0xC0 + (cc >> 6));
+            dest[1] = cast<char>(0x80 + (cc & 0x3F));
+            return 2;
+        }
+    } else
+    if (cc < 0x10000) {
+        if (max_len >= 3) {
+            dest[0] = cast<char>(0xE0 + (cc >> 12));
+            dest[1] = cast<char>(0x80 + ((cc >> 6) & 0x3F));
+            dest[2] = cast<char>(0x80 + (cc & 0x3F));
+            return 3;
+        }
+    } else
+    if (cc < 0x110000) {
+        if (max_len >= 4) {
+            dest[0] = cast<char>(0xF0 + (cc >> 18));
+            dest[1] = cast<char>(0x80 + ((cc >> 12) & 0x3F));
+            dest[2] = cast<char>(0x80 + ((cc >> 6) & 0x3F));
+            dest[3] = cast<char>(0x80 + (cc & 0x3F));
+            return 4;
+        }
+    }
+    return 0;
+}
+
+public fn u32 decode(const char *p, u32 max_len, u32* pc) {
+    if (!max_len)
+        return 0;
+
+    u32 c = cast<u8>(*p++);
+    if (c < 0x80) {
+        *pc = c;
+        return 1;
+    } else
+    if (c < 0xC2) {
+        // invalid prefix byte or naked trailing byte
+    } else
+    if (c < 0xE0) {
+        if (max_len >= 2 && p[0] >= 0x80 && p[0] <= 0xBF) {
+            *pc = ((c - 0xC0) << 6) + (p[0] - 0x80);
+            return 2;
+        }
+    } else
+    if (c < 0xF0) {
+        if (max_len >= 3
+        &&  p[0] >= 0x80 && p[0] <= 0xBF
+        &&  p[1] >= 0x80 && p[1] <= 0xBF) {
+            c = ((c - 0xE0) << 12) + ((p[0] - 0x80) << 6) + (p[1] - 0x80);
+            if (c >= 0x800) {
+                *pc = c;
+                return 3;
+            }
+        }
+    } else
+    if (c <= 0xF4) {
+        if (max_len >= 4
+        &&  p[0] >= 0x80 && p[0] <= 0xBF
+        &&  p[1] >= 0x80 && p[1] <= 0xBF
+        &&  p[2] >= 0x80 && p[2] <= 0xBF) {
+            c = ((c - 0xF0) << 18) + ((p[0] - 0x80) << 12) +
+                ((p[1] - 0x80) << 6) + (p[2] - 0x80);
+            if (c >= 0x10000 && c < 0x110000) {
+                *pc = c;
+                return 4;
+            }
+        }
+    }
+    return 0;
+}

--- a/generator/c_generator_call.c2
+++ b/generator/c_generator_call.c2
@@ -20,6 +20,7 @@ import printf_utils;
 import source_mgr;
 import src_loc local;
 import string_buffer;
+import string;
 
 fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
     CallExpr* call = cast<CallExpr*>(e);
@@ -135,7 +136,8 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
                 FormatChanger fc = { format_text, &args[call_index+1], 0, 0, out }
                 out.add1('"');
                 printf_utils.parseFormat(format_text, on_format_specifier, &fc);
-                out.add(format_text + fc.last_offset);
+                out.encodeBytes(format_text + fc.last_offset,
+                                cast<u32>(string.strlen(format_text + fc.last_offset)), '"');
                 out.add1('"');
             } else {
                 gen.emitExpr(out, args[call_index]);

--- a/generator/c_generator_expr.c2
+++ b/generator/c_generator_expr.c2
@@ -376,7 +376,7 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
     FormatChanger* fc = context;
 
     /* copy optional flags, width and precision */
-    fc.out.add2(fc.format + fc.last_offset, offset - fc.last_offset);
+    fc.out.encodeBytes(fc.format + fc.last_offset, offset - fc.last_offset, '"');
 
     fc.idx += stars;
     QualType qt = fc.args[fc.idx].getType();

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -199,11 +199,11 @@ fn void Parser.parseModule(Parser* p, bool is_generated) {
     p.expectAndConsume(Kind.KW_module);
     p.expectIdentifier();
 
-    const char*modname = p.pool.idx2str(p.tok.text_idx);
+    const char*modname = p.pool.idx2str(p.tok.name_idx);
     if (ctype.isupper(modname[0])) {
         p.error("a module name must start with a lower case character");
     }
-    p.builder.actOnModule(p.tok.text_idx,
+    p.builder.actOnModule(p.tok.name_idx,
                           p.tok.loc,
                           p.sm.getFileNameIdx(p.file_id),
                           is_generated);
@@ -215,7 +215,7 @@ fn void Parser.parseImports(Parser* p) {
     while (p.tok.kind == Kind.KW_import) {
         p.consumeToken();
         p.expectIdentifier();
-        u32 mod_name = p.tok.text_idx;
+        u32 mod_name = p.tok.name_idx;
         SrcLoc mod_loc = p.tok.loc;
 
         u32 alias_name = 0;
@@ -224,7 +224,7 @@ fn void Parser.parseImports(Parser* p) {
         if (p.tok.kind == Kind.KW_as) {
             p.consumeToken();
             p.expectIdentifier();
-            alias_name = p.tok.text_idx;
+            alias_name = p.tok.name_idx;
             alias_loc = p.tok.loc;
 
             if (!checkName(p.pool.idx2str(alias_name), false)) {
@@ -297,7 +297,7 @@ fn void Parser.parseOptionalAttributes(Parser* p) {
     while (1) {
         p.expectIdentifier();
         attr.Attr a;
-        a.name = p.tok.text_idx;
+        a.name = p.tok.name_idx;
         a.loc = p.tok.loc;
         a.value_kind = attr.ValueKind.None;
         p.consumeToken();
@@ -309,8 +309,7 @@ fn void Parser.parseOptionalAttributes(Parser* p) {
             case StringLiteral:
                 a.value_kind = attr.ValueKind.String;
                 a.value.text = p.tok.text_idx;
-                const char* str = p.pool.idx2str(a.value.text);
-                if (str[0] == 0) {
+                if (p.tok.text_len == 0) {
                     p.error("attribute argument cannot be an empty string");
                 }
                 p.consumeToken();
@@ -344,7 +343,7 @@ fn void Parser.parseParamOptionalAttributes(Parser* p, VarDecl* d) {
 
     while (1) {
         p.expectIdentifier();
-        u32 attr_id = p.tok.text_idx;
+        u32 attr_id = p.tok.name_idx;
         SrcLoc loc = p.tok.loc;
         p.consumeToken();
 
@@ -370,7 +369,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
     p.parseTypeSpecifier(&rtype, true, true);
 
     p.expectIdentifier();
-    u32 func_name = p.tok.text_idx;
+    u32 func_name = p.tok.name_idx;
     SrcLoc func_loc = p.tok.loc;
     p.consumeToken();
 
@@ -384,7 +383,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
         prefix_ref.name_idx = func_name;
         prefix_ref.decl = nil;
         prefix = &prefix_ref;
-        func_name = p.tok.text_idx;
+        func_name = p.tok.name_idx;
         func_loc = p.tok.loc;
         p.consumeToken();
     }
@@ -404,7 +403,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
         p.consumeToken();
         p.expectIdentifier();
 
-        u32 template_name = p.tok.text_idx;
+        u32 template_name = p.tok.name_idx;
         SrcLoc template_loc = p.tok.loc;
         p.consumeToken();
         // TODO parse multiple template args
@@ -494,7 +493,7 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public) {
     u32 name = 0;
     SrcLoc loc = p.tok.loc;
     if (p.tok.kind == Kind.Identifier) {
-        name = p.tok.text_idx;
+        name = p.tok.name_idx;
 
         if (!checkName(p.pool.idx2str(name), p.is_interface)) {
             p.error("a parameter name must start with a lower case character");
@@ -562,7 +561,7 @@ fn void Parser.parseOptionalArray(Parser* p,
 
 fn void Parser.parseArrayEntry(Parser* p) {
     // Syntax: name += <expr>
-    u32 name = p.tok.text_idx;
+    u32 name = p.tok.name_idx;
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
     p.consumeToken();   // +=
@@ -581,7 +580,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
     p.parseTypeSpecifier(&ref, true, true);
     p.expectIdentifier();
 
-    u32 name = p.tok.text_idx;
+    u32 name = p.tok.name_idx;
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
 
@@ -696,13 +695,13 @@ fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref, bool allo
 //   identifier
 //   identifier.identifier
 fn void Parser.parseFullTypeIdentifier(Parser* p, TypeRefHolder* ref) {
-    ref.setUser(p.tok.loc, p.tok.text_idx);
+    ref.setUser(p.tok.loc, p.tok.name_idx);
     p.consumeToken();
 
     if (p.tok.kind == Kind.Dot) {
         p.consumeToken();
         p.expectIdentifier();
-        ref.setPrefix(p.tok.loc, p.tok.text_idx);
+        ref.setPrefix(p.tok.loc, p.tok.name_idx);
         p.consumeToken();
     }
 }
@@ -718,7 +717,7 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
 
     switch (tok.kind) {
     case Identifier:
-        printf("  %s%s%s", color.Cyan, p.pool.idx2str(tok.text_idx), color.Normal);
+        printf("  %s%s%s", color.Cyan, p.pool.idx2str(tok.name_idx), color.Normal);
         break;
     case IntegerLiteral:
         switch (tok.radix) {
@@ -766,8 +765,10 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
         }
         break;
     case StringLiteral:
+        p.tokenizer.buf.clear();
+        p.tokenizer.buf.encodeBytes(p.pool.idx2str(tok.text_idx), tok.text_len, '"');
         printf("  %s\"%s\"%s (len %d)",
-            color.Cyan, p.pool.idx2str(tok.text_idx), color.Normal, tok.text_len);
+            color.Cyan, p.tokenizer.buf.data(), color.Normal, tok.text_len);
         break;
     case LineComment:
         printf("  '%s%s%s'", color.Cyan, p.pool.idx2str(tok.text_idx), color.Normal);

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -448,7 +448,7 @@ fn Expr* Parser.parseImpureMemberExpr(Parser* p, Expr* base) {
         if (refcount == elemsof(ref)) p.error("max member depth is %d", MemberExprMaxDepth);
 
         ref[refcount].loc = p.tok.loc;
-        ref[refcount].name_idx = p.tok.text_idx;
+        ref[refcount].name_idx = p.tok.name_idx;
         refcount++;
         p.consumeToken();
     }
@@ -461,7 +461,7 @@ fn Expr* Parser.parsePureMemberExpr(Parser* p) {
     Ref[MemberExprMaxDepth] ref;
 
     ref[0].loc = p.tok.loc;
-    ref[0].name_idx = p.tok.text_idx;
+    ref[0].name_idx = p.tok.name_idx;
     u32 refcount = 1;
     p.consumeToken();
 
@@ -472,7 +472,7 @@ fn Expr* Parser.parsePureMemberExpr(Parser* p) {
         if (refcount == elemsof(ref)) p.error("max member depth is %d", MemberExprMaxDepth);
 
         ref[refcount].loc = p.tok.loc;
-        ref[refcount].name_idx = p.tok.text_idx;
+        ref[refcount].name_idx = p.tok.name_idx;
         refcount++;
         p.consumeToken();
     }
@@ -481,7 +481,7 @@ fn Expr* Parser.parsePureMemberExpr(Parser* p) {
 }
 
 fn IdentifierExpr* Parser.parseIdentifier(Parser* p) {
-    IdentifierExpr* e = p.builder.actOnIdentifier(p.tok.loc, p.tok.text_idx);
+    IdentifierExpr* e = p.builder.actOnIdentifier(p.tok.loc, p.tok.name_idx);
     p.consumeToken();
     return e;
 }
@@ -495,36 +495,22 @@ fn Expr* Parser.parseStringLiteral(Parser* p) {
     if (p.tok.kind == Kind.StringLiteral) {
         char* tmp = p.multi_string;
         const char *p1 = p.pool.idx2str(idx);
-        usize len1 = string.strlen(p1);
-        if (len1 >= constants.MaxMultiString) {
+        if (len > constants.MaxMultiString) {
             p.error("multi-string literal too long");
         }
-        string.memcpy(tmp, p1, len1 + 1);
+        string.memcpy(tmp, p1, len);
 
         while (p.tok.kind == Kind.StringLiteral) {
-            if (p.tok.text_len > 1) {
-                const char *p2 = p.pool.idx2str(p.tok.text_idx);
-                usize len2 = string.strlen(p2);
-                if (len1 + len2 + 3 >= constants.MaxMultiString) {
-                    p.error("multi-string literal too long");
-                }
-                if (len1 > 0 && isxdigit(p1[len1 - 1]) && isxdigit(*p2)) {
-                    // special case: prevent inadvertent escape sequence pasting
-                    // replace first character with octal escape sequence
-                    // note: hex escape sequence would not work for "#e" as \x23e
-                    // is parsed as a single (invalid) character by the C compiler
-                    stdio.sprintf(tmp + len1, "\\%03o", *p2 & 0xFF);
-                    len1 += 4;
-                    p2 += 1;
-                    len2 -= 1;
-                }
-                string.memcpy(tmp + len1, p2, len2 + 1);
-                len1 += len2;
-                len += p.tok.text_len - 1;
+            const char *p2 = p.pool.idx2str(p.tok.text_idx);
+            usize len2 = p.tok.text_len;
+            if (len + len2 > constants.MaxMultiString) {
+                p.error("multi-string literal too long");
             }
+            string.memcpy(tmp + len, p2, len2);
+            len += len2;
             p.consumeToken();
         }
-        idx = p.pool.add(tmp, len1, false);
+        idx = p.pool.add(tmp, len, true);
     }
     return p.builder.actOnStringLiteral(loc, idx, len);
 }

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -25,7 +25,7 @@ import ctype local;
 fn void Parser.parseTypeDecl(Parser* p, bool is_public) {
     p.consumeToken();
     p.expectIdentifier();
-    u32 type_name = p.tok.text_idx;
+    u32 type_name = p.tok.name_idx;
     SrcLoc type_loc = p.tok.loc;
     const char* name = p.pool.idx2str(type_name);
     if (!isupper(name[0])) p.error("a type name must start with an upper case character");
@@ -113,7 +113,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             u32 name = 0;
             SrcLoc loc = 0;
             if (p.tok.kind == Kind.Identifier) {
-                name = p.tok.text_idx;
+                name = p.tok.name_idx;
                 loc = p.tok.loc;
 
                 if (!checkName(p.pool.idx2str(name), p.is_interface)) {
@@ -146,7 +146,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
                 loc = p.tok.loc;
             } else {
                 p.expectIdentifier();
-                name = p.tok.text_idx;
+                name = p.tok.name_idx;
                 loc = p.tok.loc;
 
                 if (!checkName(p.pool.idx2str(name), p.is_interface)) {
@@ -222,7 +222,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
         p.consumeToken();
     } else {
         while (p.tok.kind == Kind.Identifier) {
-            u32 const_name = p.tok.text_idx;
+            u32 const_name = p.tok.name_idx;
 
             const char* name_str = p.pool.idx2str(const_name);
             // TODO interface?

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -21,6 +21,7 @@ import string_buffer;
 import string_list;
 import string_pool;
 import token local;
+import utf8;
 
 import string;
 import stdlib;
@@ -262,7 +263,7 @@ public type Tokenizer struct {
     const char* line_start;
 
     string_pool.Pool* pool; // no ownership
-    string_buffer.Buf* buf; // no ownership, used for multi-strings: "a" "b" "c"
+    string_buffer.Buf* buf; // no ownership, used for strings and character constants
 
     // Feature handling
     Feature[constants.MaxFeatureDepth+1] feature_stack;
@@ -317,16 +318,15 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
         Action act = Char_lookup[cast<u8>(*t.cur)];
         switch (act) {
         case INVALID:
-            const char *endp = nil;
-            i32 cc;
-            if ((*t.cur & 0x80) && (cc = decode_utf8(t.cur, &endp)) >= 0) {
+            u32 len;
+            u32 cc;
+            if ((*t.cur & 0x80) && (len = utf8.decode(t.cur, 4, &cc)) > 0) {
                 if (cc == 0xFEFF && t.cur == t.input_start) {
                     // accept BOM \uFEFF (EF BB BF) at start of file
-                    t.cur = endp;
+                    t.cur += len;
                     continue;
                 }
                 if (t.raw_mode) {
-                    usize len = cast<usize>(endp - t.cur);
                     result.kind = Kind.Invalid;
                     string.memcpy(result.invalid, t.cur, len);
                     result.invalid[len] = '\0';
@@ -355,8 +355,8 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
             continue;
         case IDENT:
             t.lex_identifier(result);
-            if (result.text_idx <= t.kwinfo.max_index) {
-                Kind k = t.kwinfo.indexes[result.text_idx];
+            if (result.name_idx <= t.kwinfo.max_index) {
+                Kind k = t.kwinfo.indexes[result.name_idx];
                 assert(k != Kind.None);
                 result.kind = k;    // turn into keyword
             }
@@ -728,7 +728,7 @@ fn void Tokenizer.lex_identifier(Tokenizer* t, Token* result) {
         return;
     }
     t.cur += len;
-    result.text_idx = t.pool.add(start, len, true);
+    result.name_idx = t.pool.add(start, len, true);
 }
 
 fn u8 hex2val(char c) {
@@ -996,108 +996,112 @@ too_large:
     return;
 }
 
-// Returns how much to shift in source code (0 = error)
+// Returns how much to skip in source code (0 = error)
 fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result, const char* stype) {
-    // Note: t.cur is on '\'
-    const char* input = t.cur + 1;  // skip backslash
-    switch (input[0]) {
+    // Note: t.cur is after the '\'
+    const char* p = t.cur;  // after the backslash
+    u32 nc = 1;
+    u32 cc;
+    char c;
+
+    switch (c = *p) {
     case 0:
     case '\r':
     case '\n':
         t.error(result, "unterminated %s", stype);
         return 0;
-    case '"':
-        result.char_value = '"';
-        break;
-    case '\'':
-        result.char_value = '\'';
-        break;
-    case '?':
-        result.char_value = '\?';
-        break;
-    case '\\':
-        result.char_value = '\\';
-        break;
-    case 'a':
-        result.char_value = '\a';
-        break;
-    case 'b':
-        result.char_value = '\b';
-        break;
-    case 'f':
-        result.char_value = '\f';
-        break;
-    case 'n':
-        result.char_value = '\n';
-        break;
-    case 'r':
-        result.char_value = '\r';
-        break;
-    case 't':
-        result.char_value = '\t';
-        break;
-    case 'u':
-        t.error(result, "unicode escape sequences not supported yet");
-        return 0;
-    case 'v':
-        result.char_value = '\v';
-        break;
-    case 'x':
-        if (!isxdigit(input[1])) {
-            t.cur++;
-            t.error(result, "expect hexadecimal number after '\\x'");
+    case '0':   // '0' .. '7'
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+        result.radix = Radix.Octal;
+        nc = octconv(p, 3, &cc);
+        if (cc > 255) {
+            t.error(result, "octal escape sequence out of range");
             return 0;
         }
+        c = cc & 0xFF;
+        goto add_char;
+    case 'x':
         // C consumes all hex digits after \x (at least one)
         // C2 requires 2 hex digits, but rejects extra digits to simplify C generation
-        if (!isxdigit(input[2])) {
-            t.cur += 2;
+        result.radix = Radix.Hex;
+        nc = hexconv(p + 1, max_i32, &cc);
+        if (nc == 0) {
+            t.error(result, "expect hexadecimal number after '\\x'");
+            return 0;
+        } else
+        if (nc < 2) {
             t.error(result, "expect 2 hexadecimal digits after '\\x'");
             return 0;
-        }
-        if (isxdigit(input[3])) {
-            t.cur += 3;
+        } else
+        if (nc > 2) {
             t.error(result, "too many digits in hexadecimal escape sequence '\\x'");
             return 0;
         }
-        result.char_value = hex2val(input[1]) * 16 + hex2val(input[2]);
+        nc++;
+        c = cc & 0xFF;
+        goto add_char;
+    case 'a':  c = '\a'; goto add_char;
+    case 'b':  c = '\b'; goto add_char;
+    case 'f':  c = '\f'; goto add_char;
+    case 'n':  c = '\n'; goto add_char;
+    case 'r':  c = '\r'; goto add_char;
+    case 't':  c = '\t'; goto add_char;
+    case 'v':  c = '\v'; goto add_char;
+    case '"':
+    case '\'':
+    case '?':
+    case '\\':
+    add_char:
+        t.buf.add1(c);
+        break;
+    case 'u':
         result.radix = Radix.Hex;
-        return 3;
-    default:
-        u8 cc = *input;
-        if (is_octal(cc)) {
-            u32 offset = 0;
-            u32 value = 0;
-            while (is_octal(input[offset]) && offset < 3) {
-                value *= 8;
-                value += cast<u32>(input[offset] - '0');
-                offset++;
-            }
-            if (value > 255) {
-                t.cur++;
-                t.error(result, "octal escape sequence out of range");
-                return 0;
-            }
-            result.char_value = cast<u8>(value);
-            result.radix = Radix.Octal;
-            return offset;
-        }
-        // TODO: make this non fatal
-        if (cc < ' ' || cc == 0x7F) {
-            t.error(result, "invalid character 0x%02X in %s", cc, stype);
+        nc = hexconv(p + 1, 4, &cc);
+        if (nc != 4) {
+            t.error(result, "expect 4 hexadecimal digits after '\\u'");
             return 0;
         }
-        // TODO: handle UTF-8
-        t.cur++;    // skip the backslash
-        t.error(result, "unknown escape sequence '\\%c'", input[0]);
-        return 0;
+        nc++;
+        goto add_utf8;
+    case 'U':
+        result.radix = Radix.Hex;
+        nc = hexconv(p + 1, 8, &cc);
+        if (nc != 8) {
+            t.error(result, "expect 8 hexadecimal digits after '\\U'");
+            return 0;
+        }
+        nc++;
+        if (cc > 0x10FFFF) {
+            t.error(result, "code point value out of range: %08x", cc);
+            return 0;
+            //cc = 0xFFFD;
+        }
+    add_utf8:
+        t.buf.add_utf8(cc);
+        break;
+    default:
+        if (c < ' ' || c == 0x7F) {
+            t.error(result, "invalid character 0x%02X in %s", c, stype);
+        } else
+        if (c < 0x80) {
+            t.error(result, "unknown escape sequence '\\%c'", c);
+        } else {
+            t.error(result, "invalid UTF-8 escape sequence");
+        }
+        nc = 0;
+        break;
     }
-    return 1;
+    return nc;
 }
 
 fn void Tokenizer.lex_char_literal(Tokenizer* t, Token* result) {
     result.kind = Kind.CharLiteral;
-    result.radix = Radix.Default;
 
     t.cur++; // skip single quote
     switch (*t.cur) {
@@ -1110,19 +1114,34 @@ fn void Tokenizer.lex_char_literal(Tokenizer* t, Token* result) {
         t.error(result, "empty character constant");
         return;
     case '\\':
+        t.cur++; // skip the backslash
+        t.buf.clear();
         u32 esc_len = t.lex_escaped_char(result, "character constant");
-        if (esc_len == 0) return;
-        t.cur += (esc_len + 1);
-        break;
-    default:
-        u8 cc = *t.cur;
-        if (cc < ' ' || cc >= 0x7F) {
-            // TODO: check for UTF-8 contents
-            t.error(result, "invalid character 0x%02X in %s", cc, "character constant");
+        if (esc_len == 0) {
+            // invalid escape sequence, error already produced
             return;
         }
-        result.char_value = cc;
-        t.cur += 1;
+        t.cur += esc_len;
+        if (t.buf.size() != 1) {
+            t.error(result, "multi-character character constant");
+            return;
+        }
+        result.char_value = *t.buf.udata();
+        break;
+    default:
+        u8 c = *t.cur;
+        u32 cc;
+        if ((c & 0x80) && utf8.decode(t.cur, 4, &cc) > 0) {
+            t.error(result, "multi-character character constant");
+            return;
+        } else
+        if (c < ' ' || c == 0x7F) {
+            t.error(result, "invalid character 0x%02X in %s", c, "character constant");
+            return;
+        } else {
+            result.char_value = c;
+            t.cur += 1;
+        }
         break;
     }
     if (*t.cur != '\'') {
@@ -1135,42 +1154,55 @@ fn void Tokenizer.lex_char_literal(Tokenizer* t, Token* result) {
         }
         return;
     }
-    t.cur += 1;
+    t.cur += 1; // skip the closing quote
 }
 
 fn void Tokenizer.lex_string_literal(Tokenizer* t, Token* result) {
     result.kind = Kind.StringLiteral;
-    t.cur++; // skip "
-    const char* start = t.cur;
-    u32 num_escapes = 0;
 
-    while (1) {
-        switch (*t.cur) {
+    t.buf.clear();
+    t.cur++; // skip double quote
+
+    for (;;) {
+        const char* p = t.cur;
+        while (*p && *p != '\\'  && *p != '"' && *p >= ' ' && *p < 0x7F)
+            p++;
+        t.buf.add2(t.cur, cast<u32>(p - t.cur));
+        t.cur = p;
+        switch (*p) {
         case 0:
         case '\r':
         case '\n':
             t.error(result, "unterminated %s", "string");
             return;
+        case '"':
+            t.cur++; // skip string terminator
+            u32 len = t.buf.size();
+            result.text_len = len;
+            result.text_idx = t.pool.add(t.buf.data(), len, true);
+            return;
         case '\\':
+            t.cur++;
             u32 esc_len = t.lex_escaped_char(result, "string");
             if (esc_len == 0) return;
-            num_escapes += esc_len;
-            t.cur += (esc_len + 1);
+            t.cur += esc_len;
             break;
-        case '"':
-            u32 len = cast<u32>(t.cur - start);
-            t.cur++; // skip string terminator
-            // Note: we could put all empty strings at index 1 (not 0, since that means nil)
-            result.text_len = len + 1 - num_escapes;   // include 0-terminator
-            result.text_idx = t.pool.add(start, len, false);
-            return;
         default:
-            u8 cc = *t.cur;
-            if (cc < ' ' || cc == 0x7F) {
-                t.error(result, "invalid character 0x%02X in %s", cc, "string");
+            if (*p >= 0x80) {
+                u32 cc;
+                u32 nc = utf8.decode(p, 4, &cc);
+                if (nc > 0) {
+                    t.buf.add2(p, nc);
+                    t.cur += nc;
+                    break;
+                } else {
+                    t.error(result, "invalid UTF-8 sequence");
+                    return;
+                }
+            } else {
+                t.error(result, "invalid character 0x%02X in %s", *p, "string");
                 return;
             }
-            t.cur++;
             break;
         }
     }
@@ -1192,6 +1224,7 @@ fn bool Tokenizer.lex_line_comment(Tokenizer* t, Token* result) {
 
     if (t.raw_mode) {
         result.kind = Kind.LineComment;
+        result.text_len = len;
         result.text_idx = t.pool.add(start, len, false);
         return true;
     }
@@ -1363,7 +1396,7 @@ fn i64 Tokenizer.parse_ppexpr(Tokenizer* t, Token *result) {
             switch (op) {
             case Identifier:
                 val = 0;
-                const char *id = t.pool.idx2str(result.text_idx);
+                const char *id = t.pool.idx2str(result.name_idx);
                 if (!string.strcmp(id, "defined")) {
                     bool has_paren = false;
                     if (t.lex_preproc(result) == Kind.LParen) {
@@ -1371,7 +1404,7 @@ fn i64 Tokenizer.parse_ppexpr(Tokenizer* t, Token *result) {
                         t.lex_preproc(result);
                     }
                     if (result.kind == Kind.Identifier) {
-                        id = t.pool.idx2str(result.text_idx);
+                        id = t.pool.idx2str(result.name_idx);
                     } else {
                         t.error(result, "missing identifier after 'defined'");
                         return 0;
@@ -1645,9 +1678,9 @@ fn bool Tokenizer.handle_if(Tokenizer* t, Token* result, Kind kind) {
         /* handle Kind.Feat_ifdef, Kind.Feat_ifndef */
         if (t.lex_preproc(result) == Kind.Identifier) {
             // TODO use feature value
-            // XXX: cannot use t.features.contains_idx(result.text_idx)
+            // XXX: cannot use t.features.contains_idx(result.name_idx)
             //      because t.pool and t.features.pool are different in c2c
-            if (!t.features.contains(t.pool.idx2str(result.text_idx)))
+            if (!t.features.contains(t.pool.idx2str(result.name_idx)))
                 top.skipping = 1;
             if (kind == Kind.Feat_ifndef)
                 top.skipping ^= 1;
@@ -1769,50 +1802,38 @@ fn const char *skip_block_comment(const char *p) {
     return p;
 }
 
-/* decode a UTF-8 sequence:
-   return -1 on encoding error.
-   otherwise return codepoint value in range 0..0x1FFFFF and update *endp
-   note: *endp is not incremented for '\0'.
-   note: no test on invalid codepoints such as surrogate halves,
- */
-fn i32 decode_utf8(const char *s, const char **endp) {
-    const u8 *p = cast<u8 *>(s);
-    i32 c = *p++ & 0xFF; // redundant mask to prevent conversion error
-
-    if (c < 0x80) {
-        *endp = s + (c != '\0');
-        return c;
-    } else
-    if (c < 0xC2) {
-        // invalid prefix byte or naked trailing byte
-    } else
-    if (c < 0xE0) {
-        if (p[0] >= 0x80 && p[0] <= 0xBF) {
-            *endp = s + 2;
-            return ((c - 0xC0) << 6) + (p[0] - 0x80);
-        }
-    } else
-    if (c < 0xF0) {
-        if (p[0] >= 0x80 && p[0] <= 0xBF
-        &&  p[1] >= 0x80 && p[1] <= 0xBF) {
-            c = ((c - 0xE0) << 12) + ((p[0] - 0x80) << 6) + (p[1] - 0x80);
-            if (c >= 0x800) {
-                *endp = s + 3;
-                return c;
-            }
-        }
-    } else
-    if (c <= 0xF4) {
-        if (p[0] >= 0x80 && p[0] <= 0xBF
-        &&  p[1] >= 0x80 && p[1] <= 0xBF
-        &&  p[2] >= 0x80 && p[2] <= 0xBF) {
-            c = ((c - 0xF0) << 18) + ((p[0] - 0x80) << 12) +
-                ((p[1] - 0x80) << 6) + (p[2] - 0x80);
-            if (c >= 0x10000 && c < 0x110000) {
-                *endp = s + 4;
-                return c;
-            }
-        }
+fn u32 hexconv(const char* p, u32 maxn, u32* pc) {
+    u32 cc = 0;
+    u32 i;
+    for (i = 0; i < maxn; i++) {
+        i32 xval = 0;
+        char c = p[i];
+        if (c >= '0' && c <= '9')
+            xval = c - '0';
+        else
+        if (c >= 'a' && c <= 'f')
+            xval = c - 'a' + 10;
+        else
+        if (c >= 'A' && c <= 'F')
+            xval = c - 'A' + 10;
+        else
+            break;
+        cc = cc * 16 + xval;
     }
-    return -1;
+    *pc = cc;
+    return i;
+}
+
+fn u32 octconv(const char* p, u32 maxn, u32* pc) {
+    u32 cc = 0;
+    u32 i;
+    for (i = 0; i < maxn; i++) {
+        char c = p[i];
+        if (c >= '0' && c <= '7')
+            cc = cc * 8 + (c - '0');
+        else
+            break;
+    }
+    *pc = cc;
+    return i;
 }

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -304,10 +304,11 @@ public type Token struct {
     Radix radix;   // Radix: for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
     union {
         const char* error_msg;  // ERROR
-        struct {
-            u32 text_idx;  // Identifier
-            u32 text_len;  // StringLiteral, includes 0
+        struct {           // StringLiteral, LineComment, BlockComment
+            u32 text_idx;    // pool index of encoded string or comment
+            u32 text_len;    // length of converted string (without null terminator)
         }
+        u32 name_idx;      // Identifier
         u64 int_value;     // IntegerLiteral
         f64 float_value;   // FloatLiteral
         u8 char_value;     // CharLiteral

--- a/plugins/git_version_plugin.c2
+++ b/plugins/git_version_plugin.c2
@@ -91,7 +91,7 @@ fn void init(void* arg, plugin_info.Info* info) {
 
     // create variable
     u32 version = info.astPool.addStr(p.version, false);
-    ast.StringLiteral* str = ast.StringLiteral.create(info.context, 0, version, cast<u32>(strlen(p.version))+1);
+    ast.StringLiteral* str = ast.StringLiteral.create(info.context, 0, version, cast<u32>(strlen(p.version)));
     ast.Expr* initExpr = cast<ast.Expr*>(str);
     ast.VarDecl* vd = ast.VarDecl.create(info.context, ast.VarDeclKind.GlobalVar, var_name, 0, true, &ref, a.getIdx(), 0, initExpr);
     ast.Decl* d = vd.asDecl();

--- a/plugins/shell_cmd_plugin.c2
+++ b/plugins/shell_cmd_plugin.c2
@@ -166,6 +166,8 @@ fn bool run_cmd(Cmd* cmd, string_buffer.Buf* out) {
         return false;
     }
 
-    out.print("public const char[] %s = \"%s\";\n\n", cmd.variable, output);
+    out.print("public const char[] %s = \"", cmd.variable);
+    out.encodeBytes(output, cast<u32>(strlen(output)), '"');
+    out.add("\";\n\n");
     return true;
 }

--- a/recipe.txt
+++ b/recipe.txt
@@ -57,6 +57,7 @@ executable c2c
     common/string_list.c2
     common/string_utils.c2
     common/target_info.c2
+    common/utf8.c2
     common/utils.c2
     common/value_maplist.c2
     common/warning_flags.c2
@@ -287,6 +288,7 @@ executable tester
     common/file/reader.c2
     common/file/writer.c2
     common/string_utils.c2
+    common/utf8.c2
 	tools/tester/tester.c2
 	tools/tester/line_db.c2
 	tools/tester/test_db.c2
@@ -305,6 +307,7 @@ executable c2cat
     common/constants.c2
     common/file/reader.c2
     common/string_list.c2
+    common/utf8.c2
 
     ast_utils/string_pool.c2
 
@@ -329,6 +332,7 @@ executable c2loc
     common/library_list.c2
     common/source_mgr.c2
     common/string_list.c2
+    common/utf8.c2
     common/warning_flags.c2
 
     compiler/c2recipe.c2
@@ -453,6 +457,7 @@ lib deps_generator dynamic
     common/source_mgr.c2
     common/string_list.c2
     common/string_utils.c2
+    common/utf8.c2
     common/utils.c2
     common/warning_flags.c2
 
@@ -593,6 +598,7 @@ lib refs_generator dynamic
     common/source_mgr.c2
     common/string_list.c2
     common/string_utils.c2
+    common/utf8.c2
     common/utils.c2
     common/warning_flags.c2
 
@@ -738,6 +744,7 @@ lib git_version dynamic
     common/source_mgr.c2
     common/string_list.c2
     common/string_utils.c2
+    common/utf8.c2
     common/utils.c2
     common/warning_flags.c2
 
@@ -874,6 +881,7 @@ lib load_file dynamic
     common/source_mgr.c2
     common/string_list.c2
     common/string_utils.c2
+    common/utf8.c2
     common/utils.c2
     common/warning_flags.c2
 
@@ -1016,6 +1024,7 @@ lib unit_test dynamic
     common/source_mgr.c2
     common/string_list.c2
     common/string_utils.c2
+    common/utf8.c2
     common/utils.c2
     common/warning_flags.c2
 
@@ -1155,6 +1164,7 @@ lib shell_cmd dynamic
     common/source_mgr.c2
     common/string_list.c2
     common/string_utils.c2
+    common/utf8.c2
     common/utils.c2
     common/warning_flags.c2
 

--- a/test/stmt/switch/switch_case_duplicate_str.c2
+++ b/test/stmt/switch/switch_case_duplicate_str.c2
@@ -1,0 +1,23 @@
+module test;
+
+fn void test1(char *s) {
+    switch (s) {
+    case nil:     // @note{previous case is here}
+        break;
+    case "a":
+        break;
+    case nil:     // @error{duplicate case value nil}
+        break;
+    }
+}
+
+fn void test2(char *s) {
+    switch (s) {
+    case "a":     // @note{previous case is here}
+        break;
+    case "b":
+        break;
+    case "a":     // @error{duplicate case string}
+        break;
+    }
+}

--- a/test/stmt/switch/switch_case_embedded_null.c2
+++ b/test/stmt/switch/switch_case_embedded_null.c2
@@ -1,0 +1,26 @@
+module test;
+
+fn void test3(char *s) {
+    switch (s) {
+    case "a\0b":     // @error{case string value has embedded null byte}
+        break;
+    case "c" "\0" "d":  // @error{case string value has embedded null byte}
+        break;
+    case "a\0":     // @error{case string value has embedded null byte}
+        break;
+    case "\0a":     // @error{case string value has embedded null byte}
+        break;
+    case "\0":     // @error{case string value has embedded null byte}
+        break;
+    case "\00":     // @error{case string value has embedded null byte}
+        break;
+    case "\000":     // @error{case string value has embedded null byte}
+        break;
+    case "\x00":     // @error{case string value has embedded null byte}
+        break;
+    case "\u0000":     // @error{case string value has embedded null byte}
+        break;
+    case "\U00000000":     // @error{case string value has embedded null byte}
+        break;
+    }
+}

--- a/test/stmt/switch/switch_str_case_too_long.c2
+++ b/test/stmt/switch/switch_str_case_too_long.c2
@@ -22,10 +22,10 @@ fn void test1(const char* str) {
     "0123456789abcdef"
     "0123456789abcdef"
     "0123456789abcdef"
-    "0123456789abcd":       // max len 254 bytes
+    "0123456789abcde":  // max len 255 bytes
         break;
     case
-    "0123456789abcdef"  // @error{string switch case string is loo long (max 254 bytes)}
+    "0123456789abcdef"  // @error{string switch case string is loo long (max 255 bytes)}
     "0123456789abcdef"
     "0123456789abcdef"
     "0123456789abcdef"
@@ -43,7 +43,7 @@ fn void test1(const char* str) {
     "0123456789abcdef"
     "0123456789abcdef"
     "0123456789abcdef"
-    "0123456789abcde":
+    "0123456789abcdef":
     default:
         break;
     }

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -176,7 +176,7 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
     }
     switch (tok.kind) {
     case Identifier:
-        const char* str = ctx.pool.idx2str(tok.text_idx);
+        const char* str = ctx.pool.idx2str(tok.name_idx);
 
         if (ctx.in_attributes && is_attribute(str)) {
             out.color(col_attr);
@@ -235,10 +235,11 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         ctx.offset = tok.loc + len;
         break;
     case StringLiteral:
+        ctx.tokenizer.buf.clear();
+        ctx.tokenizer.buf.encodeBytes(ctx.pool.idx2str(tok.text_idx), tok.text_len, '"');
         out.color(col_string);
-        const char* str = ctx.pool.idx2str(tok.text_idx);
-        out.print("\"%s\"", str);
-        ctx.offset = tok.loc + cast<u32>(strlen(str)) + 2;
+        out.print("\"%s\"", ctx.tokenizer.buf.data());
+        ctx.offset = tok.loc + ctx.tokenizer.buf.size() + 2;
         break;
     case LineComment:
         out.color(col_comment);


### PR DESCRIPTION
* add `Token.name_idx` for clarity
* use `Token.text_idx` only for strings and comments
* `Token.text_len` no longer counts the null terminator, as the name implies
* simplify multi string concatenation.
* accept unicode escape sequences in strings and character constants
* report invalid UTF-8 sequences in strings and character constants
* add `StringLiteral.getTextIndex()`
* add `string_buffer.Buf.encodeBytes()` to encode string fragments with
* add `string_buffer.Buf.add_utf8()` to encode Unicode codepoints in UTF-8 backslash escapes.
* add **utf8** module for encoding and decoding Unicode code points.
* allow up to 255 bytes in string `case` labels
* detect and report duplicate string case labels
* detect and report string case labels `case` with embedded nulls bytes