### PR TITLE
compiler: accept full expressions in case ranges

### DIFF
--- a/analyser/conversion_checker_expr.c2
+++ b/analyser/conversion_checker_expr.c2
@@ -123,6 +123,11 @@ fn ExprWidth getExprWidth(const Expr* e) {
     case ImplicitCast:
         const ImplicitCastExpr* c = cast<ImplicitCastExpr*>(e);
         return getExprWidth(c.getInner());
+    case Range:
+        RangeExpr* b = cast<RangeExpr*>(e);
+        ExprWidth lhs = getExprWidth(b.getLHS());
+        ExprWidth rhs = getExprWidth(b.getRHS());
+        return ExprWidth.mergeWider(&lhs, &rhs);
     }
 
     e.dump();

--- a/analyser/init_checker.c2
+++ b/analyser/init_checker.c2
@@ -71,11 +71,36 @@ public fn void Checker.add(Checker* c, u32 index, SrcLoc loc) {
     c.count++;
 }
 
+public fn void Checker.add2(Checker* c, u32 index1, u32 index2, SrcLoc loc) {
+    c.add(index1, loc);
+    if (index1 != index2)
+        c.add(index2, 0);
+}
+
 public fn SrcLoc Checker.find(Checker* c, u32 index) {
     if (index > c.max) return 0;
-    for (u32 i=0; i<c.count; i++) {
-        if (c.entries[i].index == index) return c.entries[i].loc;
+    for (u32 i = 0; i < c.count; i++) {
+        if (c.entries[i].loc == 0) { // range
+            if (c.entries[i-1].index <= index && c.entries[i].index >= index)
+                return c.entries[i-1].loc;
+        } else {
+            if (c.entries[i].index == index)
+                return c.entries[i].loc;
+        }
     }
     return 0;
 }
 
+public fn SrcLoc Checker.find2(Checker* c, u32 index1, u32 index2) {
+    if (index1 > c.max) return 0;
+    for (u32 i = 0; i < c.count; i++) {
+        if (c.entries[i].loc == 0) { // range
+            if (c.entries[i-1].index <= index2 && c.entries[i].index >= index1)
+                return c.entries[i-1].loc;
+        } else {
+            if (c.entries[i].index >= index1 && c.entries[i].index <= index2)
+                return c.entries[i].loc;
+        }
+    }
+    return 0;
+}

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -112,6 +112,10 @@ fn QualType Analyser.analyseExprInner(Analyser* ma, Expr** e_ptr, u32 side) {
         return ma.analyseExplicitCast(e_ptr);
     case ImplicitCast:
         break;
+    case Range:
+        (*e_ptr).dump();
+        assert(0);
+        break;
     }
     return QualType_Invalid;
 }

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -60,7 +60,7 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
     init_checker.Checker* checker = ma.getInitChecker();
 
     bool ok = true;
