### PR TITLE
Analyser: improve vector types consistency

### DIFF
--- a/analyser/label_vector.c2
+++ b/analyser/label_vector.c2
@@ -29,67 +29,60 @@ public type Label struct {
     ast.LabelStmt* stmt;
 }
 
-public type Vector struct {
-    Label* labels;
+public type LabelVector struct {
+    Label* data;
     u32 count;
     u32 capacity;
 }
 
-public fn void Vector.init(Vector* v, u32 capacity) {
-    v.labels = nil;
+public fn void LabelVector.init(LabelVector* v, u32 capacity) @(unused) {
+    v.data = nil;
     v.count = 0;
-    v.capacity = capacity / 2; // workaround resize
+    v.capacity = capacity;
+    if (capacity) v.data = stdlib.malloc(capacity * sizeof(Label));
 }
 
-public fn void Vector.free(Vector* v) {
-    if (v.labels) stdlib.free(v.labels);
+public fn void LabelVector.free(LabelVector* v) {
+    if (v.data) stdlib.free(v.data);
     v.count = 0;
     v.capacity = 0;
-    v.labels = nil;
+    v.data = nil;
 }
 
-public fn void Vector.reset(Vector* v) {
+public fn void LabelVector.reset(LabelVector* v) {
     v.count = 0;
 }
 
-fn void Vector.resize(Vector* v) {
+fn void LabelVector.resize(LabelVector* v) {
     v.capacity = v.capacity == 0 ? 4 : v.capacity * 2;
     void* data2 = stdlib.malloc(v.capacity * sizeof(Label));
-    if (v.labels) {
-        string.memcpy(data2, v.labels, v.count * sizeof(Label));
-        stdlib.free(v.labels);
+    if (v.data) {
+        string.memcpy(data2, v.data, v.count * sizeof(Label));
+        stdlib.free(v.data);
     }
-    v.labels = data2;
+    v.data = data2;
 }
 
-public fn Label* Vector.add(Vector* v, u32 name_idx, SrcLoc loc, bool is_label) {
-    Label* l = v.find(name_idx);
-    if (!l) {
-        if (v.count == v.capacity) v.resize();
+public fn u32 LabelVector.add(LabelVector* v, Label label) {
+    if (v.count == v.capacity) v.resize();
 
-        u32 index = v.count;
-        l = &v.labels[index];
-        l.name_idx = name_idx;
-        l.loc = loc;
-        l.is_label = is_label;
-        l.used = !is_label;
-        l.stmt = nil;
-        v.count++;
-    }
-    return l;
+    u32 index = v.count;
+    v.data[index] = label;
+    v.count++;
+    return index;
 }
 
-public fn u32 Vector.getCount(const Vector* v) {
+public fn u32 LabelVector.getCount(const LabelVector* v) {
     return v.count;
 }
 
-public fn const Label* Vector.getLabels(const Vector* v) {
-    return v.labels;
+public fn const Label* LabelVector.getLabels(const LabelVector* v) {
+    return v.data;
 }
 
-public fn Label* Vector.find(Vector* v, u32 name_idx) {
+public fn Label* LabelVector.find(LabelVector* v, u32 name_idx) {
     for (u32 i=0; i<v.count; i++) {
-        if (v.labels[i].name_idx == name_idx) return &v.labels[i];
+        if (v.data[i].name_idx == name_idx) return &v.data[i];
     }
     return nil;
 }

--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -24,8 +24,8 @@ import conversion_checker as conv;
 import diagnostics;
 import init_checker;
 import module_list;
-import label_vector;
-import name_vector;
+import label_vector local;
+import name_vector local;
 import src_loc local;
 import scope;
 import string_pool;
@@ -57,12 +57,12 @@ public type Analyser struct @(opaque) {
     // collect type-functions
     u32 prefix_cache_name;
     u32 prefix_cache_idx;
-    name_vector.NameVector prefixes;
+    NameVector prefixes;
     sf_list.List* type_fn_decls;   // only set during TypeFunction collection (nil otherwise)
 
     ia_list.List* incr_values;   // only set during incremental-array value collection
 
-    label_vector.Vector labels;
+    LabelVector labels;
 
     // Type + Vars analysis
     StackLayer[MaxDepth] checkStack;
@@ -92,8 +92,7 @@ public fn Analyser* create(diagnostics.Diags* diags,
     ma.builder = builder;
     ma.allmodules = allmodules;
     ma.warnings = warnings;
-    ma.labels.init(0);
-
+    /* zero initialization is OK for ma.labels */
     for (u32 i=0; i<elemsof(ma.init_checkers); i++) {
         ma.init_checkers[i] = init_checker.Checker.create(8);
     }

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -152,12 +152,13 @@ fn void Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {
             ma.note(label.loc, "previous definition is here");
         } else {
             label.is_label = true;
+            label.stmt = ls;
             ls.setUsed();
         }
     } else {
-        label = ma.labels.add(name, ls.getLoc(), true);
+        Label lab = { .name_idx = name, .loc = ls.getLoc(), .is_label = true, .used = false, .stmt = ls }
+        ma.labels.add(lab);
     }
-    label.stmt = ls;
 
     Stmt* lss = ls.getStmt();
     if (lss) ma.analyseStmt(lss, true);
@@ -172,7 +173,8 @@ fn void Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {
         label.used = true;
         if (label.stmt) label.stmt.setUsed();
     } else {
-        ma.labels.add(name, gs.getLoc(), false);
+        Label lab = { .name_idx = name, .loc = gs.getLoc(), .is_label = false, .used = true, .stmt = nil }
+        ma.labels.add(lab);
     }
 }
 

--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -17,7 +17,7 @@ module module_analyser;
 
 import ast local;
 import ctv_analyser;
-import name_vector;
+import name_vector local;
 import size_analyser;
 
 fn void Analyser.analyseStructType(Analyser* ma, StructTypeDecl* d) {
@@ -26,10 +26,10 @@ fn void Analyser.analyseStructType(Analyser* ma, StructTypeDecl* d) {
         ma.usedPublic = false;
     }
 
-    name_vector.NameVector names;
+    NameVector names;
     names.init(d.getNumMembers());
 
-    name_vector.NameVector locs;
+    NameVector locs;
     locs.init(d.getNumMembers());
 
     ma.analyseStructNames(d, &names, &locs);
@@ -116,7 +116,7 @@ fn void Analyser.analyseStructMember(Analyser* ma, VarDecl* v) {
     // TODO check initValue
 }
 
-fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, name_vector.NameVector* names, name_vector.NameVector* locs) {
+fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, NameVector* names, NameVector* locs) {
     // note: already checked that struct doesn't have 0 members
     u32 count = d.getNumMembers();
     Decl** members = d.getMembers();
@@ -145,9 +145,9 @@ fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, name_vector
             locs.add(member.getLoc());
 
             if (member.isStructType()) {
-                name_vector.NameVector sub_names;
+                NameVector sub_names;
                 sub_names.init(sub.getNumMembers());
-                name_vector.NameVector sub_locs;
+                NameVector sub_locs;
                 sub_locs.init(sub.getNumMembers());
                 ma.analyseStructNames(sub, &sub_names, &sub_locs);
                 sub_names.free();

--- a/analyser/name_vector.c2
+++ b/analyser/name_vector.c2
@@ -24,11 +24,11 @@ public type NameVector struct {
     u32 capacity;
 }
 
-public fn void NameVector.init(NameVector* v, u32 capacity) {
+public fn void NameVector.init(NameVector* v, u32 capacity) @(unused) {
     v.data = nil;
     v.count = 0;
-    v.capacity = capacity / 2; // workaround resize
-    v.resize();
+    v.capacity = capacity;
+    if (capacity) v.data = stdlib.malloc(capacity * sizeof(u32));
 }
 
 public fn void NameVector.free(NameVector* v) {


### PR DESCRIPTION
* rename `label_vector.Vector` as `LabelVector` and import locally
* pass `Label` object to `LabelVector.add`
* import `name_vector` locally
* make `init()` method optional for `LabelVector` and `NameVector`, zero initialization OK
* fix *work around `resize()`* bug: odd init sizes caused reallocation