### PR TITLE
Parser: reduce number of malloc calls

### DIFF
--- a/analyser/incr_array_list.c2
+++ b/analyser/incr_array_list.c2
@@ -71,7 +71,7 @@ public fn void List.add(List* v, u32 name, SrcLoc loc, ast.Expr* value) {
         Info* info = &v.entries[v.count];
         info.name = name;
         info.loc = loc;
-        info.values.init(4);
+        info.values.init();
         v.count++;
         values = &info.values;
     }

--- a/ast/ast.c2
+++ b/ast/ast.c2
@@ -44,7 +44,7 @@ public type AST struct @(opaque) {
     attr_table.Table* attrs;
 }
 
-static_assert(144, sizeof(AST));
+static_assert(144+64, sizeof(AST));
 
 fn AST* AST.create(string_pool.Pool* auxPool, u32 name, Module* mod, bool is_generated) {
     AST* a = stdlib.calloc(1, sizeof(AST));
@@ -54,8 +54,8 @@ fn AST* AST.create(string_pool.Pool* auxPool, u32 name, Module* mod, bool is_gen
     a.idx = addAST(a);
     a.is_generated = is_generated;
     a.imports.init();
-    a.types.init(0);
-    a.variables.init(4);
+    a.types.init();
+    a.variables.init();
     a.functions.init();
     a.static_asserts.init(0);
     a.array_values.init(0);

--- a/ast/decl_list.c2
+++ b/ast/decl_list.c2
@@ -22,30 +22,34 @@ public type DeclList struct {
     u32 count;
     u32 capacity;
     Decl** decls;
+    Decl*[4] stash;
 }
 
-public fn void DeclList.init(DeclList* l, u32 initial_size) {
-    memset(l, 0, sizeof(DeclList));
-    if (initial_size) {
-        l.capacity = initial_size;
-        l.decls = malloc(l.capacity * sizeof(Decl*));
-    }
+public fn void DeclList.init(DeclList* l) {
+    l.count = 0;
+    l.capacity = elemsof(l.stash);
+    l.decls = l.stash;
 }
 
 public fn void DeclList.free(DeclList* l) {
-    if (l.decls) free(l.decls);
+    if (l.capacity > elemsof(l.stash)) free(l.decls);
+    l.count = 0;
+    l.capacity = 0;
 }
 
 public fn void DeclList.add(DeclList* l, Decl* d) {
     if (l.count >= l.capacity) {
-        l.capacity += 4;
-        void* decls2 = malloc(l.capacity * sizeof(Decl*));
-        void* old = l.decls;
-        if (old) {
-            memcpy(decls2, old, l.count * sizeof(Decl*));
-            free(old);
+        if (l.capacity == 0) {
+            l.capacity = elemsof(l.stash);
+            l.decls = l.stash;
+        } else {
+            u32 capacity2 = l.capacity + l.capacity / 2 + 2;
+            void* decls2 = malloc(capacity2 * sizeof(Decl*));
+            memcpy(decls2, l.decls, l.count * sizeof(Decl*));
+            if (l.capacity > elemsof(l.stash)) free(l.decls);
+            l.capacity = capacity2;
+            l.decls = decls2;
         }
-        l.decls = decls2;
     }
 
     l.decls[l.count] = d;

--- a/ast/expr_list.c2
+++ b/ast/expr_list.c2
@@ -22,30 +22,34 @@ public type ExprList struct {
     u32 count;
     u32 capacity;
     Expr** exprs;
+    Expr*[4] stash;
 }
 
-public fn void ExprList.init(ExprList* l, u32 initial_size) {
-    memset(l, 0, sizeof(ExprList));
-    if (initial_size) {
-        l.capacity = initial_size;
-        l.exprs = malloc(l.capacity * sizeof(Expr*));
-    }
+public fn void ExprList.init(ExprList* l) {
+    l.count = 0;
+    l.capacity = elemsof(l.stash);
+    l.exprs = l.stash;
 }
 
 public fn void ExprList.free(ExprList* l) {
-    if (l.exprs) free(l.exprs);
+    if (l.capacity > elemsof(l.stash)) free(l.exprs);
+    l.count = 0;
+    l.capacity = 0;
 }
 
 public fn void ExprList.add(ExprList* l, Expr* d) {
     if (l.count >= l.capacity) {
-        l.capacity += l.capacity / 2 + 4;
-        void* exprs2 = malloc(l.capacity * sizeof(Expr*));
-        void* old = l.exprs;
-        if (old) {
-            memcpy(exprs2, old, l.count * sizeof(Expr*));
-            free(old);
+        if (l.capacity == 0) {
+            l.capacity = elemsof(l.stash);
+            l.exprs = l.stash;
+        } else {
+            u32 capacity2 = l.capacity + l.capacity / 2 + 2;
+            void* exprs2 = malloc(capacity2 * sizeof(Expr*));
+            memcpy(exprs2, l.exprs, l.count * sizeof(Expr*));
+            if (l.capacity > elemsof(l.stash)) free(l.exprs);
+            l.capacity = capacity2;
+            l.exprs = exprs2;
         }
-        l.exprs = exprs2;
     }
 
     l.exprs[l.count] = d;

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -1141,7 +1141,7 @@ fn void Generator.init(Generator* gen,
     gen.header_fragments.init();
     gen.header = string_buffer.create(8192, false, 2);
     gen.imports.init(nil);  // note: cannot get string values! (not needed)
-    gen.decls.init(16);
+    gen.decls.init();
 
     gen.stdargName = astPool.addStr("stdarg", true);
 }

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -393,7 +393,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
     }
 
     DeclList params;
-    params.init(4);
+    params.init();
 
     bool is_variadic = p.parseFunctionParams(&params, is_public);
 

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -383,7 +383,7 @@ fn Expr* Parser.parseCallExpr(Parser* p, Expr* func) {
     p.consumeToken(); // '('
 
     ExprList args;
-    args.init(4);
+    args.init();
 
     while (p.tok.kind != Kind.RParen) {
 
@@ -406,7 +406,7 @@ fn Expr* Parser.parseTemplateCallExpr(Parser* p, Expr* func, const TypeRefHolder
     p.consumeToken(); // '('
 
     ExprList args;
-    args.init(4);
+    args.init();
 
     while (p.tok.kind != Kind.RParen) {
 
@@ -633,7 +633,7 @@ fn Expr* Parser.parseInitList(Parser* p) {
     p.expectAndConsume(Kind.LBrace);
 
     ExprList values;
-    values.init(8);
+    values.init();
 
     while (p.tok.kind != Kind.RBrace) {
         bool unused;

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -258,11 +258,11 @@ fn Stmt* Parser.parseAsmStmt(Parser* p) {
     Expr* str = p.parseStringLiteral();
 
     ExprList constraints;
-    constraints.init(2);
+    constraints.init();
     ExprList exprs;
-    exprs.init(2);
+    exprs.init();
     ExprList clobbers;
-    clobbers.init(2);
+    clobbers.init();
 
     // Basic Asm stmt
     if (p.tok.kind == Kind.RParen) {

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -59,7 +59,7 @@ fn void Parser.parseFunctionType(Parser* p, u32 name, SrcLoc loc, bool is_public
     p.parseSingleTypeSpecifier(&rtype, true);
 
     DeclList params;
-    params.init(4);
+    params.init();
 
     bool is_variadic = p.parseFunctionParams(&params, is_public);
     Decl* f = p.builder.actOnFunctionTypeDecl(name,
@@ -82,7 +82,7 @@ fn void Parser.parseStructType(Parser* p, bool is_struct, u32 name, SrcLoc loc, 
     p.parseOptionalAttributes();
 
     DeclList members;
-    members.init(8);
+    members.init();
     p.parseStructBlock(&members, is_public);
     StructTypeDecl* d = p.builder.actOnStructType(name,
                                                   loc,
@@ -123,7 +123,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             }
 
             DeclList sub_members;
-            sub_members.init(4);
+            sub_members.init();
 
             p.parseStructBlock(&sub_members, is_public);
             StructTypeDecl* member = p.builder.actOnStructType(name,
@@ -215,7 +215,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
     bool is_incr = false;
 
     DeclList constants;
-    constants.init(16);
+    constants.init();
 
     if (p.tok.kind == Kind.Plus) {
         is_incr = true;

--- a/plugins/unit_test_plugin.c2
+++ b/plugins/unit_test_plugin.c2
@@ -49,7 +49,7 @@ type Plugin struct {
 
 fn void* load(const char* options, bool show_timing, bool show_debug) {
     Plugin* p = calloc(1, sizeof(Plugin));
-    p.decls.init(16);
+    p.decls.init();
     p.tests.init();
 
     console.init();


### PR DESCRIPTION
* add local stash in `ExprList` and `DeclList` (4 entries)
* allow zero initialization of `ExprList` and `DeclList`
* remove `initial_size` argument to `init` constructor
* this reduces the number of calls to `malloc` and `free` by more than 70%