### PR TITLE
Compiler: rename QualType.init as QualType.create                    …

### DIFF
--- a/ast/alias_type_decl.c2
+++ b/ast/alias_type_decl.c2
@@ -34,7 +34,7 @@ public fn AliasTypeDecl* AliasTypeDecl.create(ast_context.Context* c,
     u32 size = sizeof(AliasTypeDecl) + ref.getExtraSize();
     AliasTypeDecl* d = c.alloc(size);
     AliasType* at = AliasType.create(c, d);
-    d.base.init(DeclKind.AliasType, name, loc, is_public, QualType.init(cast<Type*>(at)), ast_idx);
+    d.base.init(DeclKind.AliasType, name, loc, is_public, QualType.create(cast<Type*>(at)), ast_idx);
     ref.fill(&d.typeRef);
 #if AstStatistics
     Stats.addDecl(DeclKind.AliasType, size);

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -187,7 +187,7 @@ fn BuiltinType* BuiltinType.create(ast_context.Context* c, BuiltinKind kind) {
     BuiltinType* b = c.alloc(sizeof(BuiltinType));
     b.base.init(TypeKind.Builtin);
     b.base.builtinTypeBits.kind = kind;
-    b.base.setCanonicalType(QualType.init(&b.base));
+    b.base.setCanonicalType(QualType.create(&b.base));
 #if AstStatistics
     Stats.addType(TypeKind.Builtin, sizeof(BuiltinType));
 #endif

--- a/ast/enum_type.c2
+++ b/ast/enum_type.c2
@@ -30,7 +30,7 @@ fn EnumType* EnumType.create(ast_context.Context* c, EnumTypeDecl* decl) {
 #if AstStatistics
     Stats.addType(TypeKind.Enum, sizeof(EnumType));
 #endif
-    t.base.setCanonicalType(QualType.init(cast<Type*>(t)));
+    t.base.setCanonicalType(QualType.create(cast<Type*>(t)));
     return t;
 }
 

--- a/ast/enum_type_decl.c2
+++ b/ast/enum_type_decl.c2
@@ -49,7 +49,7 @@ public fn EnumTypeDecl* EnumTypeDecl.create(ast_context.Context* c,
     if (is_incremental) size += sizeof(EnumConstantDecl**);
     EnumTypeDecl* d = c.alloc(size);
     EnumType* etype = EnumType.create(c, d);
-    QualType qt = QualType.init(cast<Type*>(etype));
+    QualType qt = QualType.create(cast<Type*>(etype));
     d.base.init(DeclKind.EnumType, name, loc, is_public, qt, ast_idx);
     d.base.enumTypeDeclBits.is_incremental = is_incremental;
     d.base.enumTypeDeclBits.num_constants = num_constants;

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -92,7 +92,7 @@ public fn FunctionDecl* FunctionDecl.create(ast_context.Context* c,
     u32 size = sizeof(FunctionDecl) + num_params * sizeof(VarDecl*) + rtype.getExtraSize();
     FunctionDecl* d = c.alloc(size);
     FunctionType* ftype = FunctionType.create(c, d);
-    QualType qt = QualType.init(ftype.asType());
+    QualType qt = QualType.create(ftype.asType());
     d.base.init(DeclKind.Function, name, loc, is_public, qt, ast_idx);
     d.base.functionDeclBits.is_variadic = is_variadic;
     d.base.functionDeclBits.call_kind = prefix ? CallKind.StaticTypeFunc : CallKind.Normal;
@@ -136,7 +136,7 @@ public fn FunctionDecl* FunctionDecl.createTemplate(ast_context.Context* c,
     u32 size = sizeof(FunctionDecl) + num_params * sizeof(VarDecl*) + rtype.getExtraSize();
     FunctionDecl* d = c.alloc(size);
     FunctionType* ftype = FunctionType.create(c, d);
-    QualType qt = QualType.init(ftype.asType());
+    QualType qt = QualType.create(ftype.asType());
     d.base.init(DeclKind.Function, name, loc, is_public, qt, ast_idx);
     d.base.functionDeclBits.is_variadic = is_variadic;
     d.base.functionDeclBits.call_kind = CallKind.Normal;
@@ -180,7 +180,7 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
     // note: the instantiation is no longer a template function (otherwise ignored by analyseFunctionProto)
     fd2.base.functionDeclBits.is_template = 0;
     FunctionType* ftype = FunctionType.create(inst.c, fd2);
-    fd2.base.qt = QualType.init(ftype.asType());
+    fd2.base.qt = QualType.create(ftype.asType());
 
     fd2.body = fd.body.instantiate(inst);
     fd2.rt = QualType_Invalid;

--- a/ast/function_type.c2
+++ b/ast/function_type.c2
@@ -29,7 +29,7 @@ fn FunctionType* FunctionType.create(ast_context.Context* c, FunctionDecl* decl)
     t.decl = nil;
     t.decl = decl;
 
-    t.base.setCanonicalType(QualType.init(&t.base));
+    t.base.setCanonicalType(QualType.create(&t.base));
 #if AstStatistics
     Stats.addType(TypeKind.Function, sizeof(FunctionType));
 #endif

--- a/ast/module_type.c2
+++ b/ast/module_type.c2
@@ -28,7 +28,7 @@ fn ModuleType* ModuleType.create(ast_context.Context* c, Module* mod) {
     ModuleType* t = c.alloc(sizeof(ModuleType));
     t.base.init(TypeKind.Module);
     t.mod = mod;
-    t.base.setCanonicalType(QualType.init(&t.base));
+    t.base.setCanonicalType(QualType.create(&t.base));
 #if AstStatistics
     Stats.addType(TypeKind.Module, sizeof(ModuleType));
 #endif

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -27,7 +27,7 @@ public type QualType struct {
     usize ptr;
 }
 
-public fn QualType QualType.init(Type* t) {
+public fn QualType QualType.create(Type* t) {
     QualType qt = { cast<usize>(t) }
     return qt;
 }

--- a/ast/string_type_pool.c2
+++ b/ast/string_type_pool.c2
@@ -70,7 +70,7 @@ fn QualType StringTypePool.get(StringTypePool* p, u32 len) {
     // Note: re-use char[x] existing types
     for (u32 i=0; i<p.count; i++) {
         StringTypeSlot* s = &p.slots[i];
-        if (s.len == len) return QualType.init(s.type_);
+        if (s.len == len) return QualType.create(s.type_);
     }
     if (p.count == p.capacity) p.resize(p.capacity * 2);
 
@@ -79,7 +79,7 @@ fn QualType StringTypePool.get(StringTypePool* p, u32 len) {
     p.slots[idx].len = len;
     p.slots[idx].type_ = t;
     p.count++;
-    QualType qt = QualType.init(t);
+    QualType qt = QualType.create(t);
     t.setCanonicalType(qt);
     return qt;
 }

--- a/ast/struct_type_decl.c2
+++ b/ast/struct_type_decl.c2
@@ -63,7 +63,7 @@ public fn StructTypeDecl* StructTypeDecl.create(ast_context.Context* c,
     size = (size + 7) & ~0x7; // round to 8-byte (temp)
     StructTypeDecl* d = c.alloc(size);
     StructType* stype = StructType.create(c, d);
-    QualType qt = QualType.init(stype.asType());
+    QualType qt = QualType.create(stype.asType());
     stype.asType().setCanonicalType(qt);
     d.base.init(DeclKind.StructType, name, loc, is_public, qt, ast_idx);
     d.base.structTypeDeclBits.is_struct = is_struct;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -148,7 +148,7 @@ fn void Compiler.handleImport(void* arg, ast.ImportDecl* id) {
     id.setDest(m);
     m.setUsed();
     d.setChecked();
-    d.setType(ast.QualType.init(cast<ast.Type*>(m.getType())));
+    d.setType(ast.QualType.create(cast<ast.Type*>(m.getType())));
 }
 
 type Compiler struct {

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -111,7 +111,7 @@ public fn void Builder.actOnModule(Builder* b,
     d.setUsed();
     d.setChecked();
     i.setDest(b.mod);
-    d.setType(QualType.init(cast<Type*>(b.mod.getType())));
+    d.setType(QualType.create(cast<Type*>(b.mod.getType())));
     b.ast.addImport(i);
 }
 
@@ -633,14 +633,14 @@ public fn QualType Builder.actOnBuiltinType(Builder*, BuiltinKind kind) {
 }
 
 public fn QualType Builder.actOnPointerType(Builder*, QualType inner) {
-    QualType ptr = QualType.init(ast.getPointerType(inner));
+    QualType ptr = QualType.create(ast.getPointerType(inner));
 
     // canonical can be either self or a pointer to elem's canonical type
     QualType canon = inner.getCanonicalType();
     if (inner.getTypeOrNil() == canon.getTypeOrNil()) {
         canon = ptr;
     } else {
-        canon = QualType.init(ast.getPointerType(canon));
+        canon = QualType.create(ast.getPointerType(canon));
         canon.setCanonicalType(canon);
     }
     ptr.setCanonicalType(canon);
@@ -653,7 +653,7 @@ public fn QualType Builder.actOnArrayType(Builder* b,
                                           bool has_size,
                                           u32 size) {
     ArrayType* t = ArrayType.create(b.context, elem, has_size, size);
-    QualType a = QualType.init(cast<Type*>(t));
+    QualType a = QualType.create(cast<Type*>(t));
 
     // canonical can be either self or a pointer to elem's canonical type
     QualType canon = elem.getCanonicalType();
@@ -662,7 +662,7 @@ public fn QualType Builder.actOnArrayType(Builder* b,
     } else {
         ArrayType* t2 = ArrayType.create(b.context, canon, has_size, size);
         // Note: keep same quals here, even if canonical type may be a PointerType!
-        canon = QualType.init(cast<Type*>(t2));
+        canon = QualType.create(cast<Type*>(t2));
     }
     a.setCanonicalType(canon);
 
@@ -671,7 +671,7 @@ public fn QualType Builder.actOnArrayType(Builder* b,
 
 public fn QualType Builder.actOnIncrementalArrayType(Builder* b, QualType elem) {
     ArrayType* t = ArrayType.createIncremental(b.context, elem);
-    QualType a = QualType.init(cast<Type*>(t));
+    QualType a = QualType.create(cast<Type*>(t));
 
     // canonical can be either self or a pointer to elem's canonical type
     QualType canon = elem.getCanonicalType();
@@ -680,7 +680,7 @@ public fn QualType Builder.actOnIncrementalArrayType(Builder* b, QualType elem) 
     } else {
         ArrayType* t2 = ArrayType.createIncremental(b.context, canon);
         // Note: keep same quals here, even if canonical type may be a PointerType!
-        canon = QualType.init(cast<Type*>(t2));
+        canon = QualType.create(cast<Type*>(t2));
     }
     a.setCanonicalType(canon);
 


### PR DESCRIPTION
…                                                                                                                                                                                                                                                         * rename `QualType.init` as `QualType.create` for consistency as this

  is a factory, not a constructor or initializer.