### PR TITLE
analyser: fix scope error in static_assert

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -448,14 +448,16 @@ fn void Analyser.handleTypeDecl(void* arg, Decl* d) {
 
 fn void Analyser.handleStaticAssert(void* arg, StaticAssert* d) {
     Analyser* ma = arg;
-    ma.scope = d.getAST().getPtr();
 
     StaticAssert* sa = cast<StaticAssert*>(d);
     Expr* lhs = sa.getLhs();
     Expr* rhs = sa.getRhs();
 
+    // push a dummy declaration so ma.popCheck() does not set ma.scope to nil
+    if (!ma.pushCheck(nil, d.getAST().getPtr(), nil)) return;
     QualType t1 = ma.analyseExpr(&lhs, false, RHS);
     QualType t2 = ma.analyseExpr(&rhs, false, RHS);
+    ma.popCheck();
     if (t1.isInvalid() || t2.isInvalid()) return;
 
     bool error = false;
@@ -583,29 +585,34 @@ fn void Analyser.checkVarDeclAttributes(Analyser* ma, VarDecl* v) {
 
 // Note: fd is only set if analysing function bodies
 fn bool Analyser.pushCheck(Analyser* ma, Decl* d, scope.Scope* s, FunctionDecl* fd) {
-    for (u32 i=0; i<ma.checkIndex; i++) {
-        if (ma.checkStack[i].decl == d) {
-            for (u32 j=i; j<ma.checkIndex; j++) {
-                const Decl* other = ma.checkStack[j].decl;
-                ma.error(other.getLoc(), "circular declaration dependency '%s'", other.getName());
+    if (d) {
+        for (u32 i=0; i<ma.checkIndex; i++) {
+            if (ma.checkStack[i].decl == d) {
+                for (u32 j=i; j<ma.checkIndex; j++) {
+                    const Decl* other = ma.checkStack[j].decl;
+                    if (other) {
+                        ma.error(other.getLoc(), "circular declaration dependency '%s'", other.getName());
+                    }
+                }
+                // TODO use longjmp here?
+                return false;
             }
-            // TODO use longjmp here?
-            return false;
         }
     }
     // set correct scope for the current Decl (might be in different file than current Decl)
     ma.scope = s;
+    assert(ma.checkIndex <= MaxDepth);
     StackLayer* top = &ma.checkStack[ma.checkIndex];
     top.decl = d;
-    top.scope = ma.scope;
+    top.scope = s;
     top.function = fd;
-    top.usedPublic = d.isPublic();
+    top.usedPublic = d && d.isPublic();
+    // TODO: ma.curFunction may be reset by ma.popCheck()
     if (fd) ma.curFunction = fd;
     ma.usedPublic = top.usedPublic;
     ma.checkIndex++;
     // for function bodies
-    if (!d.isChecked()) d.setCheckInProgress();
-    assert(ma.checkIndex <= MaxDepth);
+    if (d && !d.isChecked()) d.setCheckInProgress();
     return true;
 }
 

--- a/test/parser/sizeof_expr_ok.c2
+++ b/test/parser/sizeof_expr_ok.c2
@@ -11,6 +11,7 @@ type Foo struct {
      f64 d;
   }
 }
+
 fn void test1() {
     Handle[2] hh;
 
@@ -27,3 +28,53 @@ fn void test1() {
     i32 k = sizeof(test.Foo.d);
 }
 
+type MyStruct struct {
+    u8[16] def;
+    u8* p;
+    usize size;
+}
+
+MyStruct s;
+MyStruct* sp = &s;
+
+// Try various combinations that caused a crash with ma.scope == nil
+static_assert(sizeof(char[8]), 8);
+static_assert(sizeof(char*), sizeof(usize));
+static_assert(sizeof(MyStruct), 16 + 2 * sizeof(usize));
+static_assert(sizeof(MyStruct), sizeof(s.def) + sizeof(s.p) + sizeof(s.size));
+static_assert(sizeof(MyStruct), sizeof(MyStruct) + sizeof(s) - sizeof(MyStruct));
+static_assert(sizeof(MyStruct), sizeof(s));
+static_assert(sizeof(MyStruct*), sizeof(usize));
+static_assert(sizeof(MyStruct*), sizeof(sp));
+static_assert(sizeof(sp), sizeof(MyStruct*));
+static_assert(sizeof(sp), sizeof(sp));
+//static_assert(sizeof(const MyStruct[10]), sizeof(MyStruct) * 10);
+//static_assert(sizeof(MyStruct[10]), sizeof(MyStruct) * 10);
+static_assert(sizeof(s), 32);
+//static_assert(sizeof(*&s), 32);
+static_assert(sizeof(s), sizeof(s));
+static_assert(sizeof(s), sizeof(MyStruct));
+//static_assert(sizeof(s), sizeof(MyStruct[1]));
+static_assert(sizeof(MyStruct), sizeof(s));
+static_assert(sizeof(MyStruct), sizeof(MyStruct));
+static_assert(32, sizeof(MyStruct));
+static_assert(sizeof(s.p), sizeof(usize));
+static_assert(sizeof(s.def), 16);
+//static_assert(sizeof(*s.def), 1);
+//static_assert(sizeof(s.def[1]), 1);
+
+i32[20] aa;
+
+static_assert(sizeof(aa), 80);
+//static_assert(sizeof(aa[0]), 4);
+//static_assert(sizeof(*aa), 4);
+
+i32 cond = 1;
+
+static_assert(sizeof(cond), 4);
+//static_assert(sizeof(cond + cond), 4);
+
+const char[] Error = "error";
+
+static_assert(sizeof(Error), 6);
+//static_assert(sizeof(*Error), 1);


### PR DESCRIPTION
Use a dummy entry in the scope stack for `static_assert` analysis. just setting ma.scope does not work: if the first expression causes `ma.pushCheck()` and `ma.popCheck()`, `ma.scope` gets reset to `nil` and the analysis of the second expression causes a null pointer exception. eg:
```
static_assert(sizeof(MyStruct), sizeof(s.def) + sizeof(s.p) + sizeof(s.size));
```