### PR TITLE
parser: change Tokenizer.lookahead() API to simplify tests

### DIFF
--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -269,8 +269,8 @@ fn void Parser.parseTopLevel(Parser* p) {
         case Eof:
             break;
         case Identifier:
-            Token next = p.tokenizer.lookahead(1);
-            if (next.kind == Kind.PlusEqual) {
+            Kind kind = p.tokenizer.lookahead(1, nil);
+            if (kind == Kind.PlusEqual) {
                 if (is_public) p.error("incremental array entries cannot be public");
                 p.parseArrayEntry();
                 break;

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -251,8 +251,7 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
         // Fast-path, keep checking multiple identifier.identifier. etc
         // parse them all in a single MemberExpr
         //TODO res = p.parseFullIdentifier(); (is a bit slower, since it checks again)
-        Token t2 = p.tokenizer.lookahead(1);
-        if (t2.kind == Kind.Dot) {
+        if (p.tokenizer.lookahead(1, nil) == Kind.Dot) {
             res = p.parsePureMemberExpr();
         } else {
             res = p.parseIdentifier().asExpr();
@@ -530,21 +529,18 @@ fn bool Parser.isTemplateFunctionCall(Parser* p) {
     u32 ahead = 1;
 
     // fast path, just for builtintype
-    Token t = p.tokenizer.lookahead(ahead);
-    //p.dump_token(&t);
-    if (t.kind >= Kind.KW_bool && t.kind <= Kind.KW_void) return true;
+    Kind kind = p.tokenizer.lookahead(ahead, nil);
+    if (kind >= Kind.KW_bool && kind <= Kind.KW_void) return true;
 
     // TODO keep mini state machine: 0 initial, 1-> seen id (dot changes nothing), 3-> * seen. if id in 3, return false (a*b)
     while (ahead < 8) {
-        t = p.tokenizer.lookahead(ahead);
-        switch (t.kind) {
+        switch (p.tokenizer.lookahead(ahead, nil)) {
         case Identifier:
         case Star:
         case Dot:
             break;
         case Greater:
-            t = p.tokenizer.lookahead(ahead+1);
-            return t.kind == Kind.LParen;
+            return p.tokenizer.lookahead(ahead+1, nil) == Kind.LParen;
         case KW_const:
             return true;
         default:
@@ -759,8 +755,7 @@ fn Expr* Parser.parseToContainerExpr(Parser* p) {
 fn Expr* Parser.parseFullIdentifier(Parser* p) {
     p.expectIdentifier();
 
-    Token t2 = p.tokenizer.lookahead(1);
-    if (t2.kind == Kind.Dot) {
+    if (p.tokenizer.lookahead(1, nil) == Kind.Dot) {
         return p.parsePureMemberExpr();
     }
     return p.parseIdentifier().asExpr();
@@ -798,8 +793,7 @@ fn bool Parser.parseAsType(Parser* p, bool* has_brackets) {
 
     u32 lookahead = 1;
     while (1) {
-        Token t2 = p.tokenizer.lookahead(lookahead);
-        switch (t2.kind) {
+        switch (p.tokenizer.lookahead(lookahead, nil)) {
         case Identifier:
             break;
         case Star:

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -101,15 +101,14 @@ fn Stmt* Parser.parseStmt(Parser* p) {
 */
 fn bool Parser.isTypeSpec(Parser* p) {
     assert(p.tok.kind == Kind.Identifier);
-    Token t;
+    Kind kind;
 
     // State: 0 = ID1, 1 = ID2, 2 = pointers, 3 = arrays
     u32 state = 0;
     u32 lookahead = 1;
     // TODO check lookahead otherwise Tokenizer can assert
     while (1) {
-        Token t2 = p.tokenizer.lookahead(lookahead);
-        switch (t2.kind) {
+        switch (p.tokenizer.lookahead(lookahead, nil)) {
         case Identifier:
             goto type_done;
         case LSquare:
@@ -123,8 +122,8 @@ fn bool Parser.isTypeSpec(Parser* p) {
             break;
         case Dot:
             if (state == 0) {
-                Token t3 = p.tokenizer.lookahead(lookahead+1);
-                if (t3.kind != Kind.Identifier) {
+                kind = p.tokenizer.lookahead(lookahead+1, nil);
+                if (kind != Kind.Identifier) {
                     // syntax error
                     return false;
                 }
@@ -140,8 +139,8 @@ fn bool Parser.isTypeSpec(Parser* p) {
     }
 type_done:
     // if token after type is identifier, it's a decl, otherwise it's not
-    t = p.tokenizer.lookahead(lookahead);
-    return t.kind == Kind.Identifier;
+    kind = p.tokenizer.lookahead(lookahead, nil);
+    return kind == Kind.Identifier;
 }
 
 fn u32 Parser.skipArray(Parser* p, u32 lookahead) {
@@ -151,8 +150,8 @@ fn u32 Parser.skipArray(Parser* p, u32 lookahead) {
     u32 square_depth = 1;
     u32 paren_depth = 0;
     while (square_depth) {
-        Token next = p.tokenizer.lookahead(lookahead);
-        switch (next.kind) {
+        Token next;
+        switch (p.tokenizer.lookahead(lookahead, &next)) {
         case LParen:
             paren_depth++;
             break;
@@ -198,8 +197,8 @@ fn Stmt* Parser.parseDeclOrStmt(Parser* p) {
 
     if (isDecl) return p.parseDeclStmt(true, true);
 
-    Token next = p.tokenizer.lookahead(1);
-    if (next.kind == Kind.Colon) return p.parseLabelStmt();
+    Kind kind = p.tokenizer.lookahead(1, nil);
+    if (kind == Kind.Colon) return p.parseLabelStmt();
 
     return p.parseExprStmt();
 }

--- a/parser/c2_parser_switch.c2
+++ b/parser/c2_parser_switch.c2
@@ -68,8 +68,8 @@ fn Expr* Parser.parseCaseCondition(Parser* p, identifier_expr_list.List* list) {
     // TODO: parse constant expression, not just single token.
     bool multi_case = false;
     if (p.tok.kind == Kind.Identifier) {
-        Token t2 = p.tokenizer.lookahead(1);
-        if (t2.kind == Kind.Comma || t2.kind == Kind.Range) multi_case = true;
+        Kind kind = p.tokenizer.lookahead(1, nil);
+        if (kind == Kind.Comma || kind == Kind.Range) multi_case = true;
     }
 
     if (!multi_case) {

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -648,7 +648,7 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
     }
 }
 
-public fn Token Tokenizer.lookahead(Tokenizer* t, u32 n) {
+public fn Kind Tokenizer.lookahead(Tokenizer* t, u32 n, Token *tok) {
     assert(n > 0);
     assert(n <= MaxLookahead);
     while (t.next_count < n) {
@@ -658,7 +658,8 @@ public fn Token Tokenizer.lookahead(Tokenizer* t, u32 n) {
     }
 
     u32 slot = (t.next_head + n - 1) % MaxLookahead;
-    return t.next[slot];
+    if (tok) *tok = t.next[slot];
+    return t.next[slot].kind;
 }
 
 fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {


### PR DESCRIPTION
- make `Tokenizer.lookahead()` return the token kind and read the token value if destination is not `nil`.