### PR TITLE
parser: fix Parser.isTypeSpec() so a * b expression is not a declaration

### DIFF
--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -103,20 +103,24 @@ fn bool Parser.isTypeSpec(Parser* p) {
     assert(p.tok.kind == Kind.Identifier);
     Kind kind;
 
-    // State: 0 = ID1, 1 = ID2, 2 = pointers, 3 = arrays
+    // State: 0 = ID1, 1 = ID2, 2 = pointers, 3 = arrays, 4 = hasname
     u32 state = 0;
     u32 lookahead = 1;
     // TODO check lookahead otherwise Tokenizer can assert
     while (1) {
         switch (p.tokenizer.lookahead(lookahead, nil)) {
         case Identifier:
-            goto type_done;
+            if (state == 4) return false;
+            state = 4;
+            lookahead++;
+            break;
         case LSquare:
+            if (state == 4) return false;
             lookahead = p.skipArray(lookahead);
             state = 3;
             break;
         case Star:
-            if (state == 3) return false; // a[1] * ..
+            if (state >= 3) return false; // a[1] *, a * b * ..
             state = 2;
             lookahead++;
             break;
@@ -127,20 +131,23 @@ fn bool Parser.isTypeSpec(Parser* p) {
                     // syntax error
                     return false;
                 }
+                // TODO: second identifier should have capital
                 state = 2;
                 lookahead += 2;
             } else {
                 return false; // a.b.c
             }
             break;
+        case Equal:
+        case Semicolon:
+        //case Comma:
+        //case RParen:
+            return state == 4;
         default:
-            goto type_done;
+            return false;
         }
     }
-type_done:
-    // if token after type is identifier, it's a decl, otherwise it's not
-    kind = p.tokenizer.lookahead(lookahead, nil);
-    return kind == Kind.Identifier;
+    return false;
 }
 
 fn u32 Parser.skipArray(Parser* p, u32 lookahead) {

--- a/test/parser/decl_condition.c2
+++ b/test/parser/decl_condition.c2
@@ -1,0 +1,8 @@
+module test;
+
+public fn i32 main() {
+    i32 a = 1;
+    if (a * a != 0)
+        return 1;
+    return 0;
+}


### PR DESCRIPTION
Simplify `Parser.isTypeSpec()` state machine to improve proper declaration detection

Fixes #221