### PR TITLE
compiler: accept c-style casts

### DIFF
--- a/ast/explicit_cast_expr.c2
+++ b/ast/explicit_cast_expr.c2
@@ -21,7 +21,8 @@ import src_loc local;
 
 type ExplicitCastExprBits struct {
     u32 : NumExprBits;
-    u32 src_len : 32 - NumExprBits;
+    u32 c_style : 1;
+    u32 src_len : 32 - NumExprBits - 1;
 }
 
 public type ExplicitCastExpr struct @(opaque) {
@@ -34,11 +35,12 @@ public type ExplicitCastExpr struct @(opaque) {
 public fn ExplicitCastExpr* ExplicitCastExpr.create(ast_context.Context* c,
                                                       SrcLoc loc, u32 src_len,
                                                       const TypeRefHolder* ref,
-                                                      Expr* inner)
+                                                      Expr* inner, bool c_style)
 {
     u32 size = sizeof(ExplicitCastExpr) + ref.getExtraSize();
     ExplicitCastExpr* e = c.alloc(size);
     e.base.init(ExprKind.ExplicitCast, loc, 0, 0, 0, ValType.NValue);
+    e.base.base.explicitCastExprBits.c_style = c_style;
     e.base.base.explicitCastExprBits.src_len = src_len;
     e.dest_type = QualType_Invalid;
     e.inner = inner;
@@ -64,6 +66,10 @@ fn Expr* ExplicitCastExpr.instantiate(ExplicitCastExpr* e, Instantiator* inst) {
 public fn void ExplicitCastExpr.setDestType(ExplicitCastExpr* e, QualType qt) { e.dest_type = qt; }
 public fn QualType ExplicitCastExpr.getDestType(const ExplicitCastExpr* e) { return e.dest_type; }
 
+public fn bool ExplicitCastExpr.getCStyle(const ExplicitCastExpr* e) {
+    return e.base.base.explicitCastExprBits.c_style;
+}
+
 public fn Expr* ExplicitCastExpr.getInner(const ExplicitCastExpr* e) { return e.inner; }
 public fn Expr** ExplicitCastExpr.getInner2(ExplicitCastExpr* e) { return &e.inner; }
 
@@ -76,11 +82,18 @@ fn SrcLoc ExplicitCastExpr.getEndLoc(const ExplicitCastExpr* e) {
 }
 
 fn void ExplicitCastExpr.printLiteral(const ExplicitCastExpr* e, string_buffer.Buf* out) {
-    out.add("cast<");
-    e.dest.print(out, true);
-    out.add(">(");
-    e.inner.printLiteral(out);
-    out.add1(')');
+    if (e.base.base.explicitCastExprBits.c_style) {
+        out.add1('(');
+        e.dest.print(out, true);
+        out.add1(')');
+        e.inner.printLiteral(out);
+    } else {
+        out.add("cast<");
+        e.dest.print(out, true);
+        out.add(">(");
+        e.inner.printLiteral(out);
+        out.add1(')');
+    }
 }
 
 fn void ExplicitCastExpr.print(const ExplicitCastExpr* e, string_buffer.Buf* out, u32 indent) {

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -130,9 +130,15 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
         ExplicitCastExpr* c = cast<ExplicitCastExpr*>(e);
         out.add("((");
         gen.emitTypePre(out, c.getDestType());
-        out.add(")(");
-        gen.emitExpr(out, c.getInner());
-        out.add("))");
+        if (c.getCStyle()) {
+            out.add1(')');
+            gen.emitExpr(out, c.getInner());
+            out.add1(')');
+        } else {
+            out.add(")(");
+            gen.emitExpr(out, c.getInner());
+            out.add("))");
+        }
         break;
     case ImplicitCast:
         ImplicitCastExpr* i = cast<ImplicitCastExpr*>(e);
@@ -319,6 +325,7 @@ fn void Generator.emitMemberExprBase(Generator* gen, string_buffer.Buf* out, Exp
 }
 
 fn void Generator.emitFieldDesigExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
+    // Cannot use printLiteral because expressions need C conversion
     FieldDesignatedInitExpr* fdi = cast<FieldDesignatedInitExpr*>(e);
     out.add1('.');
     out.add(fdi.getFieldName());
@@ -327,6 +334,7 @@ fn void Generator.emitFieldDesigExpr(Generator* gen, string_buffer.Buf* out, Exp
 }
 
 fn void Generator.emitArrayDesigExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
+    // Cannot use printLiteral because expressions need C conversion
     ArrayDesignatedInitExpr* ad = cast<ArrayDesignatedInitExpr*>(e);
     out.add1('[');
     gen.emitExpr(out, ad.getDesignator());

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -992,8 +992,8 @@ public fn Expr* Builder.actOnTemplateCallExpr(Builder* b,
 public fn Expr* Builder.actOnExplicitCast(Builder* b,
                                           SrcLoc loc, u32 src_len,
                                           const TypeRefHolder* ref,
-                                          Expr* inner) {
-    return cast<Expr*>(ExplicitCastExpr.create(b.context, loc, src_len, ref, inner));
+                                          Expr* inner, bool c_style) {
+    return cast<Expr*>(ExplicitCastExpr.create(b.context, loc, src_len, ref, inner, c_style));
 }
 
 public fn Expr* Builder.actOnMemberExpr(Builder* b, Expr* base, const Ref* refs, u32 refcount) {

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -22,6 +22,7 @@ import constants;
 import token local;
 import src_loc local;
 
+import ctype local;
 import string;
 
 /// PrecedenceLevels - These have been altered from C99 to C2
@@ -508,6 +509,24 @@ fn Expr* Parser.parseParenExpr(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
 
+    bool has_brackets = false;
+    if (p.parseAsCastType(0, Kind.RParen, &has_brackets)) {
+        TypeRefHolder ref;
+        ref.init();
+        p.parseTypeSpecifier(&ref, true, has_brackets);
+        p.expectAndConsume(Kind.RParen);
+        if (p.tok.kind == Kind.LBrace) {
+            // compound literal
+            p.error("Compound literals are not supported");
+        } else {
+            // C cast expression
+            if (has_brackets) p.error("array types are not allowed here");
+            Expr* expr = p.parseCastExpr(false, false);
+            u32 src_len = p.prev_loc - loc;
+            return p.builder.actOnExplicitCast(loc, src_len, &ref, expr, true);
+        }
+    }
+
     Expr* res = p.parseExpr();
     u32 src_len = p.tok.loc + 1 - loc;
     p.expectAndConsume(Kind.RParen);
@@ -689,7 +708,7 @@ fn Expr* Parser.parseExplicitCastExpr(Parser* p) {
     u32 src_len = p.tok.loc + 1 - loc;
     p.expectAndConsume(Kind.RParen);
 
-    return p.builder.actOnExplicitCast(loc, src_len, &ref, expr);
+    return p.builder.actOnExplicitCast(loc, src_len, &ref, expr, false);
 }
 
 // Syntax:
@@ -815,3 +834,121 @@ fn bool Parser.parseAsType(Parser* p, bool* has_brackets) {
     return false;
 }
 
+/*
+   Type parser for C style casts and compound literals.
+   Accepts all type specifications, including parametric types.
+   Return the number of tokens until and including the closing token.
+   Return 0 if the expression is not a type specification.
+   Ambiguities are resolved by checking the token after ')'.
+   Array syntax is rejected if `brackets` is nil, otherwise `*brackets` is
+   set if an array type is parsed.
+*/
+fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok, bool* brackets) {
+    Token t2 = p.tok;
+    bool is_lower = false;
+    bool ambiguous = true;
+    for (;;) {
+        if (ahead) p.tokenizer.lookahead(ahead, &t2);
+        ahead++;
+        Kind kind = t2.kind;
+        if (kind == Kind.KW_const || kind == Kind.KW_volatile) {
+            // const and volatile qualifiers must introduce a type
+            ambiguous = false;
+            continue;
+        }
+        if (kind >= Kind.KW_bool && kind <= Kind.KW_void) {
+            // builtin type, non ambiguous
+            ambiguous = false;
+            break;
+        }
+        // must have an identifier or a member expression
+        // but still potentially ambiguous.
+        if (kind != Kind.Identifier)
+            return 0;
+        for (;;) {
+            // is_lower is true if the last identifier starts with a lowercase letter
+            is_lower = islower(p.pool.idx2str(t2.name_idx)[0]);
+            if (p.tokenizer.lookahead(ahead, nil) != Kind.Dot)
+                break;
+            ahead++;
+            if (p.tokenizer.lookahead(ahead, &t2) != Kind.Identifier)
+                return 0;
+            ahead++;
+        }
+        break;
+    }
+    i32 stars = 0;
+    while (1) {
+        switch (p.tokenizer.lookahead(ahead, nil)) {
+        case Star:
+            if (stars < 0) return 0;
+            if (stars > 0) ambiguous = false;
+            stars++;
+            ahead++;
+            break;
+        case RParen:
+            if (close_tok != Kind.RParen)
+                return 0;
+            ahead++;
+            if (!ambiguous) return ahead;
+            // disambiguate depending on the next token
+            switch (p.tokenizer.lookahead(ahead, nil)) {
+            case Identifier:
+            case IntegerLiteral:
+            case FloatLiteral:
+            case CharLiteral:
+            case StringLiteral:
+            case Tilde:
+            case Exclaim:
+            case KW_cast:
+            case KW_elemsof:
+            case KW_enum_min:
+            case KW_enum_max:
+            case KW_false:
+            case KW_true:
+            case KW_nil:
+            case KW_offsetof:
+            case KW_sizeof:
+            case KW_to_container:
+            case LBrace:
+                return ahead;
+            case PlusPlus:   // ambiguous: (x)++
+            case MinusMinus: // ambiguous: (x)--
+            case LParen:     // ambiguous: (func)(args)
+                // (A)(...) is a cast, (a)(...) is a function call
+                if (is_lower)
+                    return 0;
+                return ahead;
+            default:
+                break;
+            }
+            return 0;
+        case LSquare:
+            if (!brackets)
+                return 0;
+            *brackets = true;
+            // skip expression
+            ahead = p.skipArray(ahead);
+            if (!ahead)
+                return 0;
+            stars = -1; // no longer accept stars
+            break;
+        case Less:
+            // parametric type X<type>
+            ahead = p.parseAsCastType(ahead, Kind.Greater, nil);
+            if (!ahead)
+                return 0;
+            stars = 0;
+            break;
+        case Greater:
+            if (close_tok != Kind.Greater)
+                return 0;
+            ahead++;
+            return ahead;
+        default:
+            return 0;
+        }
+    }
+    // never reached
+    return 0;
+}

--- a/test/auto_args/template_function.c2t
+++ b/test/auto_args/template_function.c2t
@@ -6,7 +6,10 @@
 module test;
 
 fn X test1(const u32 line @(auto_line), X x) template X {
-    return cast<X>(x + line);
+    if (line)
+        return cast<X>(x + line);
+    else
+        return (X)(x + line);
 }
 
 public fn i32 main() {
@@ -19,12 +22,13 @@ int32_t main(void);
 
 static int32_t test_test1_0_(const uint32_t line, int32_t x)
 {
-   return ((int32_t)((x + line)));
+    if (line) return ((int32_t)((x + line)));
+    else return ((int32_t)((x + line)));
 }
 
 int32_t main(void)
 {
-   int32_t a = test_test1_0_(8, 20);
+   int32_t a = test_test1_0_(11, 20);
    return 0;
 }
 

--- a/test/c_generator/expr/cast_expr.c2t
+++ b/test/c_generator/expr/cast_expr.c2t
@@ -9,7 +9,15 @@ public fn i32 main(i32 argc, const char** argv) {
     i32 a = 10;
 
     i32 b = cast<i8>(20);
+    i32 b1 = (i8)(20);
+    i32 b2 = (i8)20;
+    i32 b3 = (i8)+20;
+    i32 b4 = (i8)-20;
     i32 c = cast<i8>(a);
+    i32 c1 = (i8)(a);
+    i32 c2 = (i8)a;
+    i32 c3 = (i8)+a;
+    i32 c4 = (i8)-a;
     return 0;
 }
 
@@ -19,7 +27,15 @@ int32_t main(int32_t argc, const char** argv)
 {
     int32_t a = 10;
     int32_t b = ((int8_t)(20));
+    int32_t b1 = ((int8_t)(20));
+    int32_t b2 = ((int8_t)20);
+    int32_t b3 = ((int8_t)+20);
+    int32_t b4 = ((int8_t)-20);
     int32_t c = ((int8_t)(a));
+    int32_t c1 = ((int8_t)(a));
+    int32_t c2 = ((int8_t)a);
+    int32_t c3 = ((int8_t)+a);
+    int32_t c4 = ((int8_t)-a);
     return 0;
 }
 

--- a/test/expr/binary/subtract_pointer_array.c2
+++ b/test/expr/binary/subtract_pointer_array.c2
@@ -5,5 +5,6 @@ fn void test1() {
     char[256] buffer;
     char* cp = buffer;
     u32 diff = cast<u32>(cp - buffer);
+    u32 diff1 = (u32)(cp - buffer);
 }
 

--- a/test/expr/binary/subtract_pointers.c2
+++ b/test/expr/binary/subtract_pointers.c2
@@ -5,5 +5,6 @@ fn void test1(const char* p1) {
     const char* p2 = p1;
     p2 += 10;
     u32 len = cast<u32>(p2 - p1);
+    u32 len1 = (u32)(p2 - p1);
 }
 

--- a/test/expr/explicit_cast/cast_constant.c2
+++ b/test/expr/explicit_cast/cast_constant.c2
@@ -6,12 +6,17 @@ type Number32 i32;
 
 fn void test1() {
     i32 a = cast<i8>(10);
+    i32 a1 = (i8)(10);
     i32 b = cast<i8>(200);
+    i32 b1 = (i8)(200);
     i32 c = cast<i32>(200);
+    i32 c1 = (i32)(200);
     i8  d = cast<i32>(200);     // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
+    i8  d1 = (i32)(200);     // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
 }
 
 fn void test2() {
     i8  e = cast<Number32>(200);   // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
+    i8  e1 = (Number32)(200);   // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
 }
 

--- a/test/expr/explicit_cast/cast_dest_nonscalar.c2
+++ b/test/expr/explicit_cast/cast_dest_nonscalar.c2
@@ -9,3 +9,7 @@ fn void test1() {
     i32 a = cast<Struct>(200);    // @error{used type 'test.Struct' where arithmetic or pointer type is required}
 }
 
+fn void test1a() {
+    i32 a1 = (Struct)(200);    // @error{used type 'test.Struct' where arithmetic or pointer type is required}
+}
+

--- a/test/expr/explicit_cast/cast_enum_to_various.c2
+++ b/test/expr/explicit_cast/cast_enum_to_various.c2
@@ -17,18 +17,26 @@ type Func fn void(Enum);
 
 fn void test1(Enum e) {
     bool a = cast<bool>(e);
+    bool a1 = (bool)(e);
     u8 b = cast<u8>(e);
+    u8 b1 = (u8)(e);
     u32 c = cast<u32>(e);
+    u32 c1 = (u32)(e);
     f32 d = cast<f32>(e);
+    f32 d1 = (f32)(e);
     u32* f = cast<u32*>(e);   // @error{invalid cast from 'test.Enum' to 'u32*'}
+    u32* f1 = (u32*)(e);   // @error{invalid cast from 'test.Enum' to 'u32*'}
 }
 
 fn void test2(Enum e) {
     Struct* g = cast<Struct*>(e);   // @error{invalid cast from 'test.Enum' to 'test.Struct*'}
+    Struct* g1 = (Struct*)(e);   // @error{invalid cast from 'test.Enum' to 'test.Struct*'}
 }
 
 fn void test3(Enum e) {
     EnumB h = cast<EnumB>(e);
+    EnumB h1 = (EnumB)(e);
     Func i = cast<Func>(e);         // @error{invalid cast from 'test.Enum' to 'Func'}
+    Func i1 = (Func)(e);         // @error{invalid cast from 'test.Enum' to 'Func'}
 }
 

--- a/test/expr/explicit_cast/cast_func_to_various.c2
+++ b/test/expr/explicit_cast/cast_func_to_various.c2
@@ -17,32 +17,41 @@ type FuncSame fn void(i32);
 
 fn void test1(Func arg) {
     bool a = cast<bool>(arg);
+    bool a1 = (bool)(arg);
 }
 
 fn void test2(Func arg) {
     u8 b = cast<u8>(arg);       // @error{pointers may only be cast to integer type 'u64'}
+    u8 b1 = (u8)(arg);       // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test3(Func arg) {
     u32 c = cast<u32>(arg);     // @error{pointers may only be cast to integer type 'u64'}
+    u32 c1 = (u32)(arg);     // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test4(Func arg) {
     f32 d = cast<f32>(arg);   // @error{pointers may only be cast to integer type 'u64'}
+    f32 d1 = (f32)(arg);   // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test5(Func arg) {
     u32* e = cast<u32*>(arg);
+    u32* e1 = (u32*)(arg);
 }
 
 fn void test6(Func arg) {
     u32 f = cast<u32>(arg);     // @error{pointers may only be cast to integer type 'u64'}
+    u32 f1 = (u32)(arg);     // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test7(Func arg) {
     u64 g = cast<u64>(arg);
+    u64 g1 = (u64)(arg);
     FuncOther k = cast<FuncOther>(arg);
+    FuncOther k1 = (FuncOther)(arg);
     FuncSame l = cast<FuncSame>(arg);
+    FuncSame l1 = (FuncSame)(arg);
     Enum j = cast<Enum>(arg);              // @error{invalid cast from 'Func' to 'test.Enum'}
+    Enum j1 = (Enum)(arg);              // @error{invalid cast from 'Func' to 'test.Enum'}
 }
-

--- a/test/expr/explicit_cast/cast_nonword_to_ptr.c2
+++ b/test/expr/explicit_cast/cast_nonword_to_ptr.c2
@@ -5,6 +5,7 @@ type Struct struct {
     i32 x;
 }
 Struct* s;
+Struct* s1;
 
 type Enum enum u32 {
     A, B
@@ -13,25 +14,30 @@ type Enum enum u32 {
 fn void test1() {
     u16 a = 0;
     s = cast<Struct*>(a);       // @error{only integers of type 'u64' may be cast to a pointer}
+    s1 = (Struct*)a;       // @error{only integers of type 'u64' may be cast to a pointer}
 }
 
 fn void test2() {
     // TODO this is allowed on 32-bit architectures
     u32 b = 0;
     s = cast<Struct*>(b);       // @error{only integers of type 'u64' may be cast to a pointer}
+    s1 = (Struct*)b;       // @error{only integers of type 'u64' may be cast to a pointer}
 }
 
 fn void test3() {
     u64 c = 0;
     s = cast<Struct*>(c);
+    s1 = (Struct*)c;
 }
 
 fn void test4() {
     Enum d = Enum.A;
     s = cast<Struct*>(d);       // @error{invalid cast from 'test.Enum' to 'test.Struct*'}
+    s1 = (Struct*)d;       // @error{invalid cast from 'test.Enum' to 'test.Struct*'}
 }
 
 fn void test5() {
     s = cast<Struct*>(test1);
+    s1 = (Struct*)test1;
 }
 

--- a/test/expr/explicit_cast/cast_ptr_to_nonword.c2
+++ b/test/expr/explicit_cast/cast_ptr_to_nonword.c2
@@ -11,14 +11,22 @@ type Enum enum u32 {
 
 fn void test1(Struct* s) {
     u64 a = cast<u64>(s);
+    u64 a1 = (u64)(s);
+    u64 a2 = (u64)s;
     u32 b = cast<u32>(s);     // @error{pointers may only be cast to integer type 'u64'}
+    u32 b1 = (u32)(s);     // @error{pointers may only be cast to integer type 'u64'}
+    u32 b2 = (u32)s;     // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test2(Struct* s) {
     bool c = cast<bool>(s);       // @error{pointers may only be cast to integer type 'u64'}
+    bool c1 = (bool)(s);       // @error{pointers may only be cast to integer type 'u64'}
+    bool c2 = (bool)s;       // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test3(Struct* s) {
     Enum d = cast<Enum>(s);       // @error{invalid cast from 'test.Struct*' to 'test.Enum'}
+    Enum d1 = (Enum)(s);       // @error{invalid cast from 'test.Struct*' to 'test.Enum'}
+    Enum d2 = (Enum)s;       // @error{invalid cast from 'test.Struct*' to 'test.Enum'}
 }
 

--- a/test/expr/explicit_cast/cast_trunc_constant.c2
+++ b/test/expr/explicit_cast/cast_trunc_constant.c2
@@ -3,7 +3,10 @@ module test;
 
 fn void test1() {
     i8  a = cast<i8>(256+1);   // turned into 1
+    i8  a1 = (i8)(256+1);   // turned into 1
     i16 b = cast<u16>(65536+1);  // turned into 1
+    i16 b1 = (u16)(65536+1);  // turned into 1
     i8  c = cast<u16>(65536+400);  // @error{constant value 400 out-of-bounds for type 'i8', range [-128, 127]}
+    i8  c1 = (u16)(65536+400);  // @error{constant value 400 out-of-bounds for type 'i8', range [-128, 127]}
 }
 

--- a/test/expr/explicit_cast/cast_unknown.c2
+++ b/test/expr/explicit_cast/cast_unknown.c2
@@ -3,20 +3,53 @@ module test;
 
 type Number i32;
 
-fn void test1() {
+fn void test0() {
     i32 a = 10;
 
     i32 b = cast<Number>(a);
+    i32 b1 = (Number)(a);
+    i32 b2 = (Number)a;
+}
 
+fn void test1() {
+    i32 a = 10;
     i32 c = cast<Foo>(a);         // @error{unknown type 'Foo'}
+}
+
+fn void test1a() {
+    i32 a = 10;
+    i32 c1 = (Foo)(a);            // @error{unknown type 'Foo'}
+}
+
+fn void test1b() {
+    i32 a = 10;
+    i32 c2 = (Foo)a;            // @error{unknown type 'Foo'}
 }
 
 fn void test2() {
     i32 d = cast<Number>(bar);    // @error{use of undeclared identifier 'bar'}
 }
 
+fn void test2a() {
+    i32 d1 = (Number)(bar);    // @error{use of undeclared identifier 'bar'}
+}
+
+fn void test2b() {
+    i32 d2 = (Number)bar;    // @error{use of undeclared identifier 'bar'}
+}
+
 fn void test3() {
     i32 e = cast<Bar>         // @error{unknown type 'Bar'}
         (faa);                  // @error{use of undeclared identifier 'faa'}
+}
+
+fn void test3a() {
+    i32 e1 = (Bar)         // @error{unknown type 'Bar'}
+        (faa);                  // @error{use of undeclared identifier 'faa'}
+}
+
+fn void test3b() {
+    i32 e2 = (Bar)         // @error{unknown type 'Bar'}
+        faa;                  // @error{use of undeclared identifier 'faa'}
 }
 

--- a/test/expr/explicit_cast/explicit_c_cast_array.c2
+++ b/test/expr/explicit_cast/explicit_c_cast_array.c2
@@ -1,0 +1,7 @@
+// @warnings{no-unused}
+module test;
+
+fn void test1a(i32 a) {
+    char[2] b1 = (char[2])(a);  // @error{array types are not allowed here}
+}
+

--- a/test/expr/explicit_cast/explicit_casts_builtin.c2
+++ b/test/expr/explicit_cast/explicit_casts_builtin.c2
@@ -17,23 +17,38 @@ fn void test1(i32 a) {
     void* b = cast<Struct>(a);  // @error{used type 'test.Struct' where arithmetic or pointer type is required}
 }
 
+fn void test1a(i32 a) {
+    void* b1 = (Struct)(a);  // @error{used type 'test.Struct' where arithmetic or pointer type is required}
+}
+
 fn void test2(i32 a) {
     Enum b = cast<Enum>(a);
+    Enum b1 = (Enum)(a);
 }
 
 fn void test3(i32 a) {
     Func b = cast<Func>(a); // @error{only integers of type 'u64' may be cast to a pointer}
 }
 
+fn void test3a(i32 a) {
+    Func b1 = (Func)(a); // @error{only integers of type 'u64' may be cast to a pointer}
+}
+
 fn void test4(u64 a) {
     Func b = cast<Func>(a);
+    Func b1 = (Func)(a);
 }
 
 fn void test5(i32 a) {
     i32 b = cast<Alias>(a);
+    i32 b1 = (Alias)(a);
 }
 
 fn void test6(i32 a) {
     i32 b = cast<test>(a); // @error{'test' is not a type}
+}
+
+fn void test6a(i32 a) {
+    i32 b1 = (test)a; // @error{'test' is not a type}
 }
 

--- a/test/expr/explicit_cast/explicit_casts_pointer.c2
+++ b/test/expr/explicit_cast/explicit_casts_pointer.c2
@@ -13,13 +13,16 @@ type Func fn void(i32);
 
 fn void test1(void* a) {
     u32 b = cast<u32>(a);  // @error{pointers may only be cast to integer type 'u64'}
+    u32 b1 = (u32)(a);  // @error{pointers may only be cast to integer type 'u64'}
 }
 
 fn void test2(void* a) {
     Enum* b = cast<Enum*>(a);
+    Enum* b1 = (Enum*)(a);
 }
 
 fn void test3(void* a) {
     Func b = cast<Func>(a);
+    Func b1 = (Func)(a);
 }
 

--- a/test/types/conversion/cast_convert.c2
+++ b/test/types/conversion/cast_convert.c2
@@ -3,5 +3,6 @@ module test;
 
 fn void test1(u32 a) {
     u16 line = cast<u32>(a); // @error{implicit conversion loses integer precision: 'u32' to 'u16'}
+    u16 line1 = (u32)(a); // @error{implicit conversion loses integer precision: 'u32' to 'u16'}
 }
 

--- a/test/types/enum/enum_unknown_func.c2
+++ b/test/types/enum/enum_unknown_func.c2
@@ -15,7 +15,10 @@ public fn const char* Kind.str(Kind k) {
 }
 
 public fn Kind Ref.getKind(const Ref* r) {
-    return cast<Kind>(r.kind);
+    if (r)
+        return cast<Kind>(r.kind);
+    else
+        return (Kind)r.kind;
 }
 
 fn void test1(Ref left) {


### PR DESCRIPTION
* add new type lookahead parser to analyse if a paren expression                                                                                                
  is potentially a cast or a compound literals                                                                                                                  
* extend `ExplicitCastExpr` to allow c-style variant                                                                                                            
* add `printLiteral` methods for `InitListExpr` and designated initializers                                                                                     
* add tests  