### PR TITLE
Compiler: simplifications, lvalue and ctc fixes

### DIFF
--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -33,9 +33,11 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
         // when doing char*  a = "abc" -> string is lvalue (so insert ArrayToPointerDecay)
         ArrayType* at = expectedType.getArrayTypeOrNil();
         if (at) {
-            // check that element type is char/int8
+            // check that element type is char/i8/u8
             QualType elem = at.getElemType();
-            if (elem.getTypeOrNil() != builtins[BuiltinKind.Char].getTypeOrNil() && elem.getTypeOrNil() != builtins[BuiltinKind.Int8].getTypeOrNil()) {
+            if (elem.getTypeOrNil() != builtins[BuiltinKind.Char].getTypeOrNil()
+            &&  elem.getTypeOrNil() != builtins[BuiltinKind.Int8].getTypeOrNil()
+            &&  elem.getTypeOrNil() != builtins[BuiltinKind.UInt8].getTypeOrNil()) {
                 ma.errorRange(assignLoc, e.getRange(), "cannot initialize array of '%s' with a string literal", elem.diagName());
                 return false;
             }

--- a/analyser/module_analyser_unaryop.c2
+++ b/analyser/module_analyser_unaryop.c2
@@ -98,6 +98,21 @@ fn QualType Analyser.analyseUnaryOperator(Analyser* ma, Expr** e_ptr, u32 side) 
         }
         t = ma.builder.actOnPointerType(canon);
         e.copyCtcFlags(inner);
+        if (inner.getKind() == ExprKind.ArraySubscript) {
+            // Fix &a[b] as ctc if a is ctc and b is ctv
+            // a[b] should be ctc in this case, but C does not accept it because of separate compilation
+            // TODO: handle constant 2D and 3D arrays
+            ArraySubscriptExpr* e1 = cast<ArraySubscriptExpr*>(inner);
+            if (e1.getBase().isCtc() && e1.getIndex().isCtv())
+                e.setCtc();
+        } else
+        if (inner.getKind() == ExprKind.UnaryOperator) {
+            // Fix &*a as ctc if a is ctc
+            // *a should be ctc in this case, but C does not accept it because of separate compilation
+            UnaryOperator* e1 = cast<UnaryOperator*>(inner);
+            if (e1.getOpcode() == UnaryOpcode.Deref)
+                e.copyCtcFlags(e1.getInner());
+        }
         break;
     case Deref:
         if (t.isPointer()) {
@@ -207,6 +222,11 @@ fn IdentifierKind getInnerExprAddressOf(Expr* e) {
     case BinaryOperator:
         break;
     case UnaryOperator:
+        UnaryOperator* e1 = cast<UnaryOperator*>(e);
+        if (e1.getOpcode() == UnaryOpcode.Deref) {
+            // TODO check for 2D or 3D arrays
+            return IdentifierKind.Var;  // &*e is OK
+        }
         break;
     case ConditionalOperator:
         break;
@@ -214,7 +234,12 @@ fn IdentifierKind getInnerExprAddressOf(Expr* e) {
         break;
     case ArraySubscript:
         ArraySubscriptExpr* a = cast<ArraySubscriptExpr*>(e);
-        return getInnerExprAddressOf(a.getBase());
+        // a[b] is an LValue if not an array itself and if b is not a BitOffset
+        // TODO: reject if a[b] is itself an array
+        Expr* index = a.getIndex();
+        if (index.getKind() != ExprKind.BitOffset)
+            return IdentifierKind.Var;
+        break;
     case Member:
         MemberExpr* m = cast<MemberExpr*>(e);
         return m.getKind();
@@ -225,9 +250,11 @@ fn IdentifierKind getInnerExprAddressOf(Expr* e) {
         return IdentifierKind.Unresolved;
     case ExplicitCast:
         ExplicitCastExpr* c = cast<ExplicitCastExpr*>(e);
+        // TODO: this seems incorrect, casts should not produce LValues
         return getInnerExprAddressOf(c.getInner());
     case ImplicitCast:
         ImplicitCastExpr* c = cast<ImplicitCastExpr*>(e);
+        // TODO: this seems incorrect, casts should not produce LValues
         return getInnerExprAddressOf(c.getInner());
     }
 

--- a/ast/array_subscript_expr.c2
+++ b/ast/array_subscript_expr.c2
@@ -25,7 +25,7 @@ type ArraySubscriptExprBits struct {
 }
 
 public type ArraySubscriptExpr struct @(opaque) {
-    // Note: loc is that of right bracket
+    // Note: loc is that of left bracket
     Expr base;
     Expr* lhs;
     Expr* idx;

--- a/ast/unary_operator.c2
+++ b/ast/unary_operator.c2
@@ -59,7 +59,8 @@ public type UnaryOperator struct @(opaque) {
 
 public fn UnaryOperator* UnaryOperator.create(ast_context.Context* c, SrcLoc loc, UnaryOpcode kind, Expr* inner) {
     UnaryOperator* e = c.alloc(sizeof(UnaryOperator));
-    e.base.init(ExprKind.UnaryOperator, loc, 0, 0, kind <= UnaryOpcode.PreDec, ValType.RValue);
+    e.base.init(ExprKind.UnaryOperator, loc, 0, 0, kind <= UnaryOpcode.PreDec,
+                kind == UnaryOpcode.Deref ? ValType.LValue : ValType.RValue);
     e.base.base.unaryOperatorBits.kind = kind;
     e.inner = inner;
 #if AstStatistics

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -913,15 +913,6 @@ public fn Expr* Builder.actOnUnaryOperator(Builder* b, SrcLoc loc, UnaryOpcode o
     return cast<Expr*>(UnaryOperator.create(b.context, loc, opcode, inner));
 }
 
-public fn Expr* Builder.actOnPostFixUnaryOperator(Builder* b,
-                                                  SrcLoc loc,
-                                                  bool is_increment,
-                                                  Expr* inner) {
-    // can only be PlusPlus / MinusMinus
-    UnaryOpcode opcode = is_increment ? UnaryOpcode.PostInc : UnaryOpcode.PostDec;
-    return cast<Expr*>(UnaryOperator.create(b.context, loc, opcode, inner));
-}
-
 public fn Expr* Builder.actOnBinaryOperator(Builder* b,
                                             SrcLoc loc,
                                             BinaryOpcode opcode,

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -332,11 +332,11 @@ fn Expr* Parser.parsePostfixExprSuffix(Parser* p, Expr* lhs, bool couldBeTemplat
             Expr* idx = p.parseExpr();
             if (p.tok.kind  == Kind.Colon) {
                 // BitOffset <expr> : <expr>
-                SrcLoc colLoc = p.tok.loc;
+                SrcLoc colon_loc = p.tok.loc;
                 p.consumeToken();
                 Expr* rhs = p.parseExpr();
-                // TODO need colLoc?
-                idx = p.builder.actOnBitOffsetExpr(colLoc, idx, rhs);
+                // TODO need colon_loc?
+                idx = p.builder.actOnBitOffsetExpr(colon_loc, idx, rhs);
             }
             u32 src_len = p.tok.loc + 1 - loc;
             p.expectAndConsume(Kind.RSquare);
@@ -346,8 +346,11 @@ fn Expr* Parser.parsePostfixExprSuffix(Parser* p, Expr* lhs, bool couldBeTemplat
             lhs = p.parseImpureMemberExpr(lhs);
             break;
         case PlusPlus:
+            lhs = p.builder.actOnUnaryOperator(p.tok.loc, UnaryOpcode.PostInc, lhs);
+            p.consumeToken();
+            break;
         case MinusMinus:
-            lhs = p.builder.actOnPostFixUnaryOperator(p.tok.loc, p.tok.kind == Kind.PlusPlus, lhs);
+            lhs = p.builder.actOnUnaryOperator(p.tok.loc, UnaryOpcode.PostDec, lhs);
             p.consumeToken();
             break;
         case Less:

--- a/test/init/addr_of_other.c2
+++ b/test/init/addr_of_other.c2
@@ -1,0 +1,83 @@
+// @warnings{no-unused}
+module test;
+
+i32[] a = { 1, 2, 3 }
+const i32 *a1 = a;
+const i32 *a2 = &a[0];
+const i32 *a3 = &*a;
+const i32 *a4 = &a[1];
+
+const i32[] B = { 4, 5, 6 }
+const i32 *b1 = B;
+const i32 *b2 = &B[0];
+const i32 *b3 = &*B;
+const i32 *b4 = &B[1];
+
+i32 c;
+const i32 *c1 = &c;
+
+const i32 D = 32;
+const i32 *d1 = &D;
+
+char[] p = "-";
+const char *p1 = "-";
+const char *p2 = &"-"[0];
+const char *p3 = &*"-";
+const char *p4 = &"-"[1];
+
+char[] q = "abc";
+const char *q1 = q;
+const char *q2 = &q[0];
+const char *q3 = &*q;
+const char *q4 = &q[1];
+
+u8[] r = "abc";
+const u8 *r1 = r;
+const u8 *r2 = &r[0];
+const u8 *r3 = &*r;
+const u8 *r4 = &r[1];
+
+i8[] t = "abc";
+const i8 *t1 = t;
+const i8 *t2 = &t[0];
+const i8 *t3 = &*t;
+const i8 *t4 = &t[1];
+
+public fn i32 main() {
+    assert(a1 == a);
+    assert(a2 == &a[0]);
+    assert(a3 == &*a);
+    assert(a4 == &a[1]);
+
+    assert(b1 == B);
+    assert(b2 == &B[0]);
+    assert(b3 == &*B);
+    assert(b4 == &B[1]);
+
+    assert(c1 == &c);
+
+    assert(d1 == &D);
+
+    assert(*p == '-');
+    assert(*p1 == '-');
+    assert(*p2 == '-');
+    assert(*p3 == '-');
+    assert(p4[-1] == '-');
+
+    assert(q1 == q);
+    assert(q2 == &q[0]);
+    assert(q3 == &*q);
+    assert(q4 == &q[1]);
+
+    assert(r1 == r);
+    assert(r2 == &r[0]);
+    assert(r3 == &*r);
+    assert(r4 == &r[1]);
+
+    assert(t1 == t);
+    assert(t2 == &t[0]);
+    assert(t3 == &*t);
+    assert(t4 == &t[1]);
+
+    return 0;
+}

--- a/test/types/char_array_string_init_ok.c2
+++ b/test/types/char_array_string_init_ok.c2
@@ -2,4 +2,5 @@
 module test;
 
 i8[] a = "hello";
-
+u8[] b = "world";
+char[] c = "!";


### PR DESCRIPTION
- remove `actOnPostfixUnaryOperator()`
- accept string initializers for `u8[]` and `i8[]`
- make `*expr` an LValue
- fix `&*a` and `&a[b]` ctc status