### PR TITLE
file_utils: improve Reader and Writer consistency

### DIFF
--- a/common/file/reader.c2
+++ b/common/file/reader.c2
@@ -20,76 +20,108 @@ import c_errno local;
 import sys_stat local;
 import unistd local;
 import stdlib;
+import string;
 
 u8 empty;
 
-public const i32 Err_not_a_file = 2001;
+const i32 Err_not_a_file = 2001;
+const i32 Err_read_error = 2002;
 
 public type Reader struct {
-    void* region;
+    u8* region_;
     u32 size;
-    i32 errno;
+    i32 errno_;
 }
 
 public fn bool Reader.open(Reader* file, const char* filename) {
-    file.region = nil;
+    file.region_ = nil;
     file.size = 0;
+    file.errno_ = 0;
 
-    i32 fd = open(filename, O_RDONLY);
+    i32 fd = open(filename, O_RDONLY | O_BINARY);
     if (fd == -1) {
-        file.errno = errno;
+        file.errno_ = errno;
         return false;
     }
 
     Stat statbuf;
-    i32 err = fstat(fd, &statbuf);
-    if (err) {
-        file.errno = errno;
+    if (fstat(fd, &statbuf)) {
+        file.errno_ = errno;
+        close(fd);
         return false;
     }
 
     if (statbuf.st_mode & S_IFMT != S_IFREG) {
+        file.errno_ = Err_not_a_file;
         close(fd);
-        file.errno = Err_not_a_file;
         return false;
     }
 
-    file.size = cast<u32>(statbuf.st_size);
+    u32 size = cast<u32>(statbuf.st_size);
+    u8* region;
 
-    if (file.size == 0) {
-        file.region = &empty;
+    if (size == 0) {
+        region = &empty;
     } else {
-        file.region = stdlib.malloc(file.size+1);
-        isize numread = read(fd, file.region, file.size);
-        if (numread != file.size) return false;
-        // 0-terminate
-        u8* ptr = file.region;
-        ptr[file.size] = 0;
+        region = stdlib.malloc(size + 1);
+        // TODO: handle chunked or interrupted I/O
+        i64 numread = read(fd, region, size);
+        if (numread < 0) {
+            file.errno_ = errno;
+            stdlib.free(region);
+            close(fd);
+            return false;
+        }
+        if (numread != size) {
+            file.errno_ = Err_read_error;
+            stdlib.free(region);
+            close(fd);
+            return false;
+        }
+        region[size] = '\0';
     }
+    file.region_ = region;
+    file.size = size;
     close(fd);
     return true;
 }
 
 public fn void Reader.close(Reader* file) {
     if (file.size) {
-        stdlib.free(file.region);
-        file.region = nil;
+        stdlib.free(file.region_);
+        file.region_ = nil;
+        file.size = 0;
     }
 }
 
 public fn bool Reader.isOpen(const Reader* file) {
-    return file.region != nil;
+    return file.region_ != nil;
 }
 
-public fn const u8* Reader.data(Reader* file) @(unused) {
-    return cast<u8*>(file.region);
+public fn const u8* Reader.udata(Reader* file) @(unused) {
+    return file.region_;
 }
 
-public fn const char* Reader.char_data(Reader* file) @(unused) {
-    return cast<char*>(file.region);
+public fn const char* Reader.data(Reader* file) @(unused) {
+    return cast<const char*>(file.region_);
 }
 
 public fn bool Reader.isEmpty(const Reader* file) @(unused) {
     return file.size == 0;
 }
 
+public fn const char* Reader.getError(const Reader* file) @(unused) {
+    const char *msg;
+    switch (file.errno_) {
+    case Err_not_a_file:
+        msg = "not a regular file";
+        break;
+    case Err_read_error:
+        msg = "read error";
+        break;
+    default:
+        msg = string.strerror(file.errno_);
+        break;
+    }
+    return msg;
+}

--- a/common/file/writer.c2
+++ b/common/file/writer.c2
@@ -15,27 +15,35 @@
 
 module file_utils;
 
-import stdio local;
 import libc_fcntl local;
 import c_errno local;
 import string local;
 import unistd local;
 
+const i32 Err_write_error = 2003;
+
 public type Writer struct {
-    char[512] msg;
+    i32 errno_;
 }
 
-public fn bool Writer.write(Writer* writer, const char* filename, const u8* data, u32 len) {
-    writer.msg[0] = 0;
-    i32 fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0660);
+public fn bool Writer.write(Writer* writer, const char* filename, const void* data, u32 len) {
+    writer.errno_ = 0;
+
+    i32 fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0660);
     if (fd == -1) {
-        sprintf(writer.msg, "error opening %s: %s", filename, strerror(errno));
+        writer.errno_ = errno;
         return false;
     }
 
+    // TODO: handle chunked or interrupted I/O
     i64 written = write(fd, data, len);
+    if (written < 0) {
+        writer.errno_ = errno;
+        close(fd);
+        return false;
+    }
     if (written != len) {
-        sprintf(writer.msg, "error writing %s: %s", filename, strerror(errno));
+        writer.errno_ = Err_write_error;
         close(fd);
         return false;
     }
@@ -44,7 +52,16 @@ public fn bool Writer.write(Writer* writer, const char* filename, const u8* data
     return true;
 }
 
-public fn const char* Writer.getError(const Writer* writer) {
-    return writer.msg;
+public fn const char* Writer.getError(const Writer* file) @(unused) {
+    const char *msg;
+    switch (file.errno_) {
+    case Err_read_error:
+        msg = "read error";
+        break;
+    default:
+        msg = string.strerror(file.errno_);
+        break;
+    }
+    return msg;
 }
 

--- a/common/manifest_writer.c2
+++ b/common/manifest_writer.c2
@@ -80,10 +80,10 @@ public fn void write(const char* dir, component.Component* c, const char* filena
 
     char[constants.Max_path] fullname;
     // TODO use stringbuf for this
-    stdio.sprintf(fullname, "%s/%s", dir, filename);
+    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", dir, filename);
     file_utils.Writer writer;
-    if (!writer.write(fullname, cast<u8*>(out.data()), out.size())) {
-        console.error("%s", writer.getError());
+    if (!writer.write(fullname, out.data(), out.size())) {
+        console.error("cannot write to %s: %s", fullname, writer.getError());
         exit(EXIT_FAILURE);
     }
 }

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -92,7 +92,7 @@ fn u32 File.size(const File* f) {
 
 fn const char* File.data(File* f) {
     if (f.is_generated) return f.contents.data();
-    return f.file.char_data();
+    return f.file.data();
 }
 
 fn void File.addCheckPoint(File* f, u32 offset, u32 line) {
@@ -220,21 +220,13 @@ fn file_utils.Reader SourceMgr.openInternal(SourceMgr* sm, const char* filename,
     if (file.open(filename)) {
         sm.num_open++;
     } else {
-        char[256] error_msg;
-        if (file.errno == file_utils.Err_not_a_file) {
-            stdio.sprintf(error_msg, "cannot open %s: %s\n",
-                filename, "not a regular file");
-        } else {
-            stdio.sprintf(error_msg, "cannot open %s: %s\n",
-                filename, string.strerror(file.errno));
-        }
         // TODO only color if enabled (cannot use console since we need source loc first)
         if (loc) {
-            stdio.fprintf(stdio.stderr, "%s: %serror:%s %s\n",
-                sm.loc2str(loc), color.Red, color.Normal, error_msg);
+            stdio.fprintf(stdio.stderr, "%s: %serror:%s cannot open %s: %s\n",
+                sm.loc2str(loc), color.Red, color.Normal, filename, file.getError());
         } else {
-            stdio.fprintf(stdio.stderr, "%serror%s: %s\n",
-                color.Red, color.Normal, error_msg);
+            stdio.fprintf(stdio.stderr, "%serror%s: cannot open %s: %s\n",
+                color.Red, color.Normal, filename, file.getError());
         }
     }
     return file;

--- a/compiler/compiler_libs.c2
+++ b/compiler/compiler_libs.c2
@@ -96,7 +96,7 @@ fn void Compiler.open_lib(Compiler* c, Component* comp) {
     }
 
     char[512] fullname;
-    stdio.sprintf(fullname, "%s/%s", libdir, constants.manifest_name);
+    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", libdir, constants.manifest_name);
     u32 filename_idx = c.auxPool.addStr(fullname, false);
     i32 file_id = c.sm.open(filename_idx, 0, false);
     if (file_id == -1) return;
@@ -242,15 +242,15 @@ fn void Compiler.showLibs(Compiler* c, string_buffer.Buf* out, const char* dirna
     }
 
     char[512] fullname;
-    Dirent* entry = readdir(dir);
-    while (entry != nil) {
+    while (Dirent* entry = readdir(dir)) {
         const char* name = entry.d_name;
         if (name[0] != '.' && entry.d_type == DT_DIR) {
-            i32 len = stdio.sprintf(fullname, "%s/%s/%s", dirname, name, constants.manifest_name);
+            i32 len = stdio.snprintf(fullname, elemsof(fullname), "%s/%s/%s", dirname, name, constants.manifest_name);
+            if (len >= elemsof(fullname)) continue;
 
             Stat statbuf;
             i32 err = stat(fullname, &statbuf);
-            if (err) goto next;
+            if (err) continue;
 
             u32 filename_idx = c.auxPool.add(fullname, cast<usize>(len), false);
 
@@ -303,8 +303,6 @@ fn void Compiler.showLibs(Compiler* c, string_buffer.Buf* out, const char* dirna
                 out.newline();
             }
         }
-next:
-        entry = readdir(dir);
     }
     closedir(dir);
 }

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -73,7 +73,7 @@ fn void create_project(const char* name) {
     buf.add("}\n");
     bool ok = writer.write("main.c2", buf.udata(), buf.size());
     if (!ok) {
-        console.error("%s", writer.getError());
+        console.error("cannot write to %s: %s", "main.c2", writer.getError());
         exit(EXIT_FAILURE);
     }
 
@@ -89,7 +89,7 @@ fn void create_project(const char* name) {
     buf.add("end\n");
     ok = writer.write("recipe.txt", buf.udata(), buf.size());
     if (!ok) {
-        console.error("%s", writer.getError());
+        console.error("cannot write to %s: %s", "recipe.txt", writer.getError());
         exit(EXIT_FAILURE);
     }
 

--- a/generator/c/c2i_generator.c2
+++ b/generator/c/c2i_generator.c2
@@ -58,12 +58,12 @@ public fn void generate(const char* output_dir,
 
 fn void Generator.write(Generator* gen, const char* output_dir) {
     char[constants.Max_path] fullname;
-    stdio.sprintf(fullname, "%s/%s.c2i", output_dir, gen.mod.getName());
+    stdio.snprintf(fullname, elemsof(fullname), "%s/%s.c2i", output_dir, gen.mod.getName());
 
     file_utils.Writer writer;
     bool ok = writer.write(fullname, gen.out.udata(), gen.out.size());
     if (!ok) {
-        console.error("%s", writer.getError());
+        console.error("cannot write to %s: %s", fullname, writer.getError());
     }
 }
 

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -1037,9 +1037,9 @@ fn void Generator.generateInterfaceFiles(Generator* gen, Module* m) {
 
     file_utils.Writer writer;
     char[constants.Max_path] fullname;
-    stdio.sprintf(fullname, "%s/%s.h", gen.results_dir, m.getName());
-    if (!writer.write(fullname, cast<u8*>(hdr.data()), hdr.size())) {
-        console.error("%s", writer.getError());
+    stdio.snprintf(fullname, elemsof(fullname), "%s/%s.h", gen.results_dir, m.getName());
+    if (!writer.write(fullname, hdr.data(), hdr.size())) {
+        console.error("cannot write to %s: %s", fullname, writer.getError());
     }
     gen.cur_external = false;
 }
@@ -1160,12 +1160,12 @@ fn void Generator.free(Generator* gen) {
 
 fn void Generator.write(Generator* gen, const char* output_dir, const char* filename, string_buffer.Buf* buf) {
     char[constants.Max_path] fullname;
-    stdio.sprintf(fullname, "%s/%s", output_dir, filename);
+    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", output_dir, filename);
 
     file_utils.Writer writer;
     bool ok = writer.write(fullname, buf.udata(), buf.size());
     if (!ok) {
-        console.error("%s", writer.getError());
+        console.error("cannot write to %s: %s", fullname, writer.getError());
     }
 }
 

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -269,10 +269,10 @@ fn void Generator.generateC2TypesHeader(Generator* gen) {
     out.add("#endif\n");
 
     char[constants.Max_path] fullname;
-    stdio.sprintf(fullname, "%s/c2types.h", gen.results_dir);
+    stdio.snprintf(fullname, elemsof(fullname), "%s/c2types.h", gen.results_dir);
     file_utils.Writer writer;
-    if (!writer.write(fullname, cast<u8*>(out.data()), out.size())) {
-        console.error("%s", writer.getError());
+    if (!writer.write(fullname, out.data(), out.size())) {
+        console.error("cannot write to %s: %s", fullname, writer.getError());
     }
     out.clear();
 }

--- a/generator/qbe/qbe_generator.c2
+++ b/generator/qbe/qbe_generator.c2
@@ -530,12 +530,12 @@ fn void Generator.free(Generator* gen) {
 
 fn void Generator.write(Generator* gen, const char* output_dir, const char* filename) {
     char[constants.Max_path] fullname;
-    stdio.sprintf(fullname, "%s/%s", output_dir, filename);
+    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", output_dir, filename);
 
     file_utils.Writer writer;
-    bool ok = writer.write(fullname, cast<u8*>(gen.out.data()), gen.out.size());
+    bool ok = writer.write(fullname, gen.out.data(), gen.out.size());
     if (!ok) {
-        console.error("%s", writer.getError());
+        console.error("cannot write to %s: %s", fullname, writer.getError());
     }
 }
 

--- a/plugins/deps_generator.c2
+++ b/plugins/deps_generator.c2
@@ -415,7 +415,7 @@ public fn void generate(const char* title, const char* output_dir, component.Lis
     char[128] outfile;
     sprintf(outfile, "%s/%s", output_dir, "deps.xml");
     file_utils.Writer file;
-    file.write(outfile, cast<u8*>(out.data()), out.size());
+    file.write(outfile, out.data(), out.size());
 
     if (gen.visitor) gen.visitor.free();
 

--- a/plugins/load_file_plugin.c2
+++ b/plugins/load_file_plugin.c2
@@ -22,7 +22,6 @@ import plugin_info;
 import string_buffer;
 import yaml;
 
-import c_errno local;
 import ctype;
 import stdio;
 import stdlib local;
@@ -43,11 +42,12 @@ type Plugin struct {
 }
 
 fn void escape(string_buffer.Buf* out, file_utils.Reader* file, bool terminate) {
-    const u8* data = file.data();
+    const u8* data = file.udata();
+    u32 size = file.size;
     out.add("  ");
-    for (u32 i=0; i<file.size; i++) {
+    for (u32 i = 0; i < size; i++) {
         out.print("0x%02X,", data[i]);
-        if (i%20 == 19) {
+        if (i % 20 == 19) {
             out.newline();
             out.add("  ");
         }
@@ -61,7 +61,7 @@ fn bool load_file(string_buffer.Buf* out, const char* filename, const char* vari
 
     file_utils.Reader file;
     if (!file.open(filename)) {
-        console.error("load_file: cannot open file %s: %s", filename, strerror(errno));
+        console.error("load_file: cannot open file %s: %s", filename, file.getError());
         return false;
     }
 
@@ -154,12 +154,12 @@ fn void init(void* arg, plugin_info.Info* info) {
     console.debug("load_file: opening %s", p.config_file);
     file_utils.Reader file;
     if (!file.open(p.config_file)) {
-        console.error("load_file: cannot open file %s: %s", p.config_file, strerror(errno));
+        console.error("load_file: cannot open file %s: %s", p.config_file, file.getError());
         exit(EXIT_FAILURE);
     }
 
     yaml.Parser* parser = yaml.Parser.create();
-    if (!parser.parse(file.char_data())) {
+    if (!parser.parse(file.data())) {
         console.error("load_file: %s", parser.getMessage());
         exit(EXIT_FAILURE);
     }
@@ -175,7 +175,7 @@ fn void init(void* arg, plugin_info.Info* info) {
     stdio.sprintf(fullname, "%s/%s", info.output_dir, "loadfile.c2");
     console.debug("load_file: writing %s (%d bytes)", fullname, out.size());
     if (!outfile.write(fullname, out.udata(), out.size())) {
-        console.error("load_file: %s", outfile.msg);
+        console.error("load_file: cannot write to %s: %s", fullname, outfile.getError());
         exit(EXIT_FAILURE);
     }
 

--- a/plugins/shell_cmd_plugin.c2
+++ b/plugins/shell_cmd_plugin.c2
@@ -25,7 +25,6 @@ import string_utils;
 import utils;
 import yaml;
 
-import c_errno local;
 import stdlib local;
 import string local;
 
@@ -78,11 +77,11 @@ fn void init(void* arg, plugin_info.Info* info) {
     console.debug("shell_cmd: opening %s", p.config_file);
     file_utils.Reader file;
     if (!file.open(p.config_file)) {
-        console.error("shell_cmd: cannot open file %s: %s", p.config_file, strerror(errno));
+        console.error("shell_cmd: cannot open file %s: %s", p.config_file, file.getError());
         exit(EXIT_FAILURE);
     }
     yaml.Parser* parser = yaml.Parser.create();
-    if (!parser.parse(file.char_data())) {
+    if (!parser.parse(file.data())) {
         console.error("shell_cmd: %s", parser.getMessage());
         exit(EXIT_FAILURE);
     }

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -279,7 +279,7 @@ public fn i32 c2cat(const char* filename)
 {
     file_utils.Reader file;
     if (!file.open(filename)) {
-        fprintf(stderr, "error opening %s: %s\n", filename, strerror(file.errno));
+        fprintf(stderr, "error opening %s: %s\n", filename, file.getError());
         return -1;
     }
 
@@ -287,7 +287,7 @@ public fn i32 c2cat(const char* filename)
     ctx.pool = string_pool.create(16*1024, 1024);
     ctx.out = string_buffer.create(16*1024, true, 2);
     ctx.offset = 0;
-    ctx.input = file.char_data();
+    ctx.input = file.data();
     ctx.in_attributes = 0;
 
     string_list.List features;

--- a/tools/common/replacer.c2
+++ b/tools/common/replacer.c2
@@ -107,7 +107,7 @@ fn void Replacer.flushFragments(Replacer* r, const char* filename) {
     }
 
     //printf("Fragments:\n");
-    const u8* src = r.file.data();
+    const u8* src = r.file.udata();
     u32 dest_idx = 0;
     for (u32 i=0; i<r.f_count; i++) {
         Fragment* f = &r.fragments[i];
@@ -123,9 +123,9 @@ fn void Replacer.flushFragments(Replacer* r, const char* filename) {
     r.dest[dest_idx] = 0;
 
     // write
-    file_utils.Writer outfile = {}
+    file_utils.Writer outfile;
     if (!outfile.write(filename, r.dest, new_size)) {
-        fprintf(stderr, "%s\n", outfile.getError());
+        fprintf(stderr, "cannot write to %s: %s\n", filename, outfile.getError());
     }
 
     r.f_count = 0;
@@ -163,9 +163,8 @@ fn u32 Replacer.findOffset(Replacer* r, u32 line, u32 column) {
     //printf("find offset %d %d  file.size %d\n", line, column, r.file.size);
     // TODO cache last entry
 
-    const u8* data = r.file.data();
     u32 cur_line = 1;
-    const char* start = cast<char*>(data);
+    const char* start = r.file.data();
     const char* cp = start;
 
     u32 offset = findLine(cp, line);
@@ -204,7 +203,7 @@ public fn i32 Replacer.replace(Replacer* r, u16 old_len) {
             }
             cur_file = filename;
             if (!r.file.open(filename)) {
-                fprintf(stderr, "error opening %s: %s\n", filename, string.strerror(errno));
+                fprintf(stderr, "error opening %s: %s\n", filename, r.file.getError());
                 return -1;
             }
         }

--- a/tools/tester/expect_file.c2
+++ b/tools/tester/expect_file.c2
@@ -163,13 +163,13 @@ public fn bool ExpectFile.check(ExpectFile* f, string_buffer.Buf* output_, const
     file_utils.Reader file;
     bool ok = file.open(fullname);
     if (!ok) {
-        fprintf(stderr, "error opening %s: %s\n", fullname, strerror(errno));
+        fprintf(stderr, "error opening %s: %s\n", fullname, file.getError());
         exit(EXIT_FAILURE);
     }
 
     if (f.lines.size() == 0) return true;
 
-    const char* lineStart = cast<char*>(file.data());
+    const char* lineStart = file.data();
     f.setExpected();
 
     u32 line_nr = 1;

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -216,7 +216,7 @@ fn void Db.writeFile(Db* db, const char* filename, const char* data, u32 len) {
     file_utils.Writer writer;
     bool ok = writer.write(fullname, cast<u8*>(data), len);
     if (!ok) {
-        print_error("error writing %s: %s", fullname, strerror(errno));
+        print_error("error writing %s: %s", fullname, writer.getError());
         exit(EXIT_FAILURE);
     }
 }
@@ -690,7 +690,7 @@ public fn void Db.parseLine(Db* db, const char* start, const char* end) {
 }
 
 public fn bool Db.parse(Db* db) {
-    const char* cp = cast<char*>(db.file.data());
+    const char* cp = db.file.data();
     db.cur = cp;
     db.line_nr = 1;
 

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -258,7 +258,7 @@ fn void Tester.run_test(Tester* t, Test* test) {
     file_utils.Reader file;
     bool ok = file.open(test.filename);
     if (!ok) {
-        fprintf(stderr, "error opening %s: %s\n", test.filename, strerror(errno));
+        fprintf(stderr, "error opening %s: %s\n", test.filename, file.getError());
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
* open files in binary mode for portability
* hide `errno` member
* add error codes for partial read and write
* add `Reader.getError()` to get error string
* make `Writer.getError()` return error string instead of full message
* improve error detection
* free `Reader` data on errors
* always close file handle on errors
* improve consistency with string_buffer:
  * rename `Reader.data()` as `Reader.udata()`
  * rename `Reader.char_data()` as `Reader.data()`
* `Writer.write()` takes a `const void*` to avoid casts
* simplify `File.addCheckPoint()` error handling
* use `snprintf` to concatenate paths