### PR TITLE
syntax: fix compilation error on macOS

### DIFF
--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -543,7 +543,7 @@ fn void Generator.emitMemberExpr(Generator* gen, ir.Ref* result, const Expr* e) 
 
     assert(kind == IdentifierKind.StructMember);
 next:
-
+    {}
 #if 0
     if (m.hasExpr()) {
         const Expr* base = m.getExprBase();


### PR DESCRIPTION
* add dummy block `{}` after label to allow compilation with older clang.
* should rebuilt bootstrap to support labelled declarations.