### PR TITLE
ast: transpose TypeRefHolder.fill as TypeRef.init

### DIFF
--- a/ast/alias_type_decl.c2
+++ b/ast/alias_type_decl.c2
@@ -35,7 +35,7 @@ public fn AliasTypeDecl* AliasTypeDecl.create(ast_context.Context* c,
     AliasTypeDecl* d = c.alloc(size);
     AliasType* at = AliasType.create(c, d);
     d.base.init(DeclKind.AliasType, name, loc, is_public, QualType.create(cast<Type*>(at)), ast_idx);
-    ref.fill(&d.typeRef);
+    d.typeRef.init(ref);
 #if AstStatistics
     Stats.addDecl(DeclKind.AliasType, size);
 #endif

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -84,7 +84,7 @@ public fn CallExpr* CallExpr.createTemplate(ast_context.Context* c,
     e.func = func;
     string.memcpy(e.args, args, num_args * sizeof(Expr*));
     TypeRef* destRef = cast<TypeRef*>(&e.args[num_args]);
-    ref.fill(destRef);
+    destRef.init(ref);
 #if AstStatistics
     Stats.addExpr(ExprKind.Call, size);
 #endif

--- a/ast/explicit_cast_expr.c2
+++ b/ast/explicit_cast_expr.c2
@@ -42,7 +42,7 @@ public fn ExplicitCastExpr* ExplicitCastExpr.create(ast_context.Context* c,
     e.base.base.explicitCastExprBits.src_len = src_len;
     e.dest_type = QualType_Invalid;
     e.inner = inner;
-    ref.fill(&e.dest);
+    e.dest.init(ref);
 #if AstStatistics
     Stats.addExpr(ExprKind.ExplicitCast, size);
 #endif

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -104,7 +104,7 @@ public fn FunctionDecl* FunctionDecl.create(ast_context.Context* c,
     d.template_name = 0;
     d.template_loc = 0;
     d.rt = QualType_Invalid;
-    rtype.fill(&d.rtype);
+    d.rtype.init(rtype);
     d.body = nil;
     u8* tail = d.rtype.getPointerAfter();
     if (prefix) {
@@ -149,7 +149,7 @@ public fn FunctionDecl* FunctionDecl.createTemplate(ast_context.Context* c,
     d.template_name = template_name;
     d.template_loc = template_loc;
     d.rt = QualType_Invalid;
-    rtype.fill(&d.rtype);
+    d.rtype.init(rtype);
     d.body = nil;
     u8* tail = d.rtype.getPointerAfter();
 

--- a/ast/type_expr.c2
+++ b/ast/type_expr.c2
@@ -38,7 +38,7 @@ public fn TypeExpr* TypeExpr.create(ast_context.Context* c,
     TypeExpr* e = c.alloc(size);
     e.base.init(ExprKind.Type, loc, 0, 0, 0, ValType.NValue);
     e.base.base.typeExprBits.src_len = src_len;
-    ref.fill(&e.typeRef);
+    e.typeRef.init(ref);
 #if AstStatistics
     Stats.addExpr(ExprKind.Type, size);
 #endif

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -145,21 +145,6 @@ public fn void TypeRefHolder.setPrefix(TypeRefHolder* h, SrcLoc loc, u32 name_id
     h.user.decl = nil;
 }
 
-fn void TypeRefHolder.fill(const TypeRefHolder* h, TypeRef* dest) {
-    const TypeRef* r = cast<TypeRef*>(&h.ref);
-    *dest = *r;
-    if (r.isUser()) {
-        dest.refs[0] = r.refs[0];
-        if (r.hasPrefix()) {
-            dest.refs[1] = r.refs[1];
-        }
-    }
-    for (u32 i=0; i<r.flags.num_arrays; i++) {
-        Expr** a = dest.getArray2(i);
-        *a = h.arrays[i];
-    }
-}
-
 public fn void TypeRefHolder.dump(const TypeRefHolder* h) @(unused) {
     const TypeRef* r = cast<TypeRef*>(&h.ref);
     string_buffer.Buf* out = string_buffer.create(128, useColor(), 2);
@@ -173,6 +158,21 @@ public fn void TypeRefHolder.dump(const TypeRefHolder* h) @(unused) {
     out.color(col_Normal);
     stdio.puts(out.data());
     out.free();
+}
+
+fn void TypeRef.init(TypeRef* dest, const TypeRefHolder* h) {
+    const TypeRef* r = cast<const TypeRef*>(&h.ref);
+    *dest = *r;
+    if (r.isUser()) {
+        dest.refs[0] = r.refs[0];
+        if (r.hasPrefix()) {
+            dest.refs[1] = r.refs[1];
+        }
+    }
+    for (u32 i=0; i<r.flags.num_arrays; i++) {
+        Expr** a = dest.getArray2(i);
+        *a = h.arrays[i];
+    }
 }
 
 fn bool TypeRef.matchesTemplate(const TypeRef* r, u32 template_arg) {

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -74,7 +74,7 @@ public fn VarDecl* VarDecl.create(ast_context.Context* c,
     VarDecl* d = c.alloc(size);
     d.base.init(DeclKind.Variable, name, loc, is_public, QualType_Invalid, ast_idx);
     d.base.varDeclBits.kind = kind;
-    ref.fill(&d.typeRef);
+    d.typeRef.init(ref);
     if (initValue) {
         d.base.varDeclBits.has_init_or_bitfield = 1;
         SrcLoc* locpos = d.typeRef.getPointerAfter();
@@ -105,7 +105,7 @@ public fn VarDecl* VarDecl.createStructMember(ast_context.Context* c,
     d.base.varDeclBits.kind = VarDeclKind.StructMember;
 
     if (name == 0) d.base.setUsed();  // set unnamed member to used
-    ref.fill(&d.typeRef);
+    d.typeRef.init(ref);
     if (bitfield) {
         d.base.varDeclBits.has_init_or_bitfield = 1;
         Expr** i = d.getInit2();


### PR DESCRIPTION
* transpose calls to `TypeRefHolder.fill` as init calls for the destination `TypeRef` object.