### PR TITLE
compiler: improve string_utils and diagnostics output

### DIFF
--- a/ast/symbol_table.c2
+++ b/ast/symbol_table.c2
@@ -18,9 +18,9 @@ module ast;
 import string_buffer;
 import color;
 
+import stdio local;
 import stdlib;
 import string;
-import stdio;
 
 public type SymbolTable struct {
     u32 num_symbols;
@@ -121,8 +121,7 @@ public fn void SymbolTable.dump(const SymbolTable* t) {
         const char* name = ast.idx2name(name_idx);
         out.print("  [%2d]  %6d  %s\n", i, name_idx, name);
     }
-    out.stripNewline();  // puts will add another
-    stdio.puts(out.data());
+    fputs(out.data(), stdout);
     out.free();
 }
 

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -109,20 +109,6 @@ public fn void Buf.add2(Buf* buf, const char* text, u32 len) {
     buf.data_[buf.size_] = '\0';
 }
 
-public fn void Buf.add_line(Buf* buf, const char* text) {
-    assert(text);
-    const char* end = text;
-    // TODO: take maximum length as argument
-    // TODO: avoid splitting in the middle of a UTF-8 encoding
-    while (*end) {
-        if (*end == '\n' || *end == '\r') break;
-        end++;
-        if ((end - text) >= 256) break;
-    }
-    u32 len = cast<u32>(end - text);
-    buf.add2(text, len);
-}
-
 public fn void Buf.newline(Buf* buf) {
     if (buf.size_ + 2 > buf.capacity) {
         u32 new_cap = buf.capacity * 2;
@@ -149,6 +135,14 @@ public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) {
     assert(len < sizeof(tmp));
     buf.add2(tmp, cast<u32>(len));
     va_end(args);
+}
+
+public fn void Buf.vprintf(Buf* buf, const char* format, Va_list args) {
+    char[4096] tmp;
+    // NOTE: no growing
+    i32 len = vsnprintf(tmp, sizeof(tmp), format, args);
+    assert(len < sizeof(tmp));
+    buf.add2(tmp, cast<u32>(len));
 }
 
 public fn void Buf.indent(Buf* buf, u32 indent) {

--- a/common/diagnostics.c2
+++ b/common/diagnostics.c2
@@ -20,6 +20,7 @@ import source_mgr;
 import string_buffer;
 import src_loc local;
 import string_utils;
+import utf8;
 import utils;
 
 import stdarg local;
@@ -29,13 +30,13 @@ import stdlib;
 public type GetTokenEndFn fn SrcLoc (const char* input, SrcLoc start);
 
 public type Diags struct @(opaque) {
-    source_mgr.SourceMgr* sm;
-    string_buffer.Buf* out;
+    source_mgr.SourceMgr* sm;   // no ownership
+    string_buffer.Buf* out;     // owned
     u32 num_errors;
     u32 num_warnings;
     bool promote_warnings;
     GetTokenEndFn get_token_end;
-    const utils.PathInfo* path_info;
+    const utils.PathInfo* path_info;  // no ownership
 }
 
 public fn Diags* create(source_mgr.SourceMgr* sm, bool use_color, GetTokenEndFn get_token_end, const utils.PathInfo* path_info) {
@@ -80,12 +81,10 @@ const char*[] category_colors = {
 }
 
 public fn void Diags.error(Diags* diags, SrcLoc loc, const char* format @(printf_format), ...) {
-    Category category = Category.Error;
-
     Va_list args;
     va_start(args, format);
     SrcRange range = { 0, 0 }
-    diags.internal(category, loc, range, format, args);
+    diags.internal(Category.Error, loc, range, format, args);
     va_end(args);
 }
 
@@ -128,11 +127,9 @@ public fn void Diags.errorRange(Diags* diags,
                                 SrcLoc loc,
                                 SrcRange range,
                                 const char* format @(printf_format), ...) {
-    Category category = Category.Error;
-
     Va_list args;
     va_start(args, format);
-    diags.internal(category, loc, range, format, args);
+    diags.internal(Category.Error, loc, range, format, args);
     va_end(args);
 }
 
@@ -159,15 +156,7 @@ fn void Diags.internal(Diags* diags,
     string_buffer.Buf* out = diags.out;
     out.clear();
 
-    source_mgr.Location startLoc = diags.sm.getLocation(range.start);
     source_mgr.Location loc = diags.sm.getLocation(sloc);
-    // get end of last token
-    if (range.end) {
-        const char* src = diags.sm.get_token_source(range.end);
-        range.end = diags.get_token_end(src, range.end);
-    }
-    source_mgr.Location endLoc = diags.sm.getLocation(range.end);
-
     if (sloc) {
         if (diags.path_info.hasSubdir() && loc.filename[0] != '/') {
             out.add(diags.path_info.root2orig);
@@ -180,53 +169,93 @@ fn void Diags.internal(Diags* diags,
     out.add(": ");
     out.color(color.Normal);
 
-    char[256] tmp;
-    vsprintf(tmp, format, args);
-    out.add(tmp);
-    out.add("\n");
+    out.vprintf(format, args);
+    out.newline();
 
     if (sloc) {
-        // TODO if it's too long, just show relevant part
+        // Show the source line and point to the error/range location.
+        // the source line is printed first
+        // then a second line with ~~~~~^~~~~ pointing to the error location
+        // and the region if any.
+        // if the source line is long, an initial part is skipped (`skip` bytes)
         assert(loc.line_start);
-        out.add_line(loc.line_start);
-        out.add("\n");
-
+        const char *text = loc.line_start;  // pointer to the source code line
+        u32 loc_col = loc.column;       // column number for the error
+        u32 range_start_col = loc_col;  // column number for start of the ~~~ area
+        u32 range_end_col = loc_col + 1; // column number for end of the ~~~ area
+        u32 end_col = loc_col + 1;      // column number where to stop the cursor
         if (range.start && range.end) {
-            // TODO handle case where a Range is spread over multiple lines
-            assert(endLoc.column >= startLoc.column);
-            // print tabs as tabs
-            u32 offset = startLoc.column -1;
-            u32 tabs = string_utils.count_tabs(startLoc.line_start, offset);
-            assert(offset >= tabs);
-            offset -= tabs;
-            for (u32 i=0; i<tabs; i++) out.add1('\t');
-            out.indent(offset);
-            out.color(color.Bgreen);
-            u32 end_col = endLoc.column;
-            // Note: only handle loc in/after range, NOT before
-            if (loc.column > end_col) end_col = loc.column;
-            for (u32 i=startLoc.column; i<=end_col; i++) {
-                //for (u32 i=startLoc.column; i<=endLoc.column; i++) {
-                if (i == loc.column) out.add("^");
-                else if (i<=endLoc.column) out.add("~");
-                else out.space();
+            // get end of last token
+            if (diags.get_token_end) {
+                const char* src = diags.sm.get_token_source(range.end);
+                range.end = diags.get_token_end(src, range.end);
             }
-            out.color(color.Normal);
-        } else {
-            // print tabs as tabs
-            u32 offset = loc.column -1;
-            u32 tabs = string_utils.count_tabs(loc.line_start, offset);
-            assert(offset >= tabs);
-            offset -= tabs;
-            for (u32 i=0; i<tabs; i++) out.add1('\t');
-            out.indent(offset);
-            out.color(color.Bgreen);
-            out.add("^");
-            out.color(color.Normal);
+            source_mgr.Location startLoc = diags.sm.getLocation(range.start);
+            source_mgr.Location endLoc = diags.sm.getLocation(range.end);
+            // ignore range if spanning more than one line or not on the same line as error
+            if (loc.line == startLoc.line && loc.line == endLoc.line && startLoc.column < endLoc.column) {
+                range_start_col = startLoc.column;
+                range_end_col = endLoc.column;
+                if (end_col < range_end_col)    // output until the end of the region
+                    end_col = range_end_col;
+            }
+            printf("loc: %d,%d,%d  start: %d,%d,%d  end: %d,%d,%d\n",
+                   sloc, loc.line, loc.column,
+                   range.start, startLoc.line, startLoc.column,
+                   range.end, endLoc.line, endLoc.column);
         }
-    }
+        // If the line is long, show a fragment up to 128 bytes around the error
+        u32 skip = 0;
+        if (loc_col > 128) {
+            skip = loc_col - 64;
+            skip += utf8.sync(&text[skip]);  // Skip UTF-8 continuation bytes
+            // `skip` bytea are not displayed, update the boundaries of the region,
+            // the error location, the end of output and adjust the test pointer.
+            if (range_start_col > skip)
+                range_start_col -= skip;
+            else
+                range_start_col = 1;
+            if (range_end_col > skip)
+                range_end_col -= skip;
+            else
+                range_end_col = 1;
+            loc_col -= skip;
+            end_col -= skip;
+            text += skip;
+        }
+        // compute the length of the source line, potentially truncated if too long
+        u32 len = 0;
+        while (len < 128 && text[len] && text[len] != '\n' && text[len] != '\r') {
+            len++;
+        }
+        len += utf8.sync(&text[len]);  // Skip UTF-8 continuation bytes
+        if (end_col > len + 2)    // no need to output ~ past the end of the visible part
+            end_col = len + 2;
 
-    fprintf(stderr, "%s\n", out.data());
+        printf("len: %d  skip: %d  loc_col: %d  range_start: %d  range_end: %d  end_col: %d\n",
+               len, skip, loc_col, range_start_col, range_end_col, end_col);
+
+        // output the source line or fragment thereof
+        if (skip) out.add("...");
+        out.add2(text, len);
+        out.newline();
+
+        // Output the position indicator: indent with the same mixture of tabs and spaces
+        // TODO: handle wide codepoints potentially present in strings and comments
+        if (skip) out.add("   ");
+        for (u32 col = 1; col < end_col; col++) {
+            char c = ' ';
+            if (text[col - 1] == '\t')  // if a TAB was output in the soure
+                c = '\t';               // output a TAB at the same position
+            if (col == range_start_col) out.color(color.Bgreen);
+            if (col >= range_start_col && col < range_end_col) c = '~';
+            if (col == loc_col) c = '^';
+            out.add1(c);
+        }
+        out.color(color.Normal);
+        out.newline();
+    }
+    fputs(out.data(), stderr);
 }
 
 public fn bool Diags.isOk(const Diags* diags) { return diags.num_errors == 0; }

--- a/common/string_utils.c2
+++ b/common/string_utils.c2
@@ -15,36 +15,35 @@
 
 module string_utils;
 
-import ctype;
+import ctype local;
 import string local;
 
-public fn u32 count_tabs(const char* text, u32 len) {
-    u32 count = 0;
-    const char* cp = text;
-    for (u32 i=0; i<len; i++) {
-        if (*cp == 0) break;
-        if (*cp == '\t') count++;
-        if (*cp == '\n' || *cp == '\r') break;
-        cp++;
-        if ((cp - text) >= 256) break;
+public fn char* toLower(const char* input, char* output) @(unused) {
+    usize i;
+    for (i = 0; input[i]; i++) {
+        output[i] = cast<char>(toupper(input[i]));
     }
-    return count;
+    output[i] = '\0';
+    return output;
 }
 
-public fn void toUpper(const char* input, char* output) {
-    while (*input) {
-        *output = cast<char>(ctype.toupper(*input));
-        input++;
-        output++;
+public fn char* toUpper(const char* input, char* output) @(unused) {
+    usize i;
+    for (i = 0; input[i]; i++) {
+        output[i] = cast<char>(toupper(input[i]));
     }
-    *output = 0;
+    output[i] = '\0';
+    return output;
 }
 
-public fn void stripNewLine(char* buf) @(unused) {
+public fn char* stripNewLine(char* buf) @(unused) {
     usize len = strlen(buf);
-    if (buf[len -1] == '\n') {
-        buf[len -1] = 0;
+    if (len > 0 && buf[len - 1] == '\n') {
+        buf[--len] = '\0';
+        if (len > 0 && buf[len - 1] == '\r')
+            buf[--len] = '\0';
     }
+    return buf;
 }
 
 public fn void split_cmd_args(const char* input, char* cmd, char* args) @(unused) {

--- a/common/utf8.c2
+++ b/common/utf8.c2
@@ -95,3 +95,12 @@ public fn u32 decode(const char *p, u32 max_len, u32* pc) {
     }
     return 0;
 }
+
+// skip UTF-8 continuation bytes to reach a character boundary
+public fn u32 sync(const char* p) {
+    u32 i = 0;
+    while (i < 3 && (p[i] & 0xC0) == 0x80)
+        i++;
+    return i;
+}
+

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -152,7 +152,7 @@ fn void Parser.expectAndConsume(Parser* p, Kind kind) {
     if (p.prev_loc) {
         const char* src = p.sm.get_token_source(p.prev_loc);
         SrcLoc loc = parser_utils.getTokenEnd(src, p.prev_loc);
-        p.tok.loc = loc + 1;    // get position after current
+        p.tok.loc = loc;    // get position after current
     }
     if (p.tok.loc == 0) {
         // just point to start of file (happens on empty file)
@@ -168,7 +168,7 @@ fn void Parser.expect(Parser* p, Kind kind) {
     if (p.prev_loc) {
         const char* src = p.sm.get_token_source(p.prev_loc);
         SrcLoc loc = parser_utils.getTokenEnd(src, p.prev_loc);
-        p.tok.loc = loc + 1;    // get position after current
+        p.tok.loc = loc;    // get position after current
     }
     if (p.tok.loc == 0) {
         // just point to start of file (happens on empty file)

--- a/parser/parser_utils.c2
+++ b/parser/parser_utils.c2
@@ -39,6 +39,6 @@ public fn SrcLoc getTokenEnd(const char* input, SrcLoc start) {
     features.free();
     pool.free();
     buf.free();
-    return start + cast<SrcLoc>(tokenizer.cur - tokenizer.input_start) - 1;
+    return start + cast<SrcLoc>(tokenizer.cur - tokenizer.input_start);
 }
 


### PR DESCRIPTION
string_buffer:
* remove `string_buffer.Buf.add_line()`
* add `string_buffer.Buf.vprintf()`

string_utils:
* remove `string_utils.count_tabs()`
* add `string_utils.toLower()`
* fix UB on empty string in `stripNewLine()`
* handle `\r\n` in `stripNewLine()`
* return destination pointer in `toLower()`, `toUpper()`,  `stripNewline()`

utf8:
* add `utf8_sync()` to find character boundaries

parser_utils:
* return offset past the end in `getTokenEnd()`

diagnostics:
* improve range handling
* display line fragment for long lines
* detect and ignore region spanning multiple lines
* handle tabs anywhere on source line