### PR TITLE
analyser: accept conversions between char* and u8*, not i8*

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -385,10 +385,9 @@ fn bool pointer_conversion_allowed(QualType linner, QualType rinner) {
     if (in1.isVoidType()) return true; // ptr -> void* is allowed
     if (in2.isVoidType()) return true; // void* -> ptr is allowed
 
-
-    // allow i8* -> char* and reverse
-    if (linner.isInt8() && rinner.isChar()) return true;
-    if (linner.isChar() && rinner.isInt8()) return true;
+    // allow u8* -> char* and reverse
+    if (linner.isUInt8() && rinner.isChar()) return true;
+    if (linner.isChar() && rinner.isUInt8()) return true;
 
     // TODO check ptr-ptr, use ptr-inner-table
 
@@ -409,7 +408,6 @@ fn bool Checker.checkPointers(Checker* c, const Type* lcanon, const Type* rcanon
 
     QualType linner = ltype.getInner();
     QualType rinner = rtype.getInner();
-
 
     if (!pointer_conversion_allowed(linner, rinner)) {
         if (c.try_to_fix_type()) {
@@ -529,8 +527,6 @@ fn bool Checker.checkFunc2Builtin(Checker* c, const Type* lcanon, const Type* rc
 
     return false;
 }
-
-
 
 public fn bool Checker.checkCast(Checker* c, QualType lhs, QualType rhs, SrcLoc lhsLoc, SrcLoc rhsLoc) {
     c.lhs = lhs;

--- a/test/expr/bitoffset/bitoffset_invalid_base.c2
+++ b/test/expr/bitoffset/bitoffset_invalid_base.c2
@@ -17,7 +17,7 @@ fn void test2() {
 }
 
 fn void test3() {
-    const i8* text = "hallo";
+    const u8* text = "hallo";
     b = text[4:2];   // @error{bitoffsets are only allowed on unsigned integer type}
 }
 

--- a/test/expr/bitoffset/bitoffset_invalid_index.c2
+++ b/test/expr/bitoffset/bitoffset_invalid_index.c2
@@ -3,14 +3,14 @@ module test;
 
 u32 a = 0;
 u32 b = 0;
-const i8* text = "";
+const u8* text = "";
 
 fn void test1() {
     b = a[test1:0];     // @error{index of bitoffset has non-integer type 'void ()'}
 }
 
 fn void test2() {
-    b = a[0:text];      // @error{index of bitoffset has non-integer type 'const i8*'}
+    b = a[0:text];      // @error{index of bitoffset has non-integer type 'const u8*'}
 }
 
 fn void test3() {

--- a/test/init/init_array_designator_ok.c2
+++ b/test/init/init_array_designator_ok.c2
@@ -17,7 +17,7 @@ i32[] array = {
 
 type Point struct {
     i32 x;
-    const i8* name;
+    const u8* name;
 }
 
 Point[] array2 = {

--- a/test/init/init_field_designator_ok.c2
+++ b/test/init/init_field_designator_ok.c2
@@ -3,7 +3,7 @@ module test;
 
 type Point struct {
     i32 x;
-    const i8* y;
+    const u8* y;
 }
 
 Point[] array2 = {

--- a/test/literals/init_struct.c2
+++ b/test/literals/init_struct.c2
@@ -4,7 +4,7 @@ module test;
 type Struct struct {
     i8 a;
     u32 b;
-    const i8* text;
+    const u8* text;
 }
 
 Struct[3] a = { {1,2,"A"}, {3,4,"B"} }

--- a/test/types/conversion/i8_ptr_to_char_ptr_ok.c2
+++ b/test/types/conversion/i8_ptr_to_char_ptr_ok.c2
@@ -3,20 +3,20 @@ module test;
 
 fn void test1() {
     char* a = nil;
-    i8* b = nil;
+    u8* b = nil;
     a = b;
     b = a;
 }
 
 fn void test2() {
     char* a = nil;
-    u8* b = nil;
-    a = b;      // @error{invalid pointer conversion from 'u8*' to 'char*'}
+    i8* b = nil;
+    a = b;      // @error{invalid pointer conversion from 'i8*' to 'char*'}
 }
 
 fn void test3() {
     char* a = nil;
-    u8* b = nil;
-    b = a;  // @error{invalid pointer conversion from 'char*' to 'u8*'}
+    i8* b = nil;
+    b = a;  // @error{invalid pointer conversion from 'char*' to 'i8*'}
 }
 

--- a/test/types/string_init.c2
+++ b/test/types/string_init.c2
@@ -2,6 +2,6 @@
 module test;
 
 char* a = "AAA";
-i8* b = "BBB";
-u8* c = "CCC"; // @error{invalid type conversion from 'char[4]' to 'u8*'}
+u8* b = "BBB";
+i8* c = "CCC"; // @error{invalid type conversion from 'char[4]' to 'i8*'}
 

--- a/test/types/struct_array_init_ok.c2
+++ b/test/types/struct_array_init_ok.c2
@@ -2,7 +2,7 @@
 module test;
 
 type S struct {
-    i8* cp;
+    u8* cp;
     i32 a;
 }
 

--- a/test/vars/invalid_init_string.c2
+++ b/test/vars/invalid_init_string.c2
@@ -10,7 +10,7 @@ fn void test2() {
 }
 
 fn void test3() {
-    u8* a = "foo";  // @error{invalid type conversion from 'char[4]' to 'u8*'}
+    i8* a = "foo";  // @error{invalid type conversion from 'char[4]' to 'i8*'}
 }
 
 type Number i32;


### PR DESCRIPTION
* since `char` is now an alias for `u8`, we no longer accept transparent conversions between `char*` and `i8*`, but we do between `char*` and `u8*`.
* update tests