### PR TITLE
compiler: use va_list instead of Va_list

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -259,21 +259,21 @@ type StackLayer struct {
 }
 
 fn void Analyser.note(Analyser* ma, SrcLoc loc, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     ma.diags.note2(loc, format, args);
     va_end(args);
 }
 
 fn void Analyser.warn(Analyser* ma, SrcLoc loc, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     ma.diags.warn2(loc, format, args);
     va_end(args);
 }
 
 fn void Analyser.error(Analyser* ma, SrcLoc loc, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     ma.diags.error2(loc, format, args);
     va_end(args);
@@ -283,7 +283,7 @@ fn void Analyser.error(Analyser* ma, SrcLoc loc, const char* format @(printf_for
 }
 
 fn void Analyser.errorRange(Analyser* ma, SrcLoc loc, SrcRange range, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     ma.diags.errorRange2(loc, range, format, args);
     va_end(args);

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -129,7 +129,7 @@ public fn void Buf.rparen(Buf* buf) { buf.add1(')'); }
 public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) {
     char[4096] tmp;
     // NOTE: no growing
-    Va_list args;
+    va_list args;
     va_start(args, format);
     i32 len = vsnprintf(tmp, sizeof(tmp), format, args);
     assert(len < sizeof(tmp));
@@ -137,7 +137,7 @@ public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) {
     va_end(args);
 }
 
-public fn void Buf.vprintf(Buf* buf, const char* format, Va_list args) {
+public fn void Buf.vprintf(Buf* buf, const char* format, va_list args) {
     char[4096] tmp;
     // NOTE: no growing
     i32 len = vsnprintf(tmp, sizeof(tmp), format, args);

--- a/bootstrap/bootstrap.c
+++ b/bootstrap/bootstrap.c
@@ -26000,7 +26000,7 @@ static void c2_parser_Parser_parseTypeDecl(c2_parser_Parser* p, bool is_public)
    uint32_t type_name = p->tok.name_idx;
    src_loc_SrcLoc type_loc = p->tok.loc;
    const char* name = string_pool_Pool_idx2str(p->pool, type_name);
-   if (!isupper(name[0])) c2_parser_Parser_error(p, "a type name must start with an upper case character");
+   if (!isupper(name[0]) && !p->is_interface) c2_parser_Parser_error(p, "a type name must start with an upper case character");
    c2_parser_Parser_consumeToken(p);
    switch (p->tok.kind) {
    case token_Kind_KW_fn:

--- a/common/console.c2
+++ b/common/console.c2
@@ -42,7 +42,7 @@ public fn void debug(const char* format @(printf_format), ...) {
     if (!show_debug) return;
 
     char[BUF_SIZE] buf;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
@@ -55,7 +55,7 @@ public fn void debug(const char* format @(printf_format), ...) {
 
 public fn void log(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
@@ -64,7 +64,7 @@ public fn void log(const char* format @(printf_format), ...) {
 
 public fn void warn(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
@@ -77,7 +77,7 @@ public fn void warn(const char* format @(printf_format), ...) {
 
 public fn void error(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsprintf(buf, format, args);
     va_end(args);
@@ -90,7 +90,7 @@ public fn void error(const char* format @(printf_format), ...) {
 
 public fn void error_diag(const char* loc, const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsprintf(buf, format, args);
     va_end(args);

--- a/common/diagnostics.c2
+++ b/common/diagnostics.c2
@@ -76,33 +76,33 @@ const char*[] category_colors = {
 }
 
 public fn void Diags.error(Diags* diags, SrcLoc loc, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     SrcRange range = { 0, 0 }
     diags.internal(Category.Error, loc, range, format, args);
     va_end(args);
 }
 
-public fn void Diags.error2(Diags* diags, SrcLoc loc, const char* format, Va_list args) {
+public fn void Diags.error2(Diags* diags, SrcLoc loc, const char* format, va_list args) {
     SrcRange range = { 0, 0 }
     diags.internal(Category.Error, loc, range, format, args);
 }
 
 public fn void Diags.note(Diags* diags, SrcLoc loc, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     SrcRange range = { 0, 0 }
     diags.internal(Category.Note, loc, range, format, args);
     va_end(args);
 }
 
-public fn void Diags.note2(Diags* diags, SrcLoc loc, const char* format, Va_list args) {
+public fn void Diags.note2(Diags* diags, SrcLoc loc, const char* format, va_list args) {
     SrcRange range = { 0, 0 }
     diags.internal(Category.Note, loc, range, format, args);
 }
 
 public fn void Diags.warn(Diags* diags, SrcLoc loc, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     SrcRange range = { 0, 0 }
     Category category = Category.Warning;
@@ -111,7 +111,7 @@ public fn void Diags.warn(Diags* diags, SrcLoc loc, const char* format @(printf_
     va_end(args);
 }
 
-public fn void Diags.warn2(Diags* diags, SrcLoc loc, const char* format, Va_list args) {
+public fn void Diags.warn2(Diags* diags, SrcLoc loc, const char* format, va_list args) {
     SrcRange range = { 0, 0 }
     Category category = Category.Warning;
     if (diags.promote_warnings) category = Category.Error;
@@ -122,7 +122,7 @@ public fn void Diags.errorRange(Diags* diags,
                                 SrcLoc loc,
                                 SrcRange range,
                                 const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     diags.internal(Category.Error, loc, range, format, args);
     va_end(args);
@@ -132,7 +132,7 @@ public fn void Diags.errorRange2(Diags* diags,
                                  SrcLoc loc,
                                  SrcRange range,
                                  const char* format,
-                                 Va_list args) {
+                                 va_list args) {
     diags.internal(Category.Error, loc, range, format, args);
 }
 
@@ -141,7 +141,7 @@ fn void Diags.internal(Diags* diags,
                        SrcLoc sloc,
                        SrcRange range,
                        const char* format,
-                       Va_list args) {
+                       va_list args) {
     if (category == Category.Error) {
         diags.num_errors++;
     } else {

--- a/common/process_utils.c2
+++ b/common/process_utils.c2
@@ -43,7 +43,7 @@ fn char getWEXITSTATUS(i32 state) {
 
 fn void child_error(i32 fd, const char* format @(printf_format), ...) @(noreturn) {
     char[256] msg;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     i32 res = vsnprintf(msg, sizeof(msg), format, args);
     va_end(args);

--- a/common/yaml/yaml_parser.c2
+++ b/common/yaml/yaml_parser.c2
@@ -72,7 +72,7 @@ public fn const char* Parser.getMessage(const Parser* p) {
 }
 
 fn void Parser.error(Parser* p, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     char* cp = p.message;
     cp += vsnprintf(cp, MaxDiag-1, format, args);

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -193,7 +193,7 @@ fn bool Parser.addGlobalFeature(Parser* p, u32 feature) {
 
 fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(noreturn) {
     char[128] msg;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(msg, sizeof(msg)-1, format, args);
     va_end(args);

--- a/libs/libc/stdarg.c2i
+++ b/libs/libc/stdarg.c2i
@@ -4,9 +4,9 @@ import c2 local;
 
 // NOTE: because of va_list we generate the C file for this manually in C-generator!
 
-type Va_list struct @(cname="va_list") {
+type va_list struct @(cname="va_list") {
     c_char[24] pad;
 }
 
-fn void va_start(Va_list ap, const c_char* last);
-fn void va_end(Va_list ap);
+fn void va_start(va_list ap, const c_char* last);
+fn void va_end(va_list ap);

--- a/libs/libc/stdio.c2i
+++ b/libs/libc/stdio.c2i
@@ -182,8 +182,8 @@ fn c_int fpurge(FILE *);
 //fn c_int vasprintf(c_char**, const c_char*, va_list);
 fn FILE *zopen(const c_char*, const c_char*, c_int);
 
-fn c_int vdprintf(c_int __fd, const c_char *format, Va_list ap);
-fn c_int vfprintf(FILE* stream, const c_char *format, Va_list ap);
-fn c_int vprintf(const c_char* format, Va_list ap);
-fn c_int vsprintf(c_char* str, const c_char *format, Va_list ap);
-fn c_int vsnprintf(c_char* str, c_size size, const c_char *format, Va_list ap);
+fn c_int vdprintf(c_int __fd, const c_char *format, va_list ap);
+fn c_int vfprintf(FILE* stream, const c_char *format, va_list ap);
+fn c_int vprintf(const c_char* format, va_list ap);
+fn c_int vsprintf(c_char* str, const c_char *format, va_list ap);
+fn c_int vsnprintf(c_char* str, c_size size, const c_char *format, va_list ap);

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -185,7 +185,7 @@ fn void Parser.expectIdentifier(Parser* p) {
 fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(noreturn) {
     char[256] msg;
 
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(msg, sizeof(msg)-1, format, args);
     va_end(args);

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -28,7 +28,7 @@ fn void Parser.parseTypeDecl(Parser* p, bool is_public) {
     u32 type_name = p.tok.name_idx;
     SrcLoc type_loc = p.tok.loc;
     const char* name = p.pool.idx2str(type_name);
-    if (!isupper(name[0])) p.error("a type name must start with an upper case character");
+    if (!isupper(name[0]) && !p.is_interface) p.error("a type name must start with an upper case character");
 
     p.consumeToken();
 

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -693,7 +693,7 @@ public fn Kind Tokenizer.lookahead(Tokenizer* t, u32 n, Token *tok) {
 }
 
 fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
     va_end(args);
@@ -707,7 +707,7 @@ fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf
 
 // generate an error but keep parsing
 fn void Tokenizer.num_error(Tokenizer* t, Token* result, const char* p, const char* format @(printf_format), ...) {
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
     va_end(args);

--- a/plugins/unit_test_plugin.c2
+++ b/plugins/unit_test_plugin.c2
@@ -109,7 +109,7 @@ fn void generate_types(Plugin *p) {
 
     // For c2test_main, not for tests themselves
     out.add("public type ErrorFn fn void (const char* fmt @(printf_format), ...);\n");
-    out.add("public type LogFn fn void (const char* fmt, Va_list args);\n\n");
+    out.add("public type LogFn fn void (const char* fmt, va_list args);\n\n");
 
     out.add("public type Config struct {\n");
     out.add("  ErrorFn on_error;\n");
@@ -249,7 +249,7 @@ fn void generate_types(Plugin *p) {
     out.add("}\n\n");
 
     out.add("public fn void log(const char* fmt @(printf_format), ...) {\n");
-    out.add("  Va_list args;\n");
+    out.add("  va_list args;\n");
     out.add("  va_start(args, fmt);\n");
     out.add("  g_cfg.on_log(fmt, args);\n");
     out.add("  va_end(args);\n");
@@ -428,7 +428,7 @@ fn void Plugin.generate_c2test_main(Plugin* p) {
     out.add("  }\n");
     out.add("}\n\n");
 
-    out.add("fn void vprint_errormsg(const char* fmt, Va_list ap) {\n");
+    out.add("fn void vprint_errormsg(const char* fmt, va_list ap) {\n");
     out.add("  i32 ret = vsnprintf(error_msg, error_size, fmt, ap);\n");
     out.add("  if (ret < 0) {\n");
     out.add("    error_msg[0] = 0;\n");
@@ -442,7 +442,7 @@ fn void Plugin.generate_c2test_main(Plugin* p) {
     out.add("}\n\n");
 
     out.add("fn void print_errormsg(const char* fmt, ...) {\n");
-    out.add("  Va_list args;\n");
+    out.add("  va_list args;\n");
     out.add("  va_start(args, fmt);\n");
     out.add("  vprint_errormsg(fmt, args);\n");
     out.add("  va_end(args);\n");
@@ -461,7 +461,7 @@ fn void Plugin.generate_c2test_main(Plugin* p) {
     out.add("}\n\n");
 
     out.add("fn void on_error(const char* fmt @(printf_format), ...) {\n");
-    out.add("  Va_list args;\n");
+    out.add("  va_list args;\n");
     out.add("  msg_start(Yellow, \"ERR\");\n");
     out.add("  va_start(args, fmt);\n");
     out.add("  vprint_errormsg(fmt, args);\n");
@@ -470,7 +470,7 @@ fn void Plugin.generate_c2test_main(Plugin* p) {
     out.add("  longjmp(&jmpbuf, 1);\n");
     out.add("}\n\n");
 
-    out.add("public fn void on_log(const char* fmt, Va_list args) {\n");
+    out.add("public fn void on_log(const char* fmt, va_list args) {\n");
     out.add("  msg_start(Blue, \"LOG\");\n");
     out.add("  vprint_errormsg(fmt, args);\n");
     out.add("  msg_end();\n");

--- a/tools/tester/test_utils.c2
+++ b/tools/tester/test_utils.c2
@@ -52,7 +52,7 @@ public fn void set_color_output(const char *name, bool enable) {
 
 public fn void color_print(const char* col, const char* format @(printf_format), ...) {
     char[1024] buffer;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);
@@ -63,7 +63,7 @@ public fn void color_print(const char* col, const char* format @(printf_format),
 
 public fn void print_error(const char* format @(printf_format), ...) {
     char[1024] buffer;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);
@@ -78,7 +78,7 @@ public fn void color_print2(string_buffer.Buf* output,
                             ...)
 {
     char[1024] buffer;
-    Va_list args;
+    va_list args;
     va_start(args, format);
     vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);


### PR DESCRIPTION
* allow types to start with lowercase in interface files
* use `va_list` for consistency with C