### PR TITLE
compiler: improve label grammar correctness

### DIFF
--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -41,7 +41,10 @@ fn bool hasReturn(const Stmt* s) {
             break;
         case Label:
             // TODO
-            break;
+            const LabelStmt* ls = cast<LabelStmt*>(s);
+            const Stmt* lss = ls.getStmt();
+            if (!lss) return false;
+            return hasReturn(lss);
         case Compound:
             const CompoundStmt* cs = cast<CompoundStmt*>(s);
             const Stmt* last = cs.getLastStmt();
@@ -93,8 +96,8 @@ fn void Analyser.analyseStmt(Analyser* ma, Stmt* s, bool checkEffect) {
         ma.analyseFallthroughStmt(s);
         break;
     case Label:
-        ma.analyseLabelStmt(s);
         ma.scope.setReachable();
+        ma.analyseLabelStmt(s);
         break;
     case Goto:
         ma.analyseGotoStmt(s);
@@ -153,6 +156,8 @@ fn void Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {
     } else {
         ma.labels.add(name, ls.getLoc(), true);
     }
+    Stmt* lss = ls.getStmt();
+    if (lss) ma.analyseStmt(lss, true);
 }
 
 fn void Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -375,6 +375,11 @@ fn bool isTerminatingStmt(const Stmt* s, bool is_default) {
         return true;
     case Fallthrough:
         return !is_default;
+    case Label:
+        const LabelStmt* ls = cast<LabelStmt*>(s);
+        const Stmt* stmt = ls.getStmt();
+        if (!stmt) return false;
+        return isTerminatingStmt(stmt, is_default);
     case Goto:
         return true;
     case Compound:

--- a/ast/label_stmt.c2
+++ b/ast/label_stmt.c2
@@ -23,17 +23,25 @@ public type LabelStmt struct @(opaque) {
     Stmt base;
     SrcLoc loc;
     u32 name;
+    Stmt *stmt;
 }
 
-public fn LabelStmt* LabelStmt.create(ast_context.Context* c, u32 name, SrcLoc loc) {
+public fn LabelStmt* LabelStmt.create(ast_context.Context* c, u32 name, SrcLoc loc, Stmt *stmt) {
     LabelStmt* s = c.alloc(sizeof(LabelStmt));
     s.base.init(StmtKind.Label);
     s.loc = loc;
     s.name = name;
+    s.stmt = stmt;
 #if AstStatistics
     Stats.addStmt(StmtKind.Label, sizeof(LabelStmt));
 #endif
     return s;
+}
+
+fn Stmt* LabelStmt.instantiate(LabelStmt* s, Instantiator* inst) {
+    if (!s.stmt) return cast<Stmt*>(s);
+
+    return cast<Stmt*>(LabelStmt.create(inst.c, s.name, s.loc, s.stmt.instantiate(inst)));
 }
 
 public fn const char* LabelStmt.getName(const LabelStmt* s) {
@@ -48,9 +56,19 @@ public fn SrcLoc LabelStmt.getLoc(const LabelStmt* s) {
     return s.loc;
 }
 
+public fn Stmt* LabelStmt.getStmt(const LabelStmt* s) {
+    return s.stmt;
+}
+
+public fn void LabelStmt.setStmt(LabelStmt* s, Stmt* stmt) {
+    s.stmt = stmt;
+}
+
 fn void LabelStmt.print(const LabelStmt* s, string_buffer.Buf* out, u32 indent) {
-    s.base.printKind(out, indent);
+    s.base.printKind(out, indent - 1);
     out.color(col_Value);
     out.print(" %s\n", idx2name(s.name));
+    if (s.stmt)
+        s.stmt.print(out, indent);
 }
 

--- a/ast/stmt.c2
+++ b/ast/stmt.c2
@@ -117,7 +117,7 @@ fn Stmt* Stmt.instantiate(Stmt* s, Instantiator* inst) {
     case Fallthrough:
         return s;
     case Label:
-        return s;
+        return LabelStmt.instantiate(cast<LabelStmt*>(s), inst);
     case Goto:
         return s;
     case Compound:

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -38,7 +38,7 @@ static_assert(80, sizeof(FunctionDecl));
 
 static_assert(4, sizeof(Stmt));
 static_assert(12, sizeof(GotoStmt));
-static_assert(12, sizeof(LabelStmt));
+static_assert(24, sizeof(LabelStmt));
 static_assert(16, sizeof(AssertStmt));
 static_assert(16, sizeof(DeclStmt));
 static_assert(16, sizeof(SwitchStmt));

--- a/generator/ast_visitor.c2
+++ b/generator/ast_visitor.c2
@@ -195,6 +195,11 @@ fn void Visitor.handleStmt(Visitor* v, Stmt* s) {
     case Fallthrough:
         break;
     case Label:
+        LabelStmt* ls = cast<LabelStmt*>(s);
+        ast.Stmt* stmt = ls.getStmt();
+        if (stmt) {
+            v.handleStmt(stmt);
+        }
         break;
     case Goto:
         // TODO need dest in GotoStmt

--- a/generator/c/c2i_generator_stmt.c2
+++ b/generator/c/c2i_generator_stmt.c2
@@ -21,7 +21,12 @@ import string_buffer;
 fn void Generator.emitStmt(Generator* gen, ast.Stmt* s, u32 indent, bool newline) {
     string_buffer.Buf* out = gen.out;
 
-    if (newline) out.indent(indent);
+    if (newline) {
+        if (s.getKind() == StmtKind.Label)
+            out.indent(indent - 1);
+        else
+            out.indent(indent);
+    }
 
     switch (s.getKind()) {
     case Return:
@@ -142,9 +147,17 @@ fn void Generator.emitStmt(Generator* gen, ast.Stmt* s, u32 indent, bool newline
         out.add("fallthrough;\n");
         break;
     case Label:
-        LabelStmt* l = cast<LabelStmt*>(s);
-        out.add(l.getName());
-        out.add(":\n");
+        LabelStmt* ls = cast<LabelStmt*>(s);
+        ast.Stmt* stmt = ls.getStmt();
+        out.add(ls.getName());
+        out.add1(':');
+        if (!stmt || stmt.isDecl()) {
+            out.add1(';');
+        }
+        out.newline();
+        if (stmt) {
+            gen.emitStmt(stmt, indent, true);
+        }
         break;
     case Goto:
         GotoStmt* g = cast<GotoStmt*>(s);

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -174,9 +174,17 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         out.add("fallthrough;\n");
         break;
     case Label:
-        LabelStmt* l = cast<LabelStmt*>(s);
-        out.add(l.getName());
-        out.add(":\n");
+        LabelStmt* ls = cast<LabelStmt*>(s);
+        ast.Stmt* stmt = ls.getStmt();
+        out.add(ls.getName());
+        out.add1(':');
+        if (!stmt || stmt.isDecl()) {
+            out.add1(';');
+        }
+        out.newline();
+        if (stmt) {
+            gen.emitStmt(stmt, indent, true);
+        }
         break;
     case Goto:
         GotoStmt* g = cast<GotoStmt*>(s);

--- a/generator/qbe/qbe_generator_stmt.c2
+++ b/generator/qbe/qbe_generator_stmt.c2
@@ -67,10 +67,14 @@ fn bool Generator.emitStmt(Generator* gen, const Stmt* s) {
     case Fallthrough:
         break;
     case Label:
-        const LabelStmt* l = cast<LabelStmt*>(s);
-        u32 blkname_idx = gen.getLabelBlock(l.getNameIdx());
+        const LabelStmt* ls = cast<LabelStmt*>(s);
+        u32 blkname_idx = gen.getLabelBlock(ls.getNameIdx());
         const char* name = gen.names.idx2str(blkname_idx);
         gen.startBlock(name, name);
+        const Stmt* stmt = ls.getStmt();
+        if (stmt) {
+            return gen.emitStmt(stmt);
+        }
         return true;
     case Goto:
         const GotoStmt* g = cast<GotoStmt*>(s);

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -871,8 +871,8 @@ public fn Stmt* Builder.actOnFallthroughStmt(Builder* b, SrcLoc loc) {
     return cast<Stmt*>(FallthroughStmt.create(b.context, loc));
 }
 
-public fn Stmt* Builder.actOnLabelStmt(Builder* b, u32 name, SrcLoc loc) {
-    return cast<Stmt*>(LabelStmt.create(b.context, name, loc));
+public fn Stmt* Builder.actOnLabelStmt(Builder* b, u32 name, SrcLoc loc, Stmt* stmt) {
+    return cast<Stmt*>(LabelStmt.create(b.context, name, loc, stmt));
 }
 
 public fn Stmt* Builder.actOnGotoStmt(Builder* b, u32 name, SrcLoc loc) {

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -550,7 +550,18 @@ fn Stmt* Parser.parseLabelStmt(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken(); // identifier
     p.expectAndConsume(Kind.Colon);
-    return p.builder.actOnLabelStmt(name, loc);
+    Stmt* stmt = nil;
+    switch (p.tok.kind) {
+    case RBrace:
+    case KW_case:
+    case KW_default:
+    case KW_fallthrough:
+        break;
+    default:
+        stmt = p.parseStmt();
+        break;
+    }
+    return p.builder.actOnLabelStmt(name, loc, stmt);
 }
 
 fn Stmt* Parser.parseGotoStmt(Parser* p) {

--- a/test/stmt/label_decl.c2
+++ b/test/stmt/label_decl.c2
@@ -1,0 +1,45 @@
+module test;
+
+fn void foo(i32 x) {
+    if (x == 0) goto begin;
+    else
+    if (x == 1) goto end;
+    else
+    if (x == 2) done: return;
+    else
+    if (x == 3) goto done;
+begin:            // label before a declaration must expand to `begin:;`
+    i32 i = 0;
+    foo(x + i);
+end:              // label before a closing brace must expand to `end:;`
+}
+
+fn void bar(i32 x) {
+    switch (x) {
+    case 0: goto begin;
+    case 1: goto end;
+    case 2: done: return;
+    case 3: goto done;
+    case 4:
+    begin:
+    //case 5:      // should be able to label case clause
+        i32 i = 0;
+        foo(x + i);
+        break;
+    case 6:
+        if (x > 10) return;
+        else return;
+    case 9:
+    default:
+    end:
+    //default:      // should be able to label default clause
+        break;
+    }
+}
+
+public fn i32 main() {
+    foo(0);
+    bar(0);
+    return 0;
+}
+


### PR DESCRIPTION
* add `Stmt` pointer in `Label` structure.
* fix grammar for labelled statements and definitions. eg: `if (cond) done: return 0;` is now a single statement.
* accept labelled definitions (generate `label:;`)
* accept labels at end of block (generate `label:;`)
* add tests