### PR TITLE
compiler: improve assert statement

### DIFF
--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -355,8 +355,6 @@ fn void Analyser.analyseAssertStmt(Analyser* ma, Stmt* s) {
     QualType qt = ma.analyseExpr(a.getInner2(), true, RHS);
     if (qt.isInvalid()) return;
 
-    if (qt.isPointer()) a.setPointer();
-
     Expr* inner = a.getInner();
     ma.checker.check(builtins[BuiltinKind.Bool], qt, a.getInner2(), inner.getLoc());
 }

--- a/ast/assert_stmt.c2
+++ b/ast/assert_stmt.c2
@@ -19,11 +19,6 @@ import ast_context;
 import src_loc local;
 import string_buffer;
 
-type AssertStmtBits struct {
-    u32 : NumStmtBits;
-    u32 is_pointer : 1;
-}
-
 public type AssertStmt struct @(opaque) {
     Stmt base;
     SrcLoc loc;
@@ -54,14 +49,6 @@ public fn SrcLoc AssertStmt.getLoc(const AssertStmt* s) { return s.loc; }
 public fn Expr* AssertStmt.getInner(const AssertStmt* s) { return s.inner; }
 
 public fn Expr** AssertStmt.getInner2(AssertStmt* s) { return &s.inner; }
-
-public fn void AssertStmt.setPointer(AssertStmt* s) {
-    s.base.assertStmtBits.is_pointer = 1;
-}
-
-public fn bool AssertStmt.isPointer(const AssertStmt* s) {
-    return s.base.assertStmtBits.is_pointer;
-}
 
 fn void AssertStmt.print(const AssertStmt* s, string_buffer.Buf* out, u32 indent) {
     s.base.printKind(out, indent);

--- a/ast/binary_operator.c2
+++ b/ast/binary_operator.c2
@@ -148,7 +148,9 @@ fn void BinaryOperator.print(const BinaryOperator* e, string_buffer.Buf* out, u3
 
 fn void BinaryOperator.printLiteral(const BinaryOperator* e, string_buffer.Buf* out) {
     e.lhs.printLiteral(out);
+    out.space();
     out.add(binaryOpcode_names[e.getOpcode()]);
+    out.space();
     e.rhs.printLiteral(out);
 }
 

--- a/ast/builtin_expr.c2
+++ b/ast/builtin_expr.c2
@@ -211,25 +211,28 @@ fn void BuiltinExpr.print(const BuiltinExpr* e, string_buffer.Buf* out, u32 inde
 fn void BuiltinExpr.printLiteral(const BuiltinExpr* e, string_buffer.Buf* out) {
     out.add(builtin_names[e.getKind()]);
     out.lparen();
-    out.rparen();
     switch (e.getKind()) {
     case Sizeof:
+        e.inner.printLiteral(out);
         break;
     case Elemsof:
-        break;
     case EnumMin:
-        break;
     case EnumMax:
+        e.inner.printLiteral(out);
         break;
     case OffsetOf:
-        // TODO
-        //e.offset[0].member.print(out, indent + 1);
+        e.inner.printLiteral(out);
+        out.add(", ");
+        e.offset[0].member.printLiteral(out);
         break;
     case ToContainer:
-        // TODO
-        //e.container[0].member.print(out, indent + 1);
-        //e.container[0].pointer.print(out, indent + 1);
+        e.inner.printLiteral(out);
+        out.add(", ");
+        e.container[0].member.printLiteral(out);
+        out.add(", ");
+        e.container[0].pointer.printLiteral(out);
         break;
     }
+    out.rparen();
 }
 

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -176,7 +176,13 @@ public fn Expr** CallExpr.getArgs(CallExpr* e) {
 }
 
 fn void CallExpr.printLiteral(const CallExpr* e, string_buffer.Buf* out) {
-    out.add("CALL TODO");
+    e.func.printLiteral(out);
+    out.lparen();
+    for (u32 i = 0; i < e.getNumArgs(); i++) {
+        if (i) out.add(", ");
+        e.args[i].printLiteral(out);
+    }
+    out.rparen();
 }
 
 fn void CallExpr.print(const CallExpr* e, string_buffer.Buf* out, u32 indent) {

--- a/ast/char_literal.c2
+++ b/ast/char_literal.c2
@@ -66,40 +66,11 @@ public fn void CharLiteral.printLiteral(const CharLiteral* e, string_buffer.Buf*
         out.print("'\\x%02x'", c);
         return;
     default:
-        break;
-    }
-
-    switch (c) {
-    case '\a':
-        out.add("'\\a'");
-        break;
-    case '\b':
-        out.add("'\\b'");
-        break;
-    case '\f':
-        out.add("'\\f'");
-        break;
-    case '\n':
-        out.add("'\\n'");
-        break;
-    case '\r':
-        out.add("'\\r'");
-        break;
-    case '\t':
-        out.add("'\\t'");
-        break;
-    case '\v':
-        out.add("'\\v'");
-        break;
-    case '\'':
-        out.add("'\\''");
-        break;
-    case '\\':
-        out.add("'\\\\'");
-        break;
-    default:
-        out.print("'%c'", c);
-        break;
+        out.add1('\'');
+        char cc = c;
+        out.encodeBytes(&cc, 1, '\'');
+        out.add1('\'');
+        return;
     }
 }
 

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -559,8 +559,8 @@ public fn void Expr.printLiteral(const Expr* e, string_buffer.Buf* out) {
         IdentifierExpr.printLiteral(cast<IdentifierExpr*>(e), out);
         return;
     case Type:
-        // can happen? array[enum_max(Enum)} ?
-        break;
+        TypeExpr.printLiteral(cast<TypeExpr*>(e), out, false);
+        return;
     case Call:
         CallExpr.printLiteral(cast<CallExpr*>(e), out);
         return;
@@ -601,7 +601,7 @@ public fn void Expr.printLiteral(const Expr* e, string_buffer.Buf* out) {
         ImplicitCastExpr.printLiteral(cast<ImplicitCastExpr*>(e), out);
         return;
     }
-    out.print("?? kind=%d", e.getKind());
+    out.print("<<kind=%d>>", e.getKind());
 }
 
 fn void Expr.printKind(const Expr* e, string_buffer.Buf* out, u32 indent) {

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -296,10 +296,11 @@ fn void MemberExpr.print(const MemberExpr* e, string_buffer.Buf* out, u32 indent
 
 fn void MemberExpr.printLiteral(const MemberExpr* e, string_buffer.Buf* out) {
     if (e.hasExpr()) {
-        out.add("<expr>.");
+        e.refs[0].expr.printLiteral(out);
+        out.add1('.');
     }
-    for (u32 i=0; i<e.getNumRefs(); i++) {
-        if (i != 0) out.add(".");
+    for (u32 i = 0; i < e.getNumRefs(); i++) {
+        if (i != 0) out.add1('.');
         out.add(e.getName(i));
     }
 }

--- a/ast/stmt.c2
+++ b/ast/stmt.c2
@@ -67,7 +67,6 @@ const u32 NumStmtBits = 4;
 public type Stmt struct @(opaque) {
     union {
         StmtBits stmtBits;
-        AssertStmtBits assertStmtBits;
         AsmStmtBits asmStmtBits;
         LabelStmtBits labelStmtBits;
         ReturnStmtBits returnStmtBits;

--- a/ast/type_expr.c2
+++ b/ast/type_expr.c2
@@ -63,3 +63,6 @@ fn void TypeExpr.print(const TypeExpr* e, string_buffer.Buf* out, u32 indent) {
     out.newline();
 }
 
+fn void TypeExpr.printLiteral(const TypeExpr* e, string_buffer.Buf* out, bool decay) {
+    e.typeRef.printLiteral(out, true, decay);
+}

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -324,7 +324,7 @@ public fn Expr** TypeRef.getArray2(TypeRef* r, u32 idx) {
     return &arrays[idx];
 }
 
-public fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool print_prefix) {
+public fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool print_prefix, bool decay) {
     if (r.isConst()) out.add("const ");
     if (r.isVolatile()) out.add("volatile ");
 
@@ -345,8 +345,19 @@ public fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bo
     // note: convert arrays into pointers
     if (r.flags.incr_array) out.add("*");
 
-    for (u32 i=0; i<r.flags.num_arrays; i++) {
-        out.add("*");
+    if (decay) {
+        // TODO: this seems incorrect: char[10][10] does not decay as char**
+        for (u32 i = 0; i < r.flags.num_arrays; i++) {
+            out.add("*");
+        }
+    } else {
+        for (u32 i = 0; i < r.flags.num_arrays; i++) {
+            out.add1('[');
+            const Expr* a = r.getArray(i);
+            // note: a can be nil, when[]
+            if (a) a.printLiteral(out);
+            out.add1(']');
+        }
     }
 }
 

--- a/generator/c/c2i_generator_decl.c2
+++ b/generator/c/c2i_generator_decl.c2
@@ -83,7 +83,7 @@ fn void Generator.emitTypeRef(Generator* gen, const TypeRef* ref) {
     if (gen.in_body) {
         ref.printLiteral2(gen.out, is_external, print_expr, gen);
     } else {
-        ref.printLiteral(gen.out, is_external);
+        ref.printLiteral(gen.out, is_external, true);
     }
 }
 

--- a/generator/c/c2i_generator_stmt.c2
+++ b/generator/c/c2i_generator_stmt.c2
@@ -200,28 +200,23 @@ fn void Generator.emitStmt(Generator* gen, ast.Stmt* s, u32 indent, bool newline
         //gen.emitAsmStmt(cast<AsmStmt*>(s), indent);
         break;
     case Assert:
-        //AssertStmt* a = cast<AssertStmt*>(s);
-/*
+#if 0
+        // TODO: generate actual assert statement?
+        AssertStmt* a = cast<AssertStmt*>(s);
         source_mgr.Location loc = gen.sm.getLocation(a.getLoc());
         const char* funcname = gen.cur_function.asDecl().getFullName();
 
-        out.add("c2_assert((");
-        char[512] location;
-        stdio.sprintf(location, "%s:%d: %s", loc.filename, loc.line, funcname);
+        out.add("(");
         Expr* inner = a.getInner();
         gen.emitExpr(out, inner);
-        out.add(") != ");
-        if (a.isPointer()) {
-            out.add("NULL");
-        } else {
-            out.add("0");
-        }
-        out.add(", \"");
-        out.add(location);
-        out.add("\", \"");
-        inner.printLiteral(out);
-*/
+        out.print(") || c2_assert(\"%s\", %d, \"%s\", \"", loc.filename, loc.line, funcname);
+        // encode expression as a string
+        string_buffer.Buf* str = string_buffer.create(128, false, 0);
+        inner.printLiteral(str);
+        out.encodeBytes(str.data(), str.size(), '"');
+        str.free();
         out.add("\");\n");
+#endif
         break;
     }
 }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -1339,14 +1339,13 @@ fn void Generator.emit_external_header(Generator* gen, bool enable_asserts, cons
     out.add("#define to_container(type, member, ptr) ((type*)((char*)(ptr) - offsetof(type, member)))\n\n");
 
     if (enable_asserts) {
-        out.add("int dprintf(int fd, const char *format, ...);\n");
-        out.add("void abort(void);\n\n");
-        out.add("static void c2_assert(bool condition, const char* location, const char* condstr) {\n");
-        out.add("  if (condition) return;\n");
-        out.print("  static const char me[] = \"%s\";\n", target);
-        out.add("  dprintf(2, \"%s: %s: Assertion '%s' failed\\n\", me, location, condstr);\n");
-        out.add("  abort();\n");
-        out.add("}\n\n");
+        out.add("int dprintf(int fd, const char *format, ...);\n"
+                "void abort(void);\n\n"
+                "static int c2_assert(const char* filename, int line, const char* funcname, const char* condstr) {\n"
+                "    dprintf(2, \"%s:%d: function %s: Assertion failed: %s\\n\", filename, line, funcname, condstr);\n"
+                "    abort();\n"
+                "    return 0;\n"
+                "}\n\n");
     }
 
     // for switch(str):

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -19,8 +19,6 @@ import ast local;
 import source_mgr;
 import string_buffer;
 
-import stdio;
-
 fn void Generator.emitVarDecl(Generator* gen, VarDecl* vd, string_buffer.Buf* out, bool emit_init) {
     Decl* d = cast<Decl*>(vd);
     if (vd.hasLocalQualifier()) out.add("static ");
@@ -223,21 +221,15 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         source_mgr.Location loc = gen.sm.getLocation(a.getLoc());
         const char* funcname = gen.cur_function.asDecl().getFullName();
 
-        out.add("c2_assert((");
-        char[512] location;
-        stdio.sprintf(location, "%s:%d: %s", loc.filename, loc.line, funcname);
+        out.add("(");
         Expr* inner = a.getInner();
         gen.emitExpr(out, inner);
-        out.add(") != ");
-        if (a.isPointer()) {
-            out.add("NULL");
-        } else {
-            out.add("0");
-        }
-        out.add(", \"");
-        out.add(location);
-        out.add("\", \"");
-        inner.printLiteral(out);
+        out.print(") || c2_assert(\"%s\", %d, \"%s\", \"", loc.filename, loc.line, funcname);
+        // encode expression as a string
+        string_buffer.Buf* str = string_buffer.create(128, false, 0);
+        inner.printLiteral(str);
+        out.encodeBytes(str.data(), str.size(), '"');
+        str.free();
         out.add("\");\n");
         break;
     }

--- a/test/c_generator/stmts/assert.c2t
+++ b/test/c_generator/stmts/assert.c2t
@@ -19,8 +19,8 @@ int32_t main(void);
 
 int32_t main(void)
 {
-   c2_assert((test_a) != 0, "file1.c2:7: test.main", "a");
-   c2_assert((test_p) != NULL, "file1.c2:8: test.main", "p");
-    return 0;
+   (test_a) || c2_assert("file1.c2", 7, "test.main", "a");
+   (test_p) || c2_assert("file1.c2", 8, "test.main", "p");
+   return 0;
 }
 


### PR DESCRIPTION
* simplify assert statement generation, avoid function call
* use separate strings for filename and function name and assertion
* improve expression `printLiteral`, implement `printLiteral` for `sizeof`, `elemsof`, `enumMin`, `enumMax`, `offsetof`, `to_container` function calls and types with array sizes
* encode assert string (fix bugs on embedded double quotes)
* simplify `CharLiteral.printLiteral`, use `Buf.encodeBytes`