### PR TITLE
Compiler: fix boolean conversion semantics

### DIFF
--- a/analyser_utils/ctv_analyser.c2
+++ b/analyser_utils/ctv_analyser.c2
@@ -162,6 +162,9 @@ public fn Value get_value(const Expr* e) {
             if (bi.getWidth() == 32) {
                 result.setFloat(cast<f32>(result.toFloat()));
             }
+        } else
+        if (qt.isBool()) {
+            result.setUnsigned(!result.isZero());
         } else {
             if (!result.isDecimal()) {
                 // TODO: check for overflow

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -248,7 +248,7 @@ const char*[] builtinType_cnames = {
     "double",
     "ssize_t",
     "size_t",
-    "bool",
+    "_Bool",
     "void",
 }
 

--- a/test/c_generator/types/builtins.c2t
+++ b/test/c_generator/types/builtins.c2t
@@ -25,7 +25,7 @@ type S struct {
 
 typedef struct test_S_ test_S;
 struct test_S_ {
-    bool b;
+    _Bool b;
     int8_t i_8;
     int16_t i_16;
     int32_t i_32;

--- a/test/c_generator/variables/should_initalize_globals.c2t
+++ b/test/c_generator/variables/should_initalize_globals.c2t
@@ -24,7 +24,7 @@ typedef struct test_Foo_ test_Foo;
 struct test_Foo_ {
     int32_t i;
     int8_t* cp;
-    bool b;
+    _Bool b;
 };
 
 static test_Foo test_f = { };

--- a/test/expr/implicit_conversions.c2
+++ b/test/expr/implicit_conversions.c2
@@ -1,0 +1,74 @@
+// @warnings{no-unused}
+module test;
+
+// static casts
+static_assert(0, cast<bool>(false));
+static_assert(1, cast<bool>(true));
+static_assert(0, cast<bool>(0));
+static_assert(1, cast<bool>(1));
+static_assert(1, cast<bool>(2));
+static_assert(1, cast<bool>(-1));
+static_assert(1, cast<bool>(256));
+static_assert(1, cast<bool>(256+1));
+static_assert(1, cast<bool>(65536));
+static_assert(1, cast<bool>(65536+1));
+static_assert(0, cast<bool>(0.0));
+static_assert(0, cast<bool>(-0.0));
+static_assert(1, cast<bool>(1.0));
+static_assert(1, cast<bool>(0.5));
+static_assert(1, cast<bool>(2.0));
+static_assert(1, cast<bool>(256.0));
+static_assert(1, cast<bool>(257.0));
+static_assert(1, cast<bool>(65536.0));
+static_assert(1, cast<bool>(65537.0));
+static_assert(1, cast<bool>(0.0 / 0.0));
+static_assert(1, cast<bool>(1.0 / 0.0));
+
+public fn i32 main() {
+    // explicit casts
+    assert(0 == cast<bool>(false));
+    assert(1 == cast<bool>(true));
+    assert(0 == cast<bool>(0));
+    assert(1 == cast<bool>(1));
+    assert(1 == cast<bool>(2));
+    assert(1 == cast<bool>(-1));
+    assert(1 == cast<bool>(256));
+    assert(1 == cast<bool>(256+1));
+    assert(1 == cast<bool>(65536));
+    assert(1 == cast<bool>(65536+1));
+    assert(0 == cast<bool>(0.0));
+    assert(0 == cast<bool>(-0.0));
+    assert(1 == cast<bool>(1.0));
+    assert(1 == cast<bool>(0.5));
+    assert(1 == cast<bool>(2.0));
+    assert(1 == cast<bool>(256.0));
+    assert(1 == cast<bool>(257.0));
+    assert(1 == cast<bool>(65536.0));
+    assert(1 == cast<bool>(65537.0));
+    assert(1 == cast<bool>(0.0 / 0.0));
+    assert(1 == cast<bool>(1.0 / 0.0));
+
+    // implicit casts
+    bool b;
+    b = false;     assert(0 == b);
+    b = true;      assert(1 == b);
+    b = 0;         assert(0 == b);
+    b = 1;         assert(1 == b);
+    b = -1;        assert(1 == b);
+    b = 256;       assert(1 == b);
+    b = 256+1;     assert(1 == b);
+    b = 65536;     assert(1 == b);
+    b = 65536+1;   assert(1 == b);
+    b = 0.0;       assert(0 == b);
+    b = -0.0;      assert(0 == b);
+    b = 1.0;       assert(1 == b);
+    b = 0.5;       assert(1 == b);
+    b = 2.0;       assert(1 == b);
+    b = 256.0;     assert(1 == b);
+    b = 257.0;     assert(1 == b);
+    b = 65536.0;   assert(1 == b);
+    b = 65537.0;   assert(1 == b);
+    b = 0.0 / 0.0; assert(1 == b);
+    b = 1.0 / 0.0; assert(1 == b);
+    return 0;
+}


### PR DESCRIPTION
* fix constant value cast as `bool`
* generate C `_Bool` type for `bool` variables and conversions