### PR TITLE
compiler: simplify unary operator parsing and analysis

### DIFF
--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -82,7 +82,7 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
             if (!ctv_analyser.checkRange(ma.diags, implType, &ctv, 0, initval)) return;
 
             if (i > 0 && ctv.is_less(&value)) {
-                value.decr(); // to get right number
+                value.decr(); // to get the previous value
                 ma.error(initval.getLoc(), "enum constants need to increase (value %s, previous %s)", ctv.str(), value.str());
                 return;
             }

--- a/analyser_utils/ctv_analyser.c2
+++ b/analyser_utils/ctv_analyser.c2
@@ -334,7 +334,8 @@ public fn bool check(diagnostics.Diags* diags, QualType qt, const Expr* e) {
 public fn bool checkRange(diagnostics.Diags* diags, QualType qt, Value* value, SrcLoc loc, const Expr* e) {
     QualType canon = qt.getCanonicalType();
     if (!canon.isBuiltin()) return true;  // TODO find out cases
-    if (e && !e.canOverflow()) return true;
+    // hack to accept `u32 x = ~1;`
+    if (e && e.isTilde()) return true;
 
     BuiltinType* bi = canon.getBuiltin();
     u32 width = bi.getWidth();

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -225,17 +225,16 @@ public fn bool Expr.isInitList(const Expr* e) {
     return e.getKind() == ExprKind.InitList;
 }
 
-public fn bool Expr.canOverflow(const Expr* e) {
+public fn bool Expr.isTilde(const Expr* e) {
     while (e.isParen()) {
         const ParenExpr* p = cast<ParenExpr*>(e);
         e = p.getInner();
     }
-
     if (e.getKind() == ExprKind.UnaryOperator) {
         const UnaryOperator* u = cast<UnaryOperator*>(e);
-        return u.canOverflow();
+        return (u.getOpcode() == UnaryOpcode.Not);
     }
-    return true;
+    return false;
 }
 
 public fn bool Expr.isBinaryOperator(const Expr* e) {

--- a/ast/unary_operator.c2
+++ b/ast/unary_operator.c2
@@ -50,7 +50,6 @@ static_assert(elemsof(UnaryOpcode), elemsof(unaryOpcode_names));
 type UnaryOperatorBits struct {
     u32 : NumExprBits;
     u32 kind : 4;
-    u32 can_overflow : 1;
 }
 
 public type UnaryOperator struct @(opaque) {
@@ -58,11 +57,10 @@ public type UnaryOperator struct @(opaque) {
     Expr* inner;
 }
 
-public fn UnaryOperator* UnaryOperator.create(ast_context.Context* c, SrcLoc loc, UnaryOpcode kind, bool can_overflow, Expr* inner) {
+public fn UnaryOperator* UnaryOperator.create(ast_context.Context* c, SrcLoc loc, UnaryOpcode kind, Expr* inner) {
     UnaryOperator* e = c.alloc(sizeof(UnaryOperator));
     e.base.init(ExprKind.UnaryOperator, loc, 0, 0, kind <= UnaryOpcode.PreDec, ValType.RValue);
     e.base.base.unaryOperatorBits.kind = kind;
-    e.base.base.unaryOperatorBits.can_overflow = can_overflow;
     e.inner = inner;
 #if AstStatistics
     Stats.addExpr(ExprKind.UnaryOperator, sizeof(UnaryOperator));
@@ -71,7 +69,7 @@ public fn UnaryOperator* UnaryOperator.create(ast_context.Context* c, SrcLoc loc
 }
 
 fn Expr* UnaryOperator.instantiate(UnaryOperator* e, Instantiator* inst) {
-    return cast<Expr*>(UnaryOperator.create(inst.c, e.base.loc, e.getOpcode(), e.canOverflow(), e.inner.instantiate(inst)));
+    return cast<Expr*>(UnaryOperator.create(inst.c, e.base.loc, e.getOpcode(), e.inner.instantiate(inst)));
 }
 
 public fn UnaryOpcode UnaryOperator.getOpcode(const UnaryOperator* e) {
@@ -80,8 +78,6 @@ public fn UnaryOpcode UnaryOperator.getOpcode(const UnaryOperator* e) {
 
 public fn Expr* UnaryOperator.getInner(const UnaryOperator* e) { return e.inner; }
 public fn Expr** UnaryOperator.getInner2(UnaryOperator* e) { return &e.inner; }
-
-fn bool UnaryOperator.canOverflow(const UnaryOperator* e) { return e.base.base.unaryOperatorBits.can_overflow; }
 
 //public fn Expr* UnaryOperator.asExpr(UnaryOperator* e) { return &e.base; }
 
@@ -118,7 +114,6 @@ public fn const char* UnaryOperator.getOpcodeStr(const UnaryOperator* e) {
 fn void UnaryOperator.print(const UnaryOperator* e, string_buffer.Buf* out, u32 indent) {
     e.base.printKind(out, indent);
     e.base.printTypeBits(out);
-    if (!e.base.base.unaryOperatorBits.can_overflow) out.add(" cannot-overflow");
     out.space();
     out.color(col_Value);
     out.add(unaryOpcode_names[e.getOpcode()]);

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -909,12 +909,8 @@ public fn Expr* Builder.actOnParenExpr(Builder* b, SrcLoc loc, u32 src_len, Expr
     return cast<Expr*>(ParenExpr.create(b.context, loc, src_len, inner));
 }
 
-public fn Expr* Builder.actOnUnaryOperator(Builder* b,
-                                           SrcLoc loc,
-                                           UnaryOpcode opcode,
-                                           bool can_overflow,
-                                           Expr* inner) {
-    return cast<Expr*>(UnaryOperator.create(b.context, loc, opcode, can_overflow, inner));
+public fn Expr* Builder.actOnUnaryOperator(Builder* b, SrcLoc loc, UnaryOpcode opcode, Expr* inner) {
+    return cast<Expr*>(UnaryOperator.create(b.context, loc, opcode, inner));
 }
 
 public fn Expr* Builder.actOnPostFixUnaryOperator(Builder* b,
@@ -923,7 +919,7 @@ public fn Expr* Builder.actOnPostFixUnaryOperator(Builder* b,
                                                   Expr* inner) {
     // can only be PlusPlus / MinusMinus
     UnaryOpcode opcode = is_increment ? UnaryOpcode.PostInc : UnaryOpcode.PostDec;
-    return cast<Expr*>(UnaryOperator.create(b.context, loc, opcode, false, inner));
+    return cast<Expr*>(UnaryOperator.create(b.context, loc, opcode, inner));
 }
 
 public fn Expr* Builder.actOnBinaryOperator(Builder* b,

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -196,18 +196,18 @@ const u8[128] CastExprTokenLookup = {
     [Kind.Minus] = 7,
     [Kind.Exclaim] = 7,
     [Kind.Amp] = 7,
+    [Kind.PlusPlus] = 7,
+    [Kind.MinusMinus] = 7,
     [Kind.KW_cast] = 8,
-    [Kind.PlusPlus] = 9,
-    [Kind.MinusMinus] = 9,
-    [Kind.KW_elemsof] = 10,
-    [Kind.KW_enum_min] = 11,
-    [Kind.KW_enum_max] = 11,
-    [Kind.KW_false] = 12,
-    [Kind.KW_true] = 12,
-    [Kind.KW_nil] = 13,
-    [Kind.KW_offsetof] = 14,
-    [Kind.KW_sizeof] = 15,
-    [Kind.KW_to_container] = 16,
+    [Kind.KW_elemsof] = 9,
+    [Kind.KW_enum_min] = 10,
+    [Kind.KW_enum_max] = 10,
+    [Kind.KW_false] = 11,
+    [Kind.KW_true] = 11,
+    [Kind.KW_nil] = 12,
+    [Kind.KW_offsetof] = 13,
+    [Kind.KW_sizeof] = 14,
+    [Kind.KW_to_container] = 15,
 }
 
 // Note: tried lookup table, was slower..
@@ -283,41 +283,34 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
     case 6: // LParen
         res = p.parseParenExpr();
         break;
-    case 7: // Star, Tilde, Plus, Minus, Exclaim, Amp
+    case 7: // Star, Tilde, Plus, Minus, Exclaim, Amp, PlusPlus, MinusMinus
         SrcLoc loc = p.tok.loc;
         p.consumeToken();
         bool is_addrof_op = (savedKind == Kind.Amp);
         res = p.parseCastExpr(false, is_addrof_op);
         UnaryOpcode opcode = convertTokenToUnaryOpcode(savedKind);
-        bool can_overflow = (savedKind == Kind.Minus);
-        return p.builder.actOnUnaryOperator(loc, opcode, can_overflow, res);
+        return p.builder.actOnUnaryOperator(loc, opcode, res);
     case 8: // KW_cast
         res = p.parseExplicitCastExpr();
         break;
-    case 9: // PlusPlus, MinusMinus
-        SrcLoc loc = p.tok.loc;
-        p.consumeToken();
-        res = p.parseCastExpr(false, false);
-        UnaryOpcode opcode = convertTokenToUnaryOpcode(savedKind);
-        return p.builder.actOnUnaryOperator(loc, opcode, false, res);
-    case 10: // KW_elemsof
+    case 9: // KW_elemsof
         res = p.parseElemsof();
-        break; // TODO not return?
-    case 11: // KW_enum_min, KW_enum_max
+        break;
+    case 10: // KW_enum_min, KW_enum_max
         return p.parseEnumMinMax(savedKind == Kind.KW_enum_min);
-    case 12: // KW_false, KW_true
+    case 11: // KW_false, KW_true
         res = p.builder.actOnBooleanConstant(p.tok.loc, savedKind == Kind.KW_true);
         p.consumeToken();
         break;
-    case 13: // KW_nil
+    case 12: // KW_nil
         res = p.builder.actOnNilExpr(p.tok.loc);
         p.consumeToken();
         break;
-    case 14: // KW_offsetof
+    case 13: // KW_offsetof
         return p.parseOffsetOfExpr();
-    case 15: // KW_sizeof
+    case 14: // KW_sizeof
         return p.parseSizeof();
-    case 16: // KW_to_container
+    case 15: // KW_to_container
         res = p.parseToContainerExpr();
         break;
     }

--- a/test/globals/types/alias_types.c2
+++ b/test/globals/types/alias_types.c2
@@ -1,6 +1,7 @@
 module test;
 
 Number n = 300; // @error{constant value 300 out-of-bounds for type '(alias)test.Number => u8', range [0, 255]}
+Number n1 = +300; // @error{constant value 300 out-of-bounds for type '(alias)test.Number => u8', range [0, 255]}
 type Number Range;
 type Range Long;
 type Long u8;

--- a/test/types/enum/enum_constant_outofbounds.c2
+++ b/test/types/enum/enum_constant_outofbounds.c2
@@ -3,6 +3,6 @@ module test;
 
 type A enum i8 {
     B = 127,
-    C = 200,        // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
+    C = +200,        // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
 }
 

--- a/test/types/partial/init_char_constlit.c2
+++ b/test/types/partial/init_char_constlit.c2
@@ -13,6 +13,7 @@ fn void test1() {
 fn void test2() {
     char d = -128;  // @error{constant value -128 out-of-bounds for type 'char', range [0, 255]}
     char e = 260;   // @error{constant value 260 out-of-bounds for type 'char', range [0, 255]}
-    char f = 127;
+    char f = +260;  // @error{constant value 260 out-of-bounds for type 'char', range [0, 255]}
+    char g = 127;
 }
 

--- a/test/types/partial/init_struct_array.c2
+++ b/test/types/partial/init_struct_array.c2
@@ -11,6 +11,7 @@ fn void test1() {
     Point[] p = {
         { 10, 20 },
         { 100, 200 },    // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
+        { 100, +200 },   // @error{constant value 200 out-of-bounds for type 'i8', range [-128, 127]}
         { 100, 100 + a}, // @error{constant value 150 out-of-bounds for type 'i8', range [-128, 127]}
     }
 }


### PR DESCRIPTION
* remove `canOverflow()`, only test for `~` operator in `checkRange()`
* factorize code in `Parser.parseCastExpr()`
* add tests