### PR TITLE
Compiler: fix initialization bugs and template function instantiation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ msan:
 ubsan:
 	@$(MAKE) -B -C bootstrap UBSAN=1  2>&1 | sed s/\\.\\.\\///
 
+debug:
+	@$(MAKE) -B -C bootstrap DEBUG=1  2>&1 | sed s/\\.\\.\\///
+
 output/tester/tester: tools/tester/*.c2 $(C2C)
 	@$(C2C) tester
 
@@ -38,6 +41,9 @@ rebuild-bootstrap: $(C2C)
 
 test: output/tester/tester
 	@output/tester/tester -t test
+
+testv: output/tester/tester
+	@output/tester/tester -v test
 
 errors:
 	@( grep -n 'error:' `find . -name build.log` | sed -E 's/build.log:[0-9]+://' ; true )

--- a/analyser/module_analyser_builtin.c2
+++ b/analyser/module_analyser_builtin.c2
@@ -65,6 +65,10 @@ fn QualType Analyser.analyseSizeof(Analyser* ma, BuiltinExpr* e) {
             if (std.isOpaque()) {
                 const Decl* d = cast<Decl*>(std);
                 bool is_external = ma.mod != d.getModule();
+                if (ma.curFunction && ma.curFunction.getInstanceModule() == d.getModule()) {
+                    // type is local in instantiation module
+                    is_external = false;
+                }
                 if (is_external) {
                     ma.error(inner.getLoc(), "opaque type '%s' used by value", qt.diagName());
                 }

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -369,6 +369,7 @@ fn FunctionDecl* Analyser.instantiateTemplateFunction(Analyser* ma, CallExpr* ca
             .c = ma.context,
             .ref = template_arg,
             .template_name = fd.getTemplateNameIdx(),
+            .instance_ast_idx = call.getInstanceASTIdx(),
             .used_opaque = used_opaque,
             .arg = ma,
             .on_error = Analyser.opaque_callback,

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -192,6 +192,10 @@ fn QualType Analyser.analyseTypeRef(Analyser* ma, TypeRef* ref) {
         if (std.isOpaque()) {
             const Decl* d = cast<Decl*>(std);
             bool is_external = ma.mod != d.getModule();
+            if (ma.curFunction && ma.curFunction.getInstanceModule() == d.getModule()) {
+                // type is local in instantiation module
+                is_external = false;
+            }
             if (is_external) {
                 ma.error(ref.getLoc(), "opaque type '%s' used by value", resolved.diagName());
             } else if (ma.usedPublic) {

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -28,14 +28,14 @@ type CallExprBits struct {
     u32 printf_format : 4;  // 1-based, 0 means no printf-format
     u32 change_format : 1;   // if c-generator needs to re-write format
     u32 has_auto_args : 1;   // if c-generator needs to insert extra arguments (file, line)
+    u32 num_args : 8;
 }
 
 public type CallExpr struct @(opaque) {
     Expr base;
     SrcLoc endLoc;
     u16 template_idx;   // instance number
-    u8 num_args;
-    // Note: 1 byte padding here
+    u16 instance_ast_idx; // for template function calls
     Expr* func;
     Expr*[0] args; // tail-allocated
     //TypeRef template_arg; // tail-allocated, variable size
@@ -51,9 +51,10 @@ public fn CallExpr* CallExpr.create(ast_context.Context* c,
     u32 size = sizeof(CallExpr) + num_args * sizeof(Expr*);
     CallExpr* e = c.alloc(size);
     e.base.init(ExprKind.Call, loc, 0, 0, 1, ValType.RValue);
+    e.base.base.callExprBits.num_args = cast<u8>(num_args);
     e.endLoc = endLoc;
     e.template_idx = 0;
-    e.num_args = cast<u8>(num_args);
+    e.instance_ast_idx = 0;
     e.func = func;
     string.memcpy(e.args, args, num_args * sizeof(Expr*));
 #if AstStatistics
@@ -68,6 +69,7 @@ public fn CallExpr* CallExpr.createTemplate(ast_context.Context* c,
                                               Expr* func,
                                               Expr** args,
                                               u32 num_args,
+                                              u32 ast_idx,
                                               const TypeRefHolder* ref)
 {
     u32 size = sizeof(CallExpr) + num_args * sizeof(Expr*);
@@ -75,9 +77,10 @@ public fn CallExpr* CallExpr.createTemplate(ast_context.Context* c,
     CallExpr* e = c.alloc(size);
     e.base.init(ExprKind.Call, loc, 0, 0, 1, ValType.RValue);
     e.base.base.callExprBits.is_template_call = 1;
+    e.base.base.callExprBits.num_args = cast<u8>(num_args);
     e.endLoc = endLoc;
     e.template_idx = 0;
-    e.num_args = cast<u8>(num_args);
+    e.instance_ast_idx = cast<u16>(ast_idx);
     e.func = func;
     string.memcpy(e.args, args, num_args * sizeof(Expr*));
     TypeRef* destRef = cast<TypeRef*>(&e.args[num_args]);
@@ -90,13 +93,15 @@ public fn CallExpr* CallExpr.createTemplate(ast_context.Context* c,
 
 fn Expr* CallExpr.instantiate(CallExpr* e, Instantiator* inst) {
     assert(!e.isTemplateCall());
-    u32 size = sizeof(CallExpr) + e.num_args * sizeof(Expr*);
+    u32 num_args = e.base.base.callExprBits.num_args;
+    u32 size = sizeof(CallExpr) + num_args * sizeof(Expr*);
     CallExpr* e2 = inst.c.alloc(size);
     e2.base = e.base;
     e2.endLoc = e.endLoc;
-    e2.num_args = e.num_args;
+    e2.template_idx = 0;
+    e2.instance_ast_idx = e.instance_ast_idx;
     e2.func = e.func.instantiate(inst);
-    for (u32 i=0; i<e.num_args; i++) {
+    for (u32 i = 0; i < num_args; i++) {
         e2.args[i] = e.args[i].instantiate(inst);
     }
 #if AstStatistics
@@ -126,7 +131,7 @@ public fn bool CallExpr.isTemplateCall(const CallExpr* e) {
 }
 
 public fn TypeRef* CallExpr.getTemplateArg(const CallExpr* e) {
-    if (e.isTemplateCall()) return cast<TypeRef*>(&e.args[e.num_args]);
+    if (e.isTemplateCall()) return cast<TypeRef*>(&e.args[e.base.base.callExprBits.num_args]);
     return nil;
 }
 
@@ -136,6 +141,10 @@ public fn void CallExpr.setTemplateIdx(CallExpr* e, u32 idx) {
 
 public fn u32 CallExpr.getTemplateIdx(const CallExpr* e) {
     return e.template_idx;
+}
+
+public fn u16 CallExpr.getInstanceASTIdx(const CallExpr* e) {
+    return e.instance_ast_idx;
 }
 
 // note: both idx are 0-based
@@ -175,7 +184,7 @@ public fn Expr* CallExpr.getFunc(const CallExpr* e) { return e.func; }
 public fn Expr** CallExpr.getFunc2(CallExpr* e) { return &e.func; }
 
 public fn u32 CallExpr.getNumArgs(const CallExpr* e) {
-    return e.num_args;
+    return e.base.base.callExprBits.num_args;
 }
 
 public fn Expr** CallExpr.getArgs(CallExpr* e) {
@@ -206,7 +215,7 @@ fn void CallExpr.print(const CallExpr* e, string_buffer.Buf* out, u32 indent) {
         out.indent(indent + 1);
         out.color(col_Template);
         out.add("template ");
-        TypeRef* ref = cast<TypeRef*>(&e.args[e.num_args]);
+        TypeRef* ref = cast<TypeRef*>(&e.args[e.base.base.callExprBits.num_args]);
         ref.print(out, true);
         out.newline();
     }

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -46,6 +46,7 @@ type FunctionDeclBits struct {
 }
 
 type FunctionDeclFlags struct {
+    u16 instance_ast_idx : 16;  // template function instances only
     u32 num_auto_args : 4;
     u32 attr_unused_params : 1;
     u32 attr_noreturn : 1;
@@ -182,14 +183,15 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
     fd2.base.qt = QualType.init(ftype.asType());
 
     fd2.body = fd.body.instantiate(inst);
-    fd2.rt= QualType_Invalid;
+    fd2.rt = QualType_Invalid;
     fd2.num_params = fd.num_params;
     fd2.attr_printf_arg = fd.attr_printf_arg;
     fd2.instance_idx = 0;
     fd2.template_name = 0;
     fd2.template_loc = fd.template_loc;
     fd2.flagBits = fd.flagBits;
-
+    fd2.flags.instance_ast_idx = cast<u16>(inst.instance_ast_idx);
+    fd2.prefix = fd.prefix;
     fd2.rtype.instantiate(&fd.rtype, inst);
 
     VarDecl** src = cast<VarDecl**>(fd.rtype.getPointerAfter());
@@ -271,6 +273,11 @@ public fn u16 FunctionDecl.getTemplateInstanceIdx(const FunctionDecl* d) {
 
 public fn void FunctionDecl.setInstanceName(FunctionDecl* d, u32 name_idx) {
     d.base.name_idx = name_idx;
+}
+
+public fn Module* FunctionDecl.getInstanceModule(FunctionDecl* d) {
+    if (d.flags.instance_ast_idx) return idx2ast(d.flags.instance_ast_idx).getMod();
+    return nil;
 }
 
 public fn Ref* FunctionDecl.getPrefix(FunctionDecl* d) {

--- a/ast/init_list_expr.c2
+++ b/ast/init_list_expr.c2
@@ -53,6 +53,7 @@ fn Expr* InitListExpr.instantiate(InitListExpr* e, Instantiator* inst) {
     u32 size = sizeof(InitListExpr) + num_values * sizeof(Expr*);
     InitListExpr* e2 = inst.c.alloc(size);
     e2.base = e.base;
+    e2.num_values = num_values;
     e2.endLoc = e.endLoc;
     for (u32 i=0; i<num_values; i++) {
         e2.values[i] = e.values[i].instantiate(inst);

--- a/ast/instantiator.c2
+++ b/ast/instantiator.c2
@@ -24,7 +24,7 @@ public type Instantiator struct {
     ast_context.Context* c;
     const TypeRef* ref;
     u32 template_name;
-
+    u16 instance_ast_idx;
     // for opaque checking
     bool used_opaque;
     void* arg;

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -186,13 +186,16 @@ fn void TypeRef.instantiate(TypeRef* r, const TypeRef* r1, Instantiator* inst) {
         // Note: keep the srcloc intact
         // TODO enforce no prefix in template functions
         r.flagBits = r2.flagBits;
+        r.dest = r2.dest;
         if (r2.flags.is_user) {
             r.refs[0].name_idx = r2.refs[0].name_idx;
-            r.refs[0].loc = r1.refs[0].loc;
+            r.refs[0].loc = r1.refs[0].loc;     // location from instance?
+            r.refs[0].decl = r2.refs[0].decl;
             if (r2.flags.has_prefix) {
                 r.refs[1].name_idx = r2.refs[1].name_idx;
+                r.refs[1].loc = r2.refs[1].loc;
+                r.refs[1].decl = r2.refs[1].decl;
             }
-            r.refs[0].decl = r2.refs[0].decl;
         }
         r.flags.is_const |= r1.flags.is_const;
         r.flags.is_volatile |= r1.flags.is_volatile;

--- a/ast_utils/context.c2
+++ b/ast_utils/context.c2
@@ -17,6 +17,9 @@ module ast_context;
 
 import stdlib local;
 import stdio;
+#if __ASAN__ || __MSAN__ || __UBSAN__
+import string local;
+#endif
 
 type Block struct {
     u8* data;
@@ -27,6 +30,9 @@ type Block struct {
 fn Block* Block.create(u32 blk_size) {
     Block* b = malloc(sizeof(Block));
     b.data = malloc(blk_size);
+#if __ASAN__ || __MSAN__ || __UBSAN__
+    memset(b.data, 0xFD, blk_size);
+#endif
     b.size = 0;
     b.next = nil;
     return b;

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -54,6 +54,12 @@ MSG+= ubsan
 C2FLAGS+= --ubsan
 endif
 
+ifdef DEBUG
+MSG+= debug
+# should be --debug
+C2FLAGS+= --fast
+endif
+
 all: ../output/c2c/c2c
 
 ../output/bootstrap/bootstrap: $(BOOTSTRAP_FILE)
@@ -64,8 +70,9 @@ all: ../output/c2c/c2c
 ../output/c2c/c2c: ../output/bootstrap/bootstrap
 		@echo "---- running (bootstrapped$(MSG)) c2c ----"
 		@../output/bootstrap/bootstrap c2c $(C2FLAGS) --fast --noplugins
+		@mv ../output/c2c/c2c ../output/bootstrap/c2c
 		@echo "---- running c2c (no plugins$(MSG)) ----"
-		@../output/c2c/c2c $(C2FLAGS) --noplugins --fast
+		@../output/bootstrap/c2c $(C2FLAGS) --noplugins --fast
 		@(cd .. && ./install_plugins.sh )
 		@echo "---- running c2c (optimized with plugins$(MSG)) ----"
 		@../output/c2c/c2c $(C2FLAGS)

--- a/common/diagnostics.c2
+++ b/common/diagnostics.c2
@@ -152,6 +152,11 @@ fn void Diags.internal(Diags* diags,
     out.clear();
 
     source_mgr.Location loc = diags.sm.getLocation(sloc);
+    if (sloc && !loc.line_start) {
+        out.print("<invalid location %d>: ", sloc);
+        sloc = 0;
+    }
+
     if (sloc) {
         if (diags.path_info.hasSubdir() && loc.filename[0] != '/') {
             out.add(diags.path_info.root2orig);
@@ -173,7 +178,6 @@ fn void Diags.internal(Diags* diags,
         // then a second line with ~~~~~^~~~~ pointing to the error location
         // and the region if any.
         // if the source line is long, an initial part is skipped (`skip` bytes)
-        assert(loc.line_start);
         const char *text = loc.line_start;  // pointer to the source code line
         u32 loc_col = loc.column;       // column number for the error
         u32 range_start_col = loc_col;  // column number for start of the ~~~ area

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -399,7 +399,7 @@ fn File* SourceMgr.find_file(SourceMgr* sm, SrcLoc loc) {
         }
     }
     u32 right = sm.num_files;
-    while (left != right) {
+    while (left < right) {
         u32 middle = (left + right) / 2;
         File* f = &sm.files[middle];
         if (loc < f.offset) {
@@ -407,7 +407,7 @@ fn File* SourceMgr.find_file(SourceMgr* sm, SrcLoc loc) {
             continue;
         }
         if (loc > f.offset + f.size()) {
-            left = middle;
+            left = middle + 1;
             continue;
         }
         sm.checkOpen(cast<i32>(middle)); // map will be needed, so check if file is really open
@@ -438,6 +438,7 @@ fn Location SourceMgr.locate(SourceMgr* sm, SrcLoc loc) {
     if (f) {
         //f.showCheckpoints();
         l.filename = sm.pool.idx2str(f.filename);
+        assert(loc >= f.offset);
         u32 offset = loc - f.offset;
         u32 last_offset = 0;
         const char* data = f.data();

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -983,7 +983,7 @@ public fn Expr* Builder.actOnTemplateCallExpr(Builder* b,
                                               Expr** args,
                                               u32 num_args,
                                               const TypeRefHolder* ref) {
-    return cast<Expr*>(CallExpr.createTemplate(b.context, loc, endLoc, func, args, num_args, ref));
+    return cast<Expr*>(CallExpr.createTemplate(b.context, loc, endLoc, func, args, num_args, b.ast_idx, ref));
 }
 
 public fn Expr* Builder.actOnExplicitCast(Builder* b,

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -362,7 +362,11 @@ fn Expr* Parser.parsePostfixExprSuffix(Parser* p, Expr* lhs, bool couldBeTemplat
                 p.parseTypeSpecifier(&ref, false, false);
 
                 p.expectAndConsume(Kind.Greater);
+                if (p.tok.kind != Kind.LParen) {
+                    p.error("missing argument list for template function call");
+                }
                 lhs = p.parseTemplateCallExpr(lhs, &ref);
+                break;
             }
             return lhs;
         default:


### PR DESCRIPTION
Template function call instantiation:
* fix template function parsing: detect missing argument list, allow call chaining.
* add `instance_ast_idx` in `CallExpr` nodes
* add `instance_ast_idx` in `FunctionDecl` so instantiated template functions have references to both the template and the instantiator module
* add `FunctionDecl.getInstanceModule()` method
* properly detect and accept use of non public or opaque types in template function instances

Other bug fixes:
* add debug target to compile with optimisations disabled
* keep phase 2 bootstrapped executable for debugging
* optionally initialize Context arena block for debugging
* fix bug in `SourceMgr.find_file` causing infinite loop for invalid loc
* detect and report invalid loc in `Diags.internal`
* add missing initializer for `e2.num_values = num_values;` in `InitListExpr` instantiator
* add missing initializers in `TypeRef.instantiate`