-    for (u32 i=0; i<numCases; i++) {
+    for (u32 i = 0; i < numCases; i++) {
         SwitchCase* c = cases[i];
         bool is_last = (i+1 == numCases);
 
@@ -70,16 +70,14 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
 
         if (c.isDefault()) {
             if (defaultCase) {
-                ma.error(defaultCase.getLoc(), "multiple default labels");
-                ma.putInitChecker();
-                return;
+                ma.error(c.getLoc(), "multiple default labels");
+                ok = false;
             }
             defaultCase = c;
 
             if (!is_last) {
                 ma.error(c.getLoc(), "default case must be last in switch");
-                ma.putInitChecker();
-                return;
+                ok = false;
             }
         }
 
@@ -108,7 +106,7 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
                 string_buffer.Buf* out = string_buffer.create(128, false, 0);
                 u32 missing = 0;
                 EnumConstantDecl** ecd = etd.getConstants();
-                for (u32 i=0; i<numConstants; i++) {
+                for (u32 i = 0; i < numConstants; i++) {
                     Value v = ecd[i].getValue();
                     if (!checker.find(v.as_u32())) {
                         if (missing != 0) out.add(", ");
@@ -121,7 +119,9 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
                     }
                 }
 
-                ma.error(sw.getLoc(), "unhandled enumeration value%s: %s", missing > 1 ? "s" : "", out.data());
+                if (missing) {
+                    ma.error(sw.getLoc(), "unhandled enumeration value%s: %s", missing > 1 ? "s" : "", out.data());
+                }
                 out.free();
             }
         }
@@ -142,10 +142,9 @@ fn bool Analyser.analyseCase(Analyser* ma,
 
     const u32 count = c.getNumStmts();
     if (!count) return true;
-    Stmt** stmts = c.getStmts();
     bool has_decls = false;
-    for (u32 i=0; i<count; i++) {
-        Stmt* st = stmts[i];
+    for (u32 i = 0; i < count; i++) {
+        Stmt* st = c.getStmt(i);
         ma.analyseStmt(st, true);
         if (ma.has_error) return false;
 
@@ -158,7 +157,7 @@ fn bool Analyser.analyseCase(Analyser* ma,
     }
     if (has_decls) c.setHasDecls();
 
-    Stmt* last = stmts[count-1];
+    Stmt* last = c.getStmt(count-1);
     if (isTerminatingStmt(last, is_default))
         return true;
 
@@ -177,39 +176,114 @@ fn bool Analyser.analyseCaseCondition(Analyser* ma,
                                       init_checker.Checker* checker,
                                       EnumTypeDecl* etd,
                                       bool is_string) {
-    if (c.numMulti()) return ma.analyseMultiCaseCondition(c, checker, etd);
+    u32 num_conds = c.getNumConds();
+    bool res = true;
+    for (u32 i = 0; i < num_conds; i++) {
+        Expr* e = c.getCond(i);
+        SrcLoc loc = e.getLoc();
+        if (e.isRange()) {
+            if (is_string) {
+                ma.error(loc, "case ranges are not allowed for strings");
+                res = false;
+                continue;
+            }
+            RangeExpr* re = cast<RangeExpr*>(e);
+            Expr* lhs = re.getLHS();
+            Expr* rhs = re.getRHS();
+            u32 lhs_index = 0;  // numerical case value (or string index)
+            u32 rhs_index;      // numerical case value (or string index)
+            u32 lhs_name_idx = 0;   // name index of enum constant
+            u32 rhs_name_idx = 0;   // name index of enum constant
+            res &= ma.analyseCaseExpr(c, checker, etd, is_string, 0, lhs, &lhs_index, &lhs_name_idx);
+            res &= ma.analyseCaseExpr(c, checker, etd, is_string, 0, rhs, &rhs_index, &rhs_name_idx);
+            if (res) {
+                if (etd) {
+                    if (lhs_index > rhs_index) {
+                        ma.error(loc, "enum constant '%s' does not come after '%s'",
+                                 idx2name(rhs_name_idx), idx2name(lhs_name_idx));
+                        res = false;
+                        continue;
+                    }
+                    u32 num_constants = etd.getNumConstants();
+                    for (u32 idx = 0; idx < num_constants; idx++) {
+                        EnumConstantDecl* ecd = etd.getConstant(idx);
+                        Value v = ecd.getValue();
+                        u32 index = v.as_u32();
+                        if (index >= lhs_index && index <= rhs_index) {
+                            SrcLoc duplicate = checker.find(index);
+                            if (duplicate && res) {
+                                Decl* d = cast<Decl*>(ecd);
+                                ma.error(loc, "duplicate case value '%s'", d.getName());
+                                ma.note(duplicate, "previous case is here");
+                                res = false;
+                            }
+                            checker.add(index, loc);
+                        }
+                    }
+                } else {
+                    if (lhs_index > rhs_index) {
+                        ma.error(loc, "case range bounds %d and %d are out of order", lhs_index, rhs_index);
+                        res = false;
+                        continue;
+                    }
+                    SrcLoc duplicate = checker.find2(lhs_index, rhs_index);
+                    if (duplicate) {
+                        ma.error(loc, "duplicate case value in range");
+                        ma.note(duplicate, "previous case is here");
+                        res = false;
+                    }
+                    checker.add2(lhs_index, rhs_index, loc);
+                }
+            }
+        } else {
+            u32 index;      // numerical case value (or string index)
+            u32 name_idx;   // name index of enum constant
+            res &= ma.analyseCaseExpr(c, checker, etd, is_string, loc, e, &index, &name_idx);
+        }
+    }
+    return res;
+}
 
-    Expr* cond = c.getCond();
+fn bool Analyser.analyseCaseExpr(Analyser* ma,
+                                 SwitchCase* c,
+                                 init_checker.Checker* checker,
+                                 EnumTypeDecl* etd,
+                                 bool is_string,
+                                 SrcLoc loc,
+                                 Expr* cond, u32 *indexp, u32 *name_idxp) {
+    u32 index = 0;
     if (etd) {
         if (!cond.isIdentifier()) {
             if (cond.isMember()) {
+                // TODO: should accept enum full name
                 ma.error(cond.getLoc(), "enum constant may not be prefixed in case statement");
             } else {
                 ma.error(cond.getLoc(), "condition is not a constant of enum type '%s'",
-                    etd.asDecl().getFullName());
+                         etd.asDecl().getFullName());
             }
             return false;
         }
-
-        u32 enum_idx;
         IdentifierExpr* id = cast<IdentifierExpr*>(cond);
-        if (!ma.checkEnumConstantCase(id, checker, etd, &enum_idx)) return false;
+        if (!ma.checkEnumConstantCase(id, checker, etd, loc, &index, name_idxp)) return false;
     } else {
-        Expr* orig = c.getCond();
-        QualType qt = ma.analyseExpr(c.getCond2(), true, RHS);
+        Expr* orig = cond;
+        QualType qt = ma.analyseExpr(&cond, true, RHS);
 
         if (qt.isInvalid()) return false;
         cond.setType(qt);
 
         if (is_string) {
-            u32 index;
             if (orig.isNil()) {
                 index = 0;
-                SrcLoc duplicate = checker.find(index);
-                if (duplicate) {
-                    ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case value nil");
-                    ma.note(duplicate, "previous case is here");
-                    return false;
+                *name_idxp = 0;
+                if (loc) {
+                    SrcLoc duplicate = checker.find(index);
+                    if (duplicate) {
+                        ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case value nil");
+                        ma.note(duplicate, "previous case is here");
+                        return false;
+                    }
+                    checker.add(index, loc);
                 }
             } else
             if (orig.isStringLiteral()) {
@@ -224,35 +298,40 @@ fn bool Analyser.analyseCaseCondition(Analyser* ma,
                     return false;
                 }
                 index = lit.getTextIndex();
-                SrcLoc duplicate = checker.find(index);
-                if (duplicate) {
-                    ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case string");
-                    ma.note(duplicate, "previous case is here");
-                    return false;
+                *name_idxp = 0;
+                if (loc) {
+                    SrcLoc duplicate = checker.find(index);
+                    if (duplicate) {
+                        ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case string");
+                        ma.note(duplicate, "previous case is here");
+                        return false;
+                    }
+                    checker.add(index, loc);
                 }
             } else {
                 ma.error(cond.getLoc(), "string switch case can only have a string literal or nil as condition");
                 return false;
             }
-            checker.add(index, cond.getLoc());
         } else {
             if (!cond.isCtv()) {
                 ma.error(cond.getLoc(), "case condition is not compile-time constant");
                 return false;
             }
-
-            // check for duplicate value
             Value v = ctv_analyser.get_value(cond);
-            u32 index = v.as_u32();
-            SrcLoc duplicate = checker.find(index);
-            if (duplicate) {
-                ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case value %d", index);
-                ma.note(duplicate, "previous case is here");
-                return false;
+            index = v.as_u32();
+            *name_idxp = 0;
+            if (loc) {
+                SrcLoc duplicate = checker.find(index);
+                if (duplicate) {
+                    ma.errorRange(cond.getLoc(), cond.getRange(), "duplicate case value %d", index);
+                    ma.note(duplicate, "previous case is here");
+                    return false;
+                }
+                checker.add(index, loc);
             }
-            checker.add(index, cond.getLoc());
         }
     }
+    *indexp = index;
     return true;
 }
 
@@ -260,9 +339,12 @@ fn bool Analyser.checkEnumConstantCase(Analyser* ma,
                                        IdentifierExpr* id,
                                        init_checker.Checker* checker,
                                        EnumTypeDecl* etd,
-                                       u32* enum_idx) {
+                                       SrcLoc loc,
+                                       u32* ip,
+                                       u32* name_idxp) {
     Expr* e = cast<Expr*>(id);
-    EnumConstantDecl* ecd = etd.findConstantIdx(id.getNameIdx(), enum_idx);
+    *name_idxp = id.getNameIdx();
+    EnumConstantDecl* ecd = etd.findConstant(*name_idxp);
     if (!ecd) {
         ma.error(e.getLoc(), "enum '%s' has no constant '%s'", etd.asDecl().getFullName(), id.getName());
         return false;
@@ -280,64 +362,16 @@ fn bool Analyser.checkEnumConstantCase(Analyser* ma,
     // check for duplicate value
     Value v = ecd.getValue();
     u32 index = v.as_u32();
-    SrcLoc duplicate = checker.find(index);
-    if (duplicate) {
-        ma.error(e.getLoc(), "duplicate case value '%s'", id.getName());
-        ma.note(duplicate, "previous case is here");
-        return false;
-    }
-    checker.add(index, e.getLoc());
-    return true;
-}
-
-fn bool Analyser.analyseMultiCaseCondition(Analyser* ma,
-                                           SwitchCase* c,
-                                           init_checker.Checker* checker,
-                                           EnumTypeDecl* etd) {
-    if (!etd) {
-        // TODO
-        assert(0);
-    }
-
-    IdentifierExpr** multi = c.getMultiCond();
-
-    for (u32 i=0; i<c.numMulti(); i++) {
-        IdentifierExpr* id = multi[i];
-        u32 enum_idx = 0;
-        if (!ma.checkEnumConstantCase(id, checker, etd, &enum_idx)) return false;
-
-
-        if (id.isCaseRange()) {
-            IdentifierExpr* id2 = multi[i+1];
-            u32 enum_idx2 = 0;
-            if (!ma.checkEnumConstantCase(id2, checker, etd, &enum_idx2)) return false;
-
-            if (enum_idx >= enum_idx2) {
-                Expr* e = cast<Expr*>(id2);
-                ma.error(e.getLoc(), "enum constant '%s' does not come after '%s'", id2.getName(), id.getName());
-                return false;
-            }
-
-            Expr* e1 = cast<Expr*>(id);
-            SrcLoc loc1 = e1.getLoc();
-            for (u32 idx=enum_idx+1; idx<enum_idx2; idx++) {
-                EnumConstantDecl* ecd = etd.getConstant(idx);
-                // check for duplicate value
-                Value v = ecd.getValue();
-                u32 index = v.as_u32();
-                SrcLoc duplicate = checker.find(index);
-                if (duplicate) {
-                    Decl* d = cast<Decl*>(ecd);
-                    ma.error(loc1, "duplicate case value '%s'", d.getName());
-                    ma.note(duplicate, "previous case is here");
-                    return false;
-                }
-                checker.add(index, loc1);
-            }
-            i++;
+    *ip = index;
+    if (loc) {
+        SrcLoc duplicate = checker.find(index);
+        if (duplicate) {
+            ma.error(e.getLoc(), "duplicate case value '%s'", id.getName());
+            ma.note(duplicate, "previous case is here");
+            return false;
         }
+        checker.add(index, loc);
     }
-
     return true;
 }
 

--- a/analyser/module_analyser_unaryop.c2
+++ b/analyser/module_analyser_unaryop.c2
@@ -256,6 +256,8 @@ fn IdentifierKind getInnerExprAddressOf(Expr* e) {
         ImplicitCastExpr* c = cast<ImplicitCastExpr*>(e);
         // TODO: this seems incorrect, casts should not produce LValues
         return getInnerExprAddressOf(c.getInner());
+    case Range:
+        break;
     }
 
     return IdentifierKind.Unresolved;

--- a/analyser_utils/ctv_analyser.c2
+++ b/analyser_utils/ctv_analyser.c2
@@ -67,8 +67,10 @@ fn const Limit* getLimit(u32 width) {
 public fn Value get_value(const Expr* e) {
     Value result = { }
 
-    if (!e.isCtv()) e.dump(); // TEMP
-    assert(e.isCtv());
+    if (!e.isCtv()) {
+        e.dump(); // TEMP
+        assert(e.isCtv());
+    }
 
     switch (e.getKind()) {
     case IntegerLiteral:
@@ -175,6 +177,9 @@ public fn Value get_value(const Expr* e) {
     case ImplicitCast:
         const ImplicitCastExpr* i = cast<ImplicitCastExpr*>(e);
         return get_value(i.getInner());
+    case Range:
+        // should not happen
+        break;
     }
 
     return result;

--- a/ast/enum_constant_decl.c2
+++ b/ast/enum_constant_decl.c2
@@ -69,7 +69,7 @@ public fn void EnumConstantDecl.setIndex(EnumConstantDecl* d, u32 index) {
     d.base.enumConstantDeclBits.enum_index = index;
 }
 
-public fn u32 EnumConstantDecl.getIndex(const EnumConstantDecl* d) {
+public fn u32 EnumConstantDecl.getIndex(const EnumConstantDecl* d) @(unused) {
     return d.base.enumConstantDeclBits.enum_index;
 }
 
@@ -82,14 +82,14 @@ public fn Expr** EnumConstantDecl.getInit2(EnumConstantDecl* d) {
     if (d.base.enumConstantDeclBits.has_init) return &d.init[0];
     return nil;
 }
-
+#if 0
 // helper function
 public fn EnumTypeDecl* EnumConstantDecl.getEnum(const EnumConstantDecl* d) {
     QualType qt = d.base.getType();
     EnumType* et = cast<EnumType*>(qt.getType());
     return et.getDecl();
 }
-
+#endif
 fn void EnumConstantDecl.print(const EnumConstantDecl* d, string_buffer.Buf* out, u32 indent) {
     d.base.printKind(out, indent, true);
     d.base.printBits(out);

--- a/ast/enum_type_decl.c2
+++ b/ast/enum_type_decl.c2
@@ -130,20 +130,6 @@ public fn EnumConstantDecl* EnumTypeDecl.findConstant(EnumTypeDecl* d, u32 name_
     return nil;
 }
 
-public fn EnumConstantDecl* EnumTypeDecl.findConstantIdx(EnumTypeDecl* d, u32 name_idx, u32* idx) {
-    EnumConstantDecl** constants = d.constants;
-    if (d.isIncremental()) constants = d.incr_constants[0];
-    for (u32 i=0; i<d.getNumConstants(); i++) {
-        EnumConstantDecl* ecd = constants[i];
-        Decl* ed = cast<Decl*>(ecd);
-        if (ed.getNameIdx() == name_idx) {
-            *idx = i;
-            return ecd;
-        }
-    }
-    return nil;
-}
-
 public fn EnumConstantDecl* EnumTypeDecl.getConstant(const EnumTypeDecl* d, u32 idx) {
     if (d.isIncremental()) return d.incr_constants[0][idx];
     return d.constants[idx];

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -42,6 +42,7 @@ public type ExprKind enum u8 {
     BitOffset,
     ExplicitCast,
     ImplicitCast,
+    Range,
 }
 
 const char*[] exprKind_names = {
@@ -67,6 +68,7 @@ const char*[] exprKind_names = {
     "BitOffset",
     "ExplicitCast",
     "ImplicitCast",
+    "RangeExpr",
 }
 static_assert(elemsof(ExprKind), elemsof(exprKind_names));
 
@@ -180,6 +182,8 @@ fn Expr* Expr.instantiate(Expr* e, Instantiator* inst) {
     case ImplicitCast:
         // should not happen
         break;
+    case Range:
+        return RangeExpr.instantiate(cast<RangeExpr*>(e), inst);
     }
     e.dump();
     assert(0);
@@ -259,6 +263,10 @@ public fn bool Expr.isBitOffset(const Expr* e) {
 
 fn bool Expr.isParen(const Expr* e) {
     return e.getKind() == ExprKind.Paren;
+}
+
+public fn bool Expr.isRange(const Expr* e) {
+    return e.getKind() == ExprKind.Range;
 }
 
 public fn bool Expr.isCtv(const Expr* e) { return e.base.exprBits.is_ctv; }
@@ -362,6 +370,8 @@ public fn SrcLoc Expr.getStartLoc(const Expr* e) {
         break;
     case ImplicitCast:
         return (cast<ImplicitCastExpr*>(e)).getStartLoc();
+    case Range:
+        return (cast<RangeExpr*>(e)).getStartLoc();
     }
     return e.loc;
 }
@@ -412,6 +422,8 @@ public fn SrcLoc Expr.getEndLoc(const Expr* e) {
         return (cast<ExplicitCastExpr*>(e)).getEndLoc();
     case ImplicitCast:
         return (cast<ImplicitCastExpr*>(e)).getEndLoc();
+    case Range:
+        return (cast<RangeExpr*>(e)).getEndLoc();
     }
     return e.loc;
 }
@@ -501,6 +513,9 @@ fn void Expr.print(const Expr* e, string_buffer.Buf* out, u32 indent) {
     case ImplicitCast:
         ImplicitCastExpr.print(cast<ImplicitCastExpr*>(e), out, indent);
         break;
+    case Range:
+        RangeExpr.print(cast<RangeExpr*>(e), out, indent);
+        break;
     }
 }
 
@@ -569,6 +584,9 @@ public fn void Expr.printLiteral(const Expr* e, string_buffer.Buf* out) {
         return;
     case ImplicitCast:
         ImplicitCastExpr.printLiteral(cast<ImplicitCastExpr*>(e), out);
+        return;
+    case Range:
+        RangeExpr.printLiteral(cast<RangeExpr*>(e), out);
         return;
     }
     out.print("<<kind=%d>>", e.getKind());

--- a/ast/identifier_expr.c2
+++ b/ast/identifier_expr.c2
@@ -48,7 +48,6 @@ type IdentifierExprBits struct {
     u32 : NumExprBits;
     u32 has_decl : 1;
     u32 kind : 3;   // IdentifierKind
-    u32 is_case_range : 1; // only when case condition
 }
 
 public type IdentifierExpr struct @(opaque) {
@@ -72,8 +71,6 @@ public fn IdentifierExpr* IdentifierExpr.create(ast_context.Context* c, SrcLoc l
 fn Expr* IdentifierExpr.instantiate(IdentifierExpr* e, Instantiator* inst) {
     return cast<Expr*>(IdentifierExpr.create(inst.c, e.base.loc, e.name_idx));
 }
-
-//public fn u32 IdentifierExpr.getSize() { return sizeof(IdentifierExpr); }
 
 public fn Expr* IdentifierExpr.asExpr(IdentifierExpr* e) { return &e.base; }
 
@@ -110,14 +107,6 @@ fn SrcLoc IdentifierExpr.getEndLoc(const IdentifierExpr* e) {
     return e.base.loc + cast<u32>(strlen(e.getName()));
 }
 
-public fn void IdentifierExpr.setCaseRange(IdentifierExpr* e) {
-    e.base.base.identifierExprBits.is_case_range = 1;
-}
-
-public fn bool IdentifierExpr.isCaseRange(const IdentifierExpr* e) {
-    return e.base.base.identifierExprBits.is_case_range;
-}
-
 public fn u32 IdentifierExpr.getNameIdx(const IdentifierExpr* e) {
     if (e.base.base.identifierExprBits.has_decl) return e.decl.getNameIdx();
     return e.name_idx;
@@ -126,8 +115,6 @@ public fn u32 IdentifierExpr.getNameIdx(const IdentifierExpr* e) {
 fn void IdentifierExpr.print(const IdentifierExpr* e, string_buffer.Buf* out, u32 indent) {
     e.base.printKind(out, indent);
     e.base.printTypeBits(out);
-    if (e.isCaseRange()) out.add(" range");
-
     out.space();
     IdentifierKind kind = e.getKind();
     if (kind == IdentifierKind.Unresolved) out.color(col_Error);

--- a/ast/range_expr.c2
+++ b/ast/range_expr.c2
@@ -1,0 +1,81 @@
+/* Copyright 2022-2025 Bas van den Berg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+import ast_context;
+import string_buffer;
+import src_loc local;
+
+public type RangeExpr struct @(opaque) {
+    Expr base;
+    Expr* lhs;
+    Expr* rhs;
+}
+
+public fn RangeExpr* RangeExpr.create(ast_context.Context* c, SrcLoc loc, Expr* lhs, Expr* rhs) {
+    RangeExpr* e = c.alloc(sizeof(RangeExpr));
+    e.base.init(ExprKind.Range, loc, 0, 0, false, ValType.RValue);
+    e.lhs = lhs;
+    e.rhs = rhs;
+#if AstStatistics
+    Stats.addExpr(ExprKind.Range, sizeof(RangeExpr));
+#endif
+    return e;
+}
+
+fn Expr* RangeExpr.instantiate(RangeExpr* e, Instantiator* inst) {
+    return cast<Expr*>(RangeExpr.create(inst.c, e.base.loc, e.lhs.instantiate(inst), e.rhs.instantiate(inst)));
+}
+
+public fn Expr* RangeExpr.getLHS(const RangeExpr* e) { return e.lhs; }
+//public fn Expr** RangeExpr.getLHS2(RangeExpr* e) { return &e.lhs; }
+
+public fn Expr* RangeExpr.getRHS(const RangeExpr* e) { return e.rhs; }
+//public fn Expr** RangeExpr.getRHS2(RangeExpr* e) { return &e.rhs; }
+
+fn SrcLoc RangeExpr.getStartLoc(const RangeExpr* e) {
+    return e.getLHS().getStartLoc();
+}
+
+fn SrcLoc RangeExpr.getEndLoc(const RangeExpr* e) {
+    return e.getRHS().getEndLoc();
+}
+
+fn void RangeExpr.print(const RangeExpr* e, string_buffer.Buf* out, u32 indent) {
+    e.base.printKind(out, indent);
+    e.base.printTypeBits(out);
+    out.color(col_Value);
+    out.space();
+    out.add("Range");
+    out.newline();
+
+    out.indent(indent + 1);
+    out.color(col_Attr);
+    out.add("LHS=\n");
+    e.lhs.print(out, indent + 1);
+
+    out.indent(indent + 1);
+    out.color(col_Attr);
+    out.add("RHS=\n");
+    e.rhs.print(out, indent + 1);
+}
+
+fn void RangeExpr.printLiteral(const RangeExpr* e, string_buffer.Buf* out) {
+    e.lhs.printLiteral(out);
+    out.add(" ... ");
+    e.rhs.printLiteral(out);
+}
+

--- a/ast/switch_case.c2
+++ b/ast/switch_case.c2
@@ -22,7 +22,7 @@ import src_loc local;
 import string;
 
 type SwitchCaseBits struct {
-    u32 num_subcases: 8;
+    u32 num_conds : 8;
     u32 num_stmts : 10;
     u32 is_default : 1;
     u32 has_decls : 1;
@@ -34,110 +34,80 @@ public type SwitchCase struct @(opaque) {
         u32 allbits;
     }
     SrcLoc loc;
-    union {
-        Expr* cond;     // only for non-default
-        IdentifierExpr*[1] multi_cond; // tail allocated
-    }
+    Expr*[0] conds;    // tail-allocated
     //Stmt*[0] stmts; // tail-allocated
 }
 
-// Note: cond can be nil in case of multi-subcases
 public fn SwitchCase* SwitchCase.create(ast_context.Context* c,
                                         SrcLoc loc,
                                         bool is_default,
-                                        Expr* cond,
-                                        IdentifierExpr** multi,
-                                        u32 num_multi,
-                                        Stmt** stmts,
-                                        u32 numStmts)
+                                        Expr** conds, u32 num_conds,
+                                        Stmt** stmts, u32 num_stmts)
 {
-    assert(numStmts < 1024);    // 2^10
-    assert(num_multi < 256);    // 2^8
+    assert(num_stmts < 1024);   // 2^10
+    assert(num_conds < 256);    // 2^8
 
-    u32 size = sizeof(SwitchCase) + numStmts * sizeof(Stmt*);
-    if (num_multi) {
-        size += (num_multi - 1) * sizeof(IdentifierExpr*);
-    }
+    u32 size = sizeof(SwitchCase) + num_conds * sizeof(Expr*) + num_stmts * sizeof(Stmt*);
     SwitchCase* s = c.alloc(size);
     s.allbits = 0;
+    s.bits.num_conds = num_conds;
+    s.bits.num_stmts = num_stmts;
     s.bits.is_default = is_default;
-    s.bits.num_stmts = numStmts;
-    s.bits.num_subcases = num_multi;
     s.loc = loc;
-    if (num_multi) {
-        string.memcpy(s.multi_cond, multi, num_multi * sizeof(IdentifierExpr*));
-    } else {
-        s.cond = cond;
-    }
-
+    string.memcpy(s.conds, conds, num_conds * sizeof(Expr*));
     Stmt** dst_stmts = s.getStmts();
-    string.memcpy(dst_stmts, stmts, numStmts * sizeof(Stmt*));
+    string.memcpy(dst_stmts, stmts, num_stmts * sizeof(Stmt*));
 #if AstStatistics
     Stats.addSwitchCase(size);
 #endif
     return s;
 }
 
-fn SwitchCase* SwitchCase.instantiate(SwitchCase* s, Instantiator* inst) {
-    u32 numStmts = s.getNumStmts();
-    u32 size = sizeof(SwitchCase) + numStmts * sizeof(Stmt*);
-    if (s.bits.num_subcases) {
-        size += (s.bits.num_subcases - 1) * sizeof(IdentifierExpr*);
+fn SwitchCase* SwitchCase.instantiate(SwitchCase* src, Instantiator* inst) {
+    u32 num_conds = src.bits.num_conds;
+    u32 num_stmts = src.bits.num_stmts;
+    u32 size = sizeof(SwitchCase) + num_conds * sizeof(Expr*) + num_stmts * sizeof(Stmt*);
+    SwitchCase* dst = inst.c.alloc(size);
+    dst.allbits = src.allbits;
+    dst.loc = src.loc;
+    // Instantiate the conditions in case constant expressions depend on template argument
+    for (u32 i = 0; i < num_conds; i++) {
+        dst.conds[i] = src.conds[i].instantiate(inst);
     }
-    SwitchCase* s2 = inst.c.alloc(size);
-    s2.allbits = s.allbits;
-    s2.loc = s.loc;
-    if (s.bits.num_subcases) {
-        // just copy
-        string.memcpy(s2.multi_cond, s.multi_cond, s.bits.num_subcases * sizeof(IdentifierExpr*));
-    } else {
-        // just copy?
-        s2.cond = s.cond;
-        //s2.cond = s.cond.instantiate(inst);
-    }
-
-    Stmt** src_stmts = s.getStmts();
-    Stmt** dst_stmts = s.getStmts();
-    for (u32 i=0; i<numStmts; i++) {
+    Stmt** src_stmts = src.getStmts();
+    Stmt** dst_stmts = dst.getStmts();
+    for (u32 i = 0; i < num_stmts; i++) {
         dst_stmts[i] = src_stmts[i].instantiate(inst);
     }
 #if AstStatistics
     Stats.addSwitchCase(size);
 #endif
-    return s;
+    return dst;
 }
 
-public fn u32 SwitchCase.getNumStmts(const SwitchCase* s) {
-    return s.bits.num_stmts;
+public fn u32 SwitchCase.getNumConds(const SwitchCase* s) { return s.bits.num_conds; }
+public fn Expr* SwitchCase.getCond(SwitchCase* s, u32 index) {
+    return index < s.bits.num_conds ? s.conds[index] : nil;
 }
 
-public fn Stmt** SwitchCase.getStmts(const SwitchCase* s) {
-    u8* stmts = cast<u8*>(&s.cond);
-    if (s.bits.num_subcases) {
-        stmts += s.bits.num_subcases * sizeof(void*);
-    } else {
-        stmts += sizeof(void*);
+public fn u32 SwitchCase.getNumStmts(const SwitchCase* s) { return s.bits.num_stmts; }
+public fn Stmt** SwitchCase.getStmts(SwitchCase* s) {
+    return cast<Stmt**>(&s.conds[s.bits.num_conds]);
+}
+
+public fn Stmt* SwitchCase.getStmt(const SwitchCase* s, u32 n) {
+    if (n < s.bits.num_stmts) {
+        Stmt** stmts = cast<Stmt**>(&s.conds[s.bits.num_conds]);
+        return stmts[n];
     }
-    return cast<Stmt**>(stmts);
+    return nil;
 }
 
 public fn bool SwitchCase.isDefault(const SwitchCase* s) { return s.bits.is_default; }
-
-public fn u32 SwitchCase.numMulti(const SwitchCase* s) { return s.bits.num_subcases; }
-
 public fn bool SwitchCase.hasDecls(const SwitchCase* s) { return s.bits.has_decls; }
-
-public fn void SwitchCase.setHasDecls(SwitchCase* s) {
-    s.bits.has_decls = 1;
-}
+public fn void SwitchCase.setHasDecls(SwitchCase* s) { s.bits.has_decls = 1; }
 
 public fn SrcLoc SwitchCase.getLoc(const SwitchCase* s) { return s.loc; }
-
-public fn Expr* SwitchCase.getCond(const SwitchCase* s) { return s.cond; }
-
-public fn Expr** SwitchCase.getCond2(SwitchCase* s) { return &s.cond; }
-
-public fn IdentifierExpr** SwitchCase.getMultiCond(SwitchCase* s) { return s.multi_cond; }
 
 fn void SwitchCase.print(const SwitchCase* s, string_buffer.Buf* out, u32 indent) {
     out.indent(indent);
@@ -151,25 +121,21 @@ fn void SwitchCase.print(const SwitchCase* s, string_buffer.Buf* out, u32 indent
         out.color(col_Attr);
         out.add(" decls");
     }
-    if (s.bits.num_subcases) {
+    if (s.bits.num_conds > 1) {
         out.color(col_Attr);
         out.add(" multi");
     }
     out.newline();
 
-    if (s.cond) {
-        if (s.bits.num_subcases) {
-            for (u32 i=0; i<s.bits.num_subcases; i++) {
-                s.multi_cond[i].print(out, indent + 1);
-            }
-        } else {
-            s.cond.print(out, indent + 1);
-        }
+    out.indent(indent + 1);
+    out.add(" case");
+    for (u32 i = 0; i < s.bits.num_conds; i++) {
+        if (i != 0) out.add(", ");
+        s.conds[i].print(out, indent + 1);
     }
 
-    Stmt** stmts = s.getStmts();
-    for (u32 i=0; i<s.bits.num_stmts; i++) {
-        stmts[i].print(out, indent + 1);
+    for (u32 i = 0; i < s.bits.num_stmts; i++) {
+        s.getStmt(i).print(out, indent + 2);
     }
 }
 

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -85,7 +85,7 @@ static_assert(24, sizeof(StructType));
 static_assert(32, sizeof(ArrayType));
 
 static_assert(16, sizeof(ArrayValue));
-static_assert(16, sizeof(SwitchCase));
+static_assert(8, sizeof(SwitchCase));
 static_assert(24, sizeof(StaticAssert));
 static_assert(8, sizeof(TypeRef));
 

--- a/generator/ast_visitor.c2
+++ b/generator/ast_visitor.c2
@@ -172,20 +172,10 @@ fn void Visitor.handleStmt(Visitor* v, Stmt* s) {
         SwitchCase** cases = sw.getCases();
         for (u32 i=0; i<numcases; i++) {
             SwitchCase* c = cases[i];
-            if (c.numMulti()) {
-                IdentifierExpr** multi = c.getMultiCond();
-                for (u32 j=0; j<c.numMulti(); j++) {
-                    IdentifierExpr* id = multi[j];
-                    Ref ref = id.getRef();
-                    v.on_ref(v.arg, &ref);
-                }
-            } else {
-                if (c.getCond()) v.handleExpr(c.getCond());
-            }
-
-            const u32 numstmts = c.getNumStmts();
-            Stmt** stmts = c.getStmts();
-            for (u32 j=0; j<numstmts; j++) v.handleStmt(stmts[j]);
+            u32 numconds = c.getNumConds();
+            for (u32 j=0; j<numconds; j++) v.handleExpr(c.getCond(j));
+            u32 numstmts = c.getNumStmts();
+            for (u32 j=0; j<numstmts; j++) v.handleStmt(c.getStmt(j));
         }
         break;
     case Break:

--- a/generator/ast_visitor_expr.c2
+++ b/generator/ast_visitor_expr.c2
@@ -110,6 +110,11 @@ fn void Visitor.handleExpr(Visitor* v, Expr* e) {
         ImplicitCastExpr* ic = cast<ImplicitCastExpr*>(e);
         v.handleExpr(ic.getInner());
         break;
+    case Range:
+        RangeExpr* b = cast<RangeExpr*>(e);
+        v.handleExpr(b.getLHS());
+        v.handleExpr(b.getRHS());
+        break;
     }
 }
 

--- a/generator/c/c2i_generator_expr.c2
+++ b/generator/c/c2i_generator_expr.c2
@@ -111,6 +111,12 @@ fn void Generator.emitExpr(Generator* gen, const Expr* e) {
         const ImplicitCastExpr* c = cast<ImplicitCastExpr*>(e);
         gen.emitExpr(c.getInner());
         return;
+    case Range:
+        const RangeExpr* b = cast<RangeExpr*>(e);
+        gen.emitExpr(b.getLHS());
+        out.print(" ... ");
+        gen.emitExpr(b.getRHS());
+        return;
     }
     e.dump();
     assert(0);

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -138,6 +138,12 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
         ImplicitCastExpr* i = cast<ImplicitCastExpr*>(e);
         gen.emitExpr(out, i.getInner());
         break;
+    case Range:
+        const RangeExpr* b = cast<RangeExpr*>(e);
+        gen.emitExpr(out, b.getLHS());
+        out.print(" ... ");
+        gen.emitExpr(out, b.getRHS());
+        return;
     }
 }
 

--- a/generator/c/c_generator_pure_call.c2
+++ b/generator/c/c_generator_pure_call.c2
@@ -145,6 +145,9 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
     case ImplicitCast:
         const ImplicitCastExpr* i = cast<ImplicitCastExpr*>(e);
         return eval.get_value(i.getInner());
+    case Range:
+        assert(0);
+        break;
     }
 
     return result;

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -322,11 +322,11 @@ fn void Generator.emitSwitchStmt(Generator* gen, Stmt* s, u32 indent) {
         gen.emitExpr(out, sw.getCond());
         out.add(",");
         bool has_s2 = false;
-        for (u32 i=0; i<num_cases; i++) {
+        for (u32 i = 0; i < num_cases; i++) {
             SwitchCase* c = cases[i];
             if (c.isDefault())
                 continue;
-            Expr* e = c.getCond();
+            Expr* e = c.getCond(0);
             if (e.isImplicitCast()) {
                 const ImplicitCastExpr* ic = cast<ImplicitCastExpr*>(e);
                 e = ic.getInner();
@@ -349,7 +349,7 @@ fn void Generator.emitSwitchStmt(Generator* gen, Stmt* s, u32 indent) {
         out.add(")) {\n");
 
         u32 lab = 2;
-        for (u32 i=0; i<num_cases; i++) {
+        for (u32 i = 0; i < num_cases; i++) {
             gen.emitCase(cases[i], indent, &lab);
         }
         out.indent(indent);
@@ -359,10 +359,9 @@ fn void Generator.emitSwitchStmt(Generator* gen, Stmt* s, u32 indent) {
         gen.emitExpr(out, sw.getCond());
         out.add(") {\n");
 
-        for (u32 i=0; i<num_cases; i++) {
+        for (u32 i = 0; i < num_cases; i++) {
             gen.emitCase(cases[i], indent, nil);
         }
-
         out.indent(indent);
         out.add("}\n");
     }
@@ -375,67 +374,44 @@ fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) 
         out.indent(indent);
         out.add("default:");
     } else {
-        if (c.numMulti()) {
-            IdentifierExpr** multi = c.getMultiCond();
-            for (u32 i=0; i<c.numMulti(); i++) {
-                IdentifierExpr* id = multi[i];
-                out.indent(indent);
-                out.add("case ");
-                Decl* d = id.getDecl();
-                gen.emitDeclName(out, d);
-                out.add1(':');
-                if (i != c.numMulti()-1) {
-                    out.newline();
-                    out.indent(indent+1);
-                    out.add("fallthrough;\n");
-                }
-                if (id.isCaseRange()) {
-                    IdentifierExpr* id2 = multi[i+1];
-                    EnumConstantDecl* ecd1 = cast<EnumConstantDecl*>(id.getDecl());
-                    EnumConstantDecl* ecd2 = cast<EnumConstantDecl*>(id2.getDecl());
-                    EnumTypeDecl* etd = ecd1.getEnum();
-                    EnumConstantDecl** constants = etd.getConstants();
-                    for (u32 j=ecd1.getIndex()+1; j<ecd2.getIndex(); j++) {
-                        out.indent(indent);
-                        out.add("case ");
-                        gen.emitDeclName(out, cast<Decl*>(constants[j]));
-                        out.add1(':');
-                        out.newline();
-                        out.indent(indent+1);
-                        out.add("fallthrough;\n");
-                    }
-                }
+        out.indent(indent);
+        out.add("case ");
+        if (lab) {  /* string case */
+            Expr* e = c.getCond(0);
+            if (e.isImplicitCast()) {
+                const ImplicitCastExpr* ic = cast<ImplicitCastExpr*>(e);
+                e = ic.getInner();
             }
-        } else {
-            out.indent(indent);
-            out.add("case ");
-            if (lab) {
-                Expr* e = c.getCond();
-                if (e.isImplicitCast()) {
-                    const ImplicitCastExpr* ic = cast<ImplicitCastExpr*>(e);
-                    e = ic.getInner();
-                }
-                if (e.isNil()) {
-                    out.add("0: // nil");
-                } else
-                if (e.isStringLiteral()) {
-                    StringLiteral* lit = cast<StringLiteral*>(e);
-                    const char *p = lit.getText();
-                    if (*p) {
-                        out.print("%d:", *lab);
-                        out.print(" // \"%s\"", p);
-                        *lab += 1;
-                    } else {
-                        out.add("1: // \"\"");
-                    }
+            if (e.isNil()) {
+                out.add("0: // nil");
+            } else
+            if (e.isStringLiteral()) {
+                StringLiteral* lit = cast<StringLiteral*>(e);
+                const char *p = lit.getText();
+                if (*p) {
+                    out.print("%d:", *lab);
+                    out.print(" // \"%s\"", p);
+                    *lab += 1;
                 } else {
-                    e.dump();
-                    assert(0);
+                    out.add("1: // \"\"");
                 }
             } else {
-                gen.emitExpr(out, c.getCond());
-                out.add1(':');
+                e.dump();
+                assert(0);
             }
+        } else {
+            u32 num_conds = c.getNumConds();
+            for (u32 i = 0; i < num_conds; i++) {
+                if (i) {
+                    out.add(":\n");
+                    out.indent(indent);
+                    out.add("case ");
+                }
+                // TODO: if compiler does not handle case ranges, expand as
+                //       individual cases or generate alternative code
+                gen.emitExpr(out, c.getCond(i));
+            }
+            out.add1(':');
         }
     }
 

--- a/generator/c/dep_finder.c2
+++ b/generator/c/dep_finder.c2
@@ -221,6 +221,11 @@ fn void Finder.handleExpr(Finder* s, Expr* e) {
         ImplicitCastExpr* c = cast<ImplicitCastExpr*>(e);
         s.handleExpr(c.getInner());
         break;
+    case Range:
+        RangeExpr* b = cast<RangeExpr*>(e);
+        s.handleExpr(b.getLHS());
+        s.handleExpr(b.getRHS());
+        break;
     }
 }
 

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -327,6 +327,9 @@ fn void Generator.emitInit(Generator* gen, const Expr* e, u32 size) {
         const ImplicitCastExpr* ic = cast<ImplicitCastExpr*>(e);
         gen.emitInit(ic.getInner(), size);
         break;
+    case Range:
+        assert(0);
+        break;
     }
 }
 

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -125,6 +125,9 @@ fn void Generator.emitExpr(Generator* gen, ir.Ref* result, const Expr* e) {
             break;
         }
         break;
+    case Range:
+        assert(0);  // should not happen
+        break;
     }
 }
 
@@ -360,6 +363,9 @@ fn void Generator.emitCond(Generator* gen, const Expr* e, BlockId true_blk, Bloc
     case BitOffset:
     case ExplicitCast:
     case ImplicitCast:
+        break;
+    case Range:
+        assert(0);  // should not happen
         break;
     }
     gen.emitExpr(&ref, e);

--- a/generator/qbe/qbe_generator_expr.c2
+++ b/generator/qbe/qbe_generator_expr.c2
@@ -196,6 +196,9 @@ fn void Generator.emitExpr(Generator* gen, ExprRef* result, const Expr* e) {
             break;
         }
         break;
+    case Range:
+        assert(0);
+        break;
     }
 }
 

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -21,7 +21,6 @@ import attr_handler;
 import attr local;
 import component;
 import diagnostics;
-import identifier_expr_list;
 import number_radix local;
 import src_loc local;
 import string_pool;
@@ -836,24 +835,17 @@ public fn Stmt* Builder.actOnForStmt(Builder* b,
 public fn Stmt* Builder.actOnSwitchStmt(Builder* b,
                                         SrcLoc loc,
                                         Expr* cond,
-                                        SwitchCase** cases,
-                                        u32 num_cases) {
+                                        SwitchCase** cases, u32 num_cases) {
     return cast<Stmt*>(SwitchStmt.create(b.context, loc, cond, cases, num_cases));
 }
 
 public fn SwitchCase* Builder.actOnCase(Builder* b,
                                         SrcLoc loc,
                                         bool is_default,
-                                        Expr* cond,
-                                        identifier_expr_list.List* conditions,
-                                        Stmt** stmts,
-                                        u32 num_stmts) {
-    return SwitchCase.create(b.context,
-                             loc,
-                             is_default,
-                             cond,
-                             conditions.getData(), conditions.size(),
-                             stmts, num_stmts);
+                                        Expr** conds, u32 num_conds,
+                                        Stmt** stmts, u32 num_stmts) {
+    return SwitchCase.create(b.context, loc, is_default,
+                             conds, num_conds, stmts, num_stmts);
 }
 
 public fn Stmt* Builder.actOnAssertStmt(Builder* b, SrcLoc loc, Expr* inner) {
@@ -1003,6 +995,10 @@ public fn Expr* Builder.actOnExplicitCast(Builder* b,
 
 public fn Expr* Builder.actOnMemberExpr(Builder* b, Expr* base, const Ref* refs, u32 refcount) {
     return cast<Expr*>(MemberExpr.create(b.context, base, refs, refcount));
+}
+
+public fn Expr* Builder.actOnRange(Builder* b, SrcLoc loc, Expr* lhs, Expr* rhs) {
+    return cast<Expr*>(RangeExpr.create(b.context, loc, lhs, rhs));
 }
 
 public fn Expr* Builder.actOnInitList(Builder* b,

--- a/parser/c2_parser_switch.c2
+++ b/parser/c2_parser_switch.c2
@@ -17,7 +17,7 @@ module c2_parser;
 
 import stmt_list;
 import case_list;
-import identifier_expr_list;
+import expr_list;
 import ast local;
 import token local;
 import src_loc local;
@@ -64,87 +64,34 @@ fn Stmt* Parser.parseSwitchStmt(Parser* p) {
     return s;
 }
 
-fn Expr* Parser.parseCaseCondition(Parser* p, identifier_expr_list.List* list) {
-    // TODO: parse constant expression, not just single token.
-    bool multi_case = false;
-    if (p.tok.kind == Kind.Identifier) {
-        Kind kind = p.tokenizer.lookahead(1, nil);
-        if (kind == Kind.Comma || kind == Kind.Ellipsis) multi_case = true;
-    }
-
-    if (!multi_case) {
-        Expr* e;
-        switch (p.tok.kind) {
-            case Identifier:
-                e = p.parseFullIdentifier();
-                break;
-            case IntegerLiteral:
-                e = p.builder.actOnIntegerLiteral(p.tok.loc, p.tok.len, p.tok.int_value, p.tok.getRadix());
-                p.consumeToken();
-                break;
-            case CharLiteral:
-                e = p.builder.actOnCharLiteral(p.tok.loc, p.tok.len, p.tok.char_value, p.tok.getRadix());
-                p.consumeToken();
-                break;
-            case StringLiteral:
-                e = p.parseStringLiteral();
-                break;
-            case Plus:
-                e = p.parseExpr();
-                break;
-            case Minus:
-                e = p.parseExpr();
-                break;
-            case KW_nil:
-                e = p.builder.actOnNilExpr(p.tok.loc);
-                p.consumeToken();
-                break;
-            default:
-                p.error("expected case condition");
-                return nil;
-        }
-        if (p.tok.kind == Kind.Comma || p.tok.kind == Kind.Ellipsis) {
-            p.error("multi-condition case statements are only allowed with unprefixed enum constants");
-        }
-        return e;
-    }
-
-    while (1) {
-        // TODO accept general ranges: expr1 ... expr1 and let analyser check if expr1 <= expr2
-        p.expectIdentifier();
-
-        IdentifierExpr* id1 = p.parseIdentifier();
-        if (!list.add(id1)) p.error("too many conditions");
-
-        if (p.tok.kind == Kind.Ellipsis) { // A ... C
+fn void Parser.parseCaseCondition(Parser* p, expr_list.List* list) {
+    for (;;) {
+        Expr* e = p.parseExpr();
+        if (p.tok.kind == Kind.Ellipsis) {
+            SrcLoc loc = p.tok.loc;
             p.consumeToken();
-            p.expectIdentifier();
-            IdentifierExpr* id2 = p.parseIdentifier();
-            id1.setCaseRange();
-            if (!list.add(id2)) p.error("too many conditions");
+            Expr* e1 = p.parseExpr();
+            e = p.builder.actOnRange(loc, e, e1);
         }
-
+        list.add(e);
         if (p.tok.kind == Kind.Colon) break;
-
         p.expectAndConsume(Kind.Comma);
     }
-    return nil;
 }
 
 fn SwitchCase* Parser.parseCase(Parser* p, bool is_default) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
 
-    Expr* cond = nil;
-
-    identifier_expr_list.List list;
-    list.init();
+    // TODO: potential memory leak on error
+    expr_list.List conds;
+    conds.init();
     if (!is_default) {
-        cond = p.parseCaseCondition(&list);
+        p.parseCaseCondition(&conds);
     }
-
     p.expectAndConsume(Kind.Colon);
 
+    // TODO: potential memory leak on error
     stmt_list.List stmts;
     stmts.init();
 
@@ -162,7 +109,8 @@ fn SwitchCase* Parser.parseCase(Parser* p, bool is_default) {
         }
     }
 
-    SwitchCase* s = p.builder.actOnCase(loc, is_default, cond, &list, stmts.getData(), stmts.size());
+    SwitchCase* s = p.builder.actOnCase(loc, is_default, conds.getData(), conds.size(), stmts.getData(), stmts.size());
+    conds.free();
     stmts.free();
     return s;
 }

--- a/parser/expr_list.c2
+++ b/parser/expr_list.c2
@@ -13,33 +13,51 @@
  * limitations under the License.
  */
 
-module identifier_expr_list;
+module expr_list;
 
 import ast local;
 
-public const u32 MaxSize = 32;
+import string local;
+import stdlib local;
+
+// Use stack for small lists, heap for larger ones
+
+public const u32 StackSize = 4;
 
 public type List struct {
     u32 count;
-    IdentifierExpr*[MaxSize] data;
+    u32 capacity;
+    Expr*[StackSize] stack;
+    Expr** data;
 }
 
 public fn void List.init(List* l) {
-    l.count = 0;
+    memset(l, 0, sizeof(List));
+    l.data = l.stack;
+    l.capacity = elemsof(l.stack);
 }
 
-public fn bool List.add(List* l, IdentifierExpr* i) {
-    if (l.count == MaxSize) return false;
-    l.data[l.count] = i;
+public fn void List.add(List* l, Expr* e) {
+    if (l.count == l.capacity) {
+        l.capacity *= 2;
+        Expr** data2 = malloc(l.capacity * sizeof(Expr*));
+        memcpy(data2, l.data, l.count * sizeof(Expr*));
+        if (l.data != l.stack) free(l.data);
+        l.data = data2;
+    }
+    l.data[l.count] = e;
     l.count++;
-    return true;
+}
+
+public fn void List.free(List* l) {
+    if (l.data != l.stack) free(l.data);
 }
 
 public fn u32 List.size(const List* l) {
     return l.count;
 }
 
-public fn IdentifierExpr** List.getData(List* l) {
+public fn Expr** List.getData(List* l) {
     return l.data;
 }
 

--- a/parser/stmt_list.c2
+++ b/parser/stmt_list.c2
@@ -28,29 +28,29 @@ public type List struct {
     u32 count;
     u32 capacity;
     Stmt*[StackSize] stack;
-    Stmt** heap;
+    Stmt** data;
 }
 
 public fn void List.init(List* l) {
     memset(l, 0, sizeof(List));
-    l.heap = l.stack;
+    l.data = l.stack;
     l.capacity = elemsof(l.stack);
 }
 
 public fn void List.add(List* l, Stmt* s) {
     if (l.count == l.capacity) {
         l.capacity *= 2;
-        Stmt** heap2 = malloc(l.capacity * sizeof(Stmt*));
-        memcpy(heap2, l.heap, l.count * sizeof(Stmt*));
-        if (l.heap != l.stack) free(l.heap);
-        l.heap = heap2;
+        Stmt** data2 = malloc(l.capacity * sizeof(Stmt*));
+        memcpy(data2, l.data, l.count * sizeof(Stmt*));
+        if (l.data != l.stack) free(l.data);
+        l.data = data2;
     }
-    l.heap[l.count] = s;
+    l.data[l.count] = s;
     l.count++;
 }
 
 public fn void List.free(List* l) {
-    if (l.heap != l.stack) free(l.heap);
+    if (l.data != l.stack) free(l.data);
 }
 
 public fn u32 List.size(const List* l) {
@@ -58,6 +58,6 @@ public fn u32 List.size(const List* l) {
 }
 
 public fn Stmt** List.getData(List* l) {
-    return l.heap;
+    return l.data;
 }
 

--- a/recipe.txt
+++ b/recipe.txt
@@ -89,6 +89,7 @@ set ast
     ast/member_expr.c2
     ast/nil_expr.c2
     ast/paren_expr.c2
+    ast/range_expr.c2
     ast/string_literal.c2
     ast/type_expr.c2
     ast/unary_operator.c2
@@ -190,7 +191,7 @@ executable c2c
     parser/c2_parser_type.c2
     parser/c2_tokenizer.c2
     parser/case_list.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
     parser/keywords.c2
     parser/stmt_list.c2
     parser/token.c2
@@ -410,7 +411,7 @@ lib deps_generator dynamic
     (common)
 
     parser/ast_builder.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
 
     generator/ast_visitor.c2
     generator/ast_visitor_expr.c2
@@ -438,7 +439,7 @@ lib refs_generator dynamic
     common/quicksort.c2
 
     parser/ast_builder.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
 
     generator/c2refs.c2
     generator/ast_visitor.c2
@@ -461,7 +462,7 @@ lib git_version dynamic
     (common)
 
     parser/ast_builder.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
 
     plugins/plugin_info.c2
     plugins/git_version_plugin.c2
@@ -477,7 +478,7 @@ lib load_file dynamic
     (yaml)
 
     parser/ast_builder.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
 
     plugins/plugin_info.c2
     plugins/load_file_plugin.c2
@@ -492,7 +493,7 @@ lib unit_test dynamic
     (common)
 
     parser/ast_builder.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
 
     plugins/plugin_info.c2
     plugins/unit_test_plugin.c2
@@ -508,7 +509,7 @@ lib shell_cmd dynamic
     (yaml)
 
     parser/ast_builder.c2
-    parser/identifier_expr_list.c2
+    parser/expr_list.c2
 
     plugins/plugin_info.c2
     plugins/shell_cmd_plugin.c2

--- a/test/c_generator/stmts/multi_condition_switch.c2t
+++ b/test/c_generator/stmts/multi_condition_switch.c2t
@@ -32,15 +32,9 @@ static void test_test1(test_Foo f)
    case test_Foo_A:
       break;
    case test_Foo_B:
-      fallthrough;
    case test_Foo_C:
       break;
-   case test_Foo_D:
-      fallthrough;
-   case test_Foo_E:
-      fallthrough;
-   case test_Foo_F:
-      fallthrough;
+   case test_Foo_D ... test_Foo_F:
    case test_Foo_G:
       break;
    }

--- a/test/c_generator/stmts/multi_condition_switch_incr.c2t
+++ b/test/c_generator/stmts/multi_condition_switch_incr.c2t
@@ -31,14 +31,9 @@ public fn i32 main() {
 static void test_test1(test_Foo f)
 {
    switch (f) {
-   case test_Foo_A:
-      fallthrough;
-   case test_Foo_B:
-      fallthrough;
-   case test_Foo_C:
+   case test_Foo_A ... test_Foo_C:
       break;
    case test_Foo_D:
-      fallthrough;
    case test_Foo_E:
       break;
    }

--- a/test/parser/switch_valid.c2
+++ b/test/parser/switch_valid.c2
@@ -1,0 +1,57 @@
+// @warnings{no-unused}
+module test;
+
+const i32 F3 = 3;
+const i32 F10 = 10;
+const i32 F12 = 12;
+const i32 F17 = 17;
+const i32 F18 = 18;
+const i32 F19 = 19;
+const i32 F20 = 20;
+
+type Foo struct {
+    char[22] a;
+    char b;
+    char c;
+}
+
+Foo s;
+
+fn i32 foo(i32 n) {
+    switch (n) {
+    case 0: return 0;
+    case !0 * 1: return 1;
+    case 2 ... 2: return 2;
+    case +3: return 3;
+    case 2+2: return 4;
+    case -1+6: return 5;
+    case (6): return 6;
+    case (((7)))...(7): return 7;
+    case (9-1): return 8;
+    case F3*3: return 9;
+    case F20/2: return 10;
+    case F10+1: return 11;
+    case F12...F12: return 12;
+    case F12+1 ... F12+1: return 13;
+    case ~-1+14: return 14;
+    case 15,16: return n;
+    case F17,F18,F19...F20: return n;
+    case sizeof(char[21]): return 21;
+    case elemsof(s.a): return 22;
+    case offsetof(Foo, c): return 23;
+    case sizeof(Foo): return 24;
+    case 24 + (0 || 1): return 25;
+    case 26 + (0 && 1): return 26;
+    case 26 + (0 | 1): return 27;
+    case 28 + (0 & 1): return 28;
+    //case true ? 29 : 30: return 29;
+    }
+    return 0;
+}
+
+public fn i32 main() {
+    for (i32 i = 0; i <= 28; i++) {
+        assert(foo(i) == i);
+    }
+    return 0;
+}

--- a/test/stmt/multi_case/no_enum_multi.c2
+++ b/test/stmt/multi_case/no_enum_multi.c2
@@ -10,7 +10,7 @@ fn void test1(u32 a) {
     case Foo.G: fallthrough;
     case Foo.A:
         break;
-    case Foo.B, Foo.C:  // @error{multi-condition case statements are only allowed with unprefixed enum constants}
+    case Foo.B, Foo.C:
         break;
     }
 }

--- a/test/stmt/multi_case/no_enum_range.c2
+++ b/test/stmt/multi_case/no_enum_range.c2
@@ -10,7 +10,7 @@ fn void test1(u32 a) {
     case Foo.G: fallthrough;
     case Foo.A:
         break;
-    case Foo.B ... Foo.F:  // @error{multi-condition case statements are only allowed with unprefixed enum constants}
+    case Foo.B ... Foo.F:
         break;
     }
 }

--- a/test/stmt/multi_case/range_same_constant.c2
+++ b/test/stmt/multi_case/range_same_constant.c2
@@ -7,8 +7,8 @@ type Foo enum u8 {
 
 fn void test1(Foo f) {
     switch (f) {
-    case B...    // @note{previous case is here}
-        B:       // @error{duplicate case value 'B'}
+    case B...B,  // @note{previous case is here}
+         B:      // @error{duplicate case value 'B'}
         break;
     }
 }

--- a/test/stmt/switch/multi_number_case.c2
+++ b/test/stmt/switch/multi_number_case.c2
@@ -6,7 +6,7 @@ fn void test1() {
     switch (a) {
     case 1:
         break;
-    case 2 ... 10:  // @error{multi-condition case statements are only allowed with unprefixed enum constants}
+    case 2 ... 10:
         break;
     }
 }

--- a/test/stmt/switch/switch_multiple_defaults.c2
+++ b/test/stmt/switch/switch_multiple_defaults.c2
@@ -5,7 +5,7 @@ fn void test1() {
     switch (10) {
     default:    // @error{default case must be last in switch}
         break;
-    default:
+    default:    // @error{multiple default labels}
         break;
     }
 }

--- a/test/stmt/switch/switch_str_function_call_case.c2
+++ b/test/stmt/switch/switch_str_function_call_case.c2
@@ -3,7 +3,7 @@ module test;
 
 fn void test1(const char* str) {
     switch (str) {
-    case test1(nil):  // @error{expected ':'}
+    case test1(nil):  // @error{string switch case can only have a string literal or nil as condition}
         break;
     }
 }

--- a/test/stmt/switch/switch_str_multiple_defaults.c2
+++ b/test/stmt/switch/switch_str_multiple_defaults.c2
@@ -4,7 +4,7 @@ module test;
 fn void test1() {
     switch ("text") {
     default:    // @error{default case must be last in switch}
-    default:
+    default:    // @error{multiple default labels}
     }
 }
 


### PR DESCRIPTION
Case handling:
* add `expr_list.List` with dynamic allocation beyond initial set
* remove `identifier_expr_list.c2`
* remove `EnumTypeDecl.findConstantIdx`
* remove `IdentifierExpr.setCaseRange`, `IdentifierExpr.isCaseRange`
* fix `SwitchCase.instantiate`, did not return new expr
* simplify and generalize multi-case implementation
* update tests

Analyser:
* add range support in init_checker (`Checker.add2` and `Checker.find2`)
* simplify and generalize multi-case analysis

Generator:
* generate case ranges as both gcc and clang support them

Makefile:
* disable format warning when compiling bootstrap
* patch compilation output to fix filenames in error messages