### PR TITLE
Analyser: fix scope stack and init_checkers' array

### DIFF
--- a/analyser/init_checker.c2
+++ b/analyser/init_checker.c2
@@ -32,19 +32,27 @@ public type Checker struct {
     u32 max;
 }
 
+#if 0
 // Note: checker itself is not malloc'ed
 public fn Checker Checker.create(u32 capacity) {
-    assert(capacity != 0);
     Checker c;
     c.count = 0;
     c.capacity = capacity;
     c.max = 0;
-    c.entries = stdlib.malloc(capacity * sizeof(InitEntry));
+    c.entries= nil;
+    if (capacity) {
+        c.entries = stdlib.malloc(capacity * sizeof(InitEntry));
+    }
     return c;
 }
+#endif
 
 public fn void Checker.free(Checker* c) {
     stdlib.free(c.entries);
+    c.entries = nil;
+    c.count = 0;
+    c.capacity = 0;
+    c.max = 0;
 }
 
 public fn void Checker.clear(Checker* c) {
@@ -58,10 +66,12 @@ public fn u32 Checker.getCount(const Checker* c) {
 
 public fn void Checker.add(Checker* c, u32 index, SrcLoc loc) {
     if (c.count >= c.capacity) {
-        c.capacity *= 2;
+        c.capacity = c.capacity ? c.capacity * 2 : 8;
         InitEntry* entries = stdlib.malloc(c.capacity * sizeof(InitEntry));
-        string.memcpy(entries, c.entries, c.count * sizeof(InitEntry));
-        stdlib.free(c.entries);
+        if (c.entries) {
+            string.memcpy(entries, c.entries, c.count * sizeof(InitEntry));
+            stdlib.free(c.entries);
+        }
         c.entries = entries;
     }
     InitEntry* entry = &c.entries[c.count];

--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -73,8 +73,8 @@ public type Analyser struct @(opaque) {
     FunctionDecl* curFunction; // set when analysing a function-body
     bool has_error;
 
-    init_checker.Checker[4] init_checkers;
     u32 check_idx;
+    init_checker.Checker[4] init_checkers;
 }
 
 public fn Analyser* create(diagnostics.Diags* diags,
@@ -93,15 +93,12 @@ public fn Analyser* create(diagnostics.Diags* diags,
     ma.allmodules = allmodules;
     ma.warnings = warnings;
     ma.labels.init(0);
-
-    for (u32 i=0; i<elemsof(ma.init_checkers); i++) {
-        ma.init_checkers[i] = init_checker.Checker.create(8);
-    }
+    /* zero initialization is OK for ma.init_checkers */
     return ma;
 }
 
 public fn void Analyser.free(Analyser* ma) {
-    for (u32 i=0; i<elemsof(ma.init_checkers); i++) {
+    for (u32 i = 0; i < elemsof(ma.init_checkers); i++) {
         ma.init_checkers[i].free();
     }
     ma.prefixes.free();  // Note: safe to be freed twice
@@ -158,16 +155,24 @@ public fn void Analyser.check(Analyser* ma, Module* mod) {
 }
 
 fn init_checker.Checker* Analyser.getInitChecker(Analyser* ma) {
-    assert(ma.check_idx != elemsof(ma.init_checkers));
-    init_checker.Checker* c = &ma.init_checkers[ma.check_idx++];
-    c.clear();
-    return c;
+    if (ma.check_idx >= elemsof(ma.init_checkers)) {
+        ma.check_idx++;
+        return stdlib.calloc(1, sizeof(init_checker.Checker));
+    } else {
+        init_checker.Checker* c = &ma.init_checkers[ma.check_idx++];
+        c.clear();
+        return c;
+    }
 }
 
-fn void Analyser.putInitChecker(Analyser* ma) {
+fn void Analyser.putInitChecker(Analyser* ma, init_checker.Checker* c) {
+    assert(ma.check_idx > 0);
     ma.check_idx--;
+    if (ma.check_idx >= elemsof(ma.init_checkers)) {
+        c.free();
+        stdlib.free(c);
+    }
 }
-
 
 fn void Analyser.collectTypeFunctions(Analyser* ma) {
     sf_list.List type_fn_decls = { }

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -98,7 +98,6 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             }
             if (v.hasAttrAutoLine() && !ref.isU32()) {  // check for 'u32'
                 ma.error(ref.getLoc(), "attribute 'auto_line' requires a parameter of type 'u32'");
-
             }
         }
 
@@ -127,8 +126,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
         const Ref* param_ref = ref.getUser();
         if (pd.isStructType()) {
             // Note: for struct/union it can only be a pointer to that Type.
-           is_non_static = ref.isPointerTo(prefixType.getIndex());
-
+            is_non_static = ref.isPointerTo(prefixType.getIndex());
         } else {    // enum type
             // Note: for unum types it can be the Type or a pointer to that type
             is_non_static = ((param_ref && param_ref.decl == prefix.decl) || ref.isPointerTo(prefixType.getIndex()));
@@ -169,7 +167,6 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             ma.error(rtype.getLoc(), "functions marked with '%s' cannot return a value",
                 fd.hasAttrConstructor() ? "constructor" : "destructor");
         }
-
         if (num_params || fd.isVariadic()) {
             ma.error(rtype.getLoc(), "functions marked with '%s' cannot have arguments",
                 fd.hasAttrConstructor() ? "constructor" : "destructor");
@@ -187,7 +184,6 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
         if (!fd.hasReturn()) {
             ma.error(rtype.getLoc(), "pure functions must return a value");
             return;
-
         }
         if (auto_arg_count) {
             VarDecl* v = params[first_auto_arg];

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -201,7 +201,7 @@ fn bool Analyser.analyseInitListArray(Analyser* ma, InitListExpr* ile, QualType 
 
         init_checker.Checker* checker = ma.getInitChecker();
         ok = ma.checkArrayDesignators(ile, &array_size, checker);
-        ma.putInitChecker();
+        ma.putInitChecker(checker);
 
         if (!at.hasSize()) at.setSize(cast<u32>(array_size));
 
@@ -335,7 +335,7 @@ fn bool Analyser.analyseInitListStruct(Analyser* ma, InitListExpr* ile, QualType
     if (haveDesignators) {
         init_checker.Checker* checker = ma.getInitChecker();
         bool ok = ma.checkFieldDesignators(ile, checker);
-        ma.putInitChecker();
+        ma.putInitChecker(checker);
         if (!ok) return false;
     }
 

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -222,7 +222,7 @@ fn void Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
     ma.scope.enter(scope.Decl);
 
     ma.analyseCondition(i.getCond2(), true);
-    if (ma.has_error) return;
+    if (ma.has_error) goto done;
 
     ma.scope.enter(scope.Decl);
     ma.analyseStmt(i.getThen(), true);
@@ -234,7 +234,7 @@ fn void Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
         ma.analyseStmt(else_, true);
         ma.scope.exit(ma.has_error);
     }
-
+done:
     ma.scope.exit(ma.has_error);
 }
 
@@ -245,23 +245,24 @@ fn void Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
     Stmt** init_ = f.getInit2();
     if (init_) {
         QualType ct = ma.analyseCondition(init_, false);
-        if (ct.isInvalid()) return;
+        if (ct.isInvalid()) goto done;
     }
 
     Expr** cond = f.getCond2();
     if (cond) {
         QualType qt = ma.analyseExpr(cond, true, RHS);
-        if (qt.isInvalid()) return;
+        if (qt.isInvalid()) goto done;
         ma.checker.check(builtins[BuiltinKind.Bool], qt, cond, (*cond).getLoc());
     }
 
     Expr** cont = f.getCont2();
     if (cont) {
         QualType qt = ma.analyseExpr(cont, true, RHS);
-        if (qt.isInvalid()) return;
+        if (qt.isInvalid()) goto done;
     }
 
     ma.analyseStmt(f.getBody(), true);
+done:
     ma.scope.exit(ma.has_error);
 }
 
@@ -269,11 +270,12 @@ fn void Analyser.analyseWhileStmt(Analyser* ma, Stmt* s) {
     WhileStmt* w = cast<WhileStmt*>(s);
     ma.scope.enter(scope.Decl);
     ma.analyseCondition(w.getCond2(), true);
-    if (ma.has_error) return;
+    if (ma.has_error) goto done;
 
     ma.scope.enter(scope.Break | scope.Continue | scope.Decl | scope.Control);
     ma.analyseStmt(w.getBody(), true);
     ma.scope.exit(ma.has_error);
+done:
     ma.scope.exit(ma.has_error);
 }
 

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -33,7 +33,10 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
     EnumTypeDecl* etd = nil;
     // TODO switch is not a condition, not a bool!
     QualType ct = ma.analyseExpr(sw.getCond2(), true, RHS);
-    if (ct.isInvalid()) return;
+    if (ct.isInvalid()) {
+        ma.scope.exit(ma.has_error);
+        return;
+    }
 
     bool isCharPtr = ct.isCharPointer();
 
@@ -52,6 +55,7 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
 
     if (numCases == 0) {
         ma.error(sw.getLoc(), "switch without cases or default");
+        ma.scope.exit(ma.has_error);
         return;
     }
 
@@ -66,35 +70,27 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
 
         u32 flags = scope.Decl | scope.Break;
         if (!is_last) flags |= scope.Fallthrough;
-        ma.scope.enter(flags);
 
         if (c.isDefault()) {
             if (defaultCase) {
-                ma.error(defaultCase.getLoc(), "multiple default labels");
-                ma.putInitChecker();
-                return;
-            }
-            defaultCase = c;
-
+                ma.error(c.getLoc(), "multiple default labels");
+                ok = false;
+            } else
             if (!is_last) {
                 ma.error(c.getLoc(), "default case must be last in switch");
-                ma.putInitChecker();
-                return;
+                ok = false;
             }
+            defaultCase = c;
         }
 
+        ma.scope.enter(flags);
         ok &= ma.analyseCase(c, checker, etd, is_string);
         ma.scope.exit(ma.has_error);
     }
 
-    if (!ok) {
-        ma.putInitChecker();
-        return;
-    }
-
     ma.scope.exit(ma.has_error);
 
-    if (etd) {
+    if (ok && etd) {
         const u32 numConstants = etd.getNumConstants();
 
         if (defaultCase) {
@@ -127,7 +123,7 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
         }
     }
 
-    ma.putInitChecker();
+    ma.putInitChecker(checker);
 }
 
 fn bool Analyser.analyseCase(Analyser* ma,

--- a/test/stmt/switch/switch_multiple_defaults.c2
+++ b/test/stmt/switch/switch_multiple_defaults.c2
@@ -5,7 +5,7 @@ fn void test1() {
     switch (10) {
     default:    // @error{default case must be last in switch}
         break;
-    default:
+    default:    // @error{multiple default labels}
         break;
     }
 }

--- a/test/stmt/switch/switch_nested.c2
+++ b/test/stmt/switch/switch_nested.c2
@@ -1,0 +1,26 @@
+module test;
+
+public fn i32 main() {
+    i32 a = 1;
+    switch (a) {
+    default:
+        switch (a) {
+        default:
+            switch (a) {
+            default:
+                switch (a) {
+                default:
+                    switch (a) {
+                    default:
+                        break;
+                    }
+                    break;
+                }
+                break;
+            }
+            break;
+        }
+        break;
+    }
+    return 0;
+}

--- a/test/stmt/switch/switch_str_multiple_defaults.c2
+++ b/test/stmt/switch/switch_str_multiple_defaults.c2
@@ -4,7 +4,7 @@ module test;
 fn void test1() {
     switch ("text") {
     default:    // @error{default case must be last in switch}
-    default:
+    default:    // @error{multiple default labels}
     }
 }
 


### PR DESCRIPTION
* fix some missing `ma.scope.exit()` calls
* fix missing duplicate default/default not at the end errors
* add more sanity checks in `init_checkers`, allow empty start
* allocate extra `init_check.Checker` objects if needed (eg: more than 4 nested switch statements)