### PR TITLE
Compiler: fix some location inconsistencies

### DIFF
--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -73,7 +73,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
     u32 call_num_args = call.getNumArgs();
 
     bool isTypeFuncCall = false;  // Not for static type-functions!
-    SrcLoc loc = e.getLoc();
+    // TODO: why use this location instead of that of the origFn?
+    SrcLoc loc = e.getLoc();      // call location is the opening '('
 
     QualType baseType;
     MemberExpr* m = nil;
@@ -94,8 +95,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
                 isTypeFuncCall = true;
                 call.setCallsTypeFunc();
                 baseType = m.getBaseType();
-                // TODO: why use this location instead of that of the '('?
-                loc = m.getEndLoc();
+                // loc points to the last member of the function name
+                loc = m.getLastLoc();
             }
             break;
         case StaticTypeFunc:

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -226,10 +226,9 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
     // check for return stmt if function returns a value
     QualType rtype = fd.getRType();
     if (!rtype.isVoid()) {
-        Stmt* st = cast<Stmt*>(body);
-        if (!hasReturn(st)) {
-            // error loc is closing brace
-            ma.error(st.getLoc() - 1, "control reaches end of non-void function");
+        if (!hasReturn(cast<Stmt*>(body))) {
+            // error loc is closing brace of the function body
+            ma.error(body.getEndLoc() - 1, "control reaches end of non-void function");
         }
     }
 

--- a/ast/compound_stmt.c2
+++ b/ast/compound_stmt.c2
@@ -77,6 +77,11 @@ public fn Stmt* CompoundStmt.getLastStmt(const CompoundStmt* s) {
     return nil;
 }
 
+public fn SrcLoc CompoundStmt.getEndLoc(const CompoundStmt* e) {
+    // e.base.loc is the location of the closing brace '}'
+    return e.base.loc + 1;
+}
+
 fn void CompoundStmt.print(const CompoundStmt* s, string_buffer.Buf* out, u32 indent) {
     s.base.printKind(out, indent);
     out.newline();

--- a/ast/if_stmt.c2
+++ b/ast/if_stmt.c2
@@ -16,6 +16,7 @@
 module ast;
 
 import ast_context;
+import src_loc local;
 import string_buffer;
 
 type IfStmtBits struct {
@@ -30,12 +31,12 @@ public type IfStmt struct @(opaque) {
     Stmt*[0] else_stmt; // tail-allocated
 }
 
-public fn IfStmt* IfStmt.create(ast_context.Context* c, Stmt* cond, Stmt* then, Stmt* else_stmt) {
+public fn IfStmt* IfStmt.create(ast_context.Context* c, SrcLoc loc, Stmt* cond, Stmt* then, Stmt* else_stmt) {
     u32 size = sizeof(IfStmt);
     if (else_stmt) size += sizeof(Stmt*);
 
     IfStmt* s = c.alloc(size);
-    s.base.init(StmtKind.If, 0);
+    s.base.init(StmtKind.If, loc);
     s.cond = cond;
     s.then = then;
 
@@ -55,7 +56,7 @@ fn Stmt* IfStmt.instantiate(IfStmt* s, Instantiator* inst) {
     Stmt* else2 = nil;
     if (s.base.ifStmtBits.has_else) else2 = s.else_stmt[0].instantiate(inst);
 
-    return cast<Stmt*>(IfStmt.create(inst.c, cond2, then2, else2));
+    return cast<Stmt*>(IfStmt.create(inst.c, s.base.loc, cond2, then2, else2));
 }
 
 public fn Stmt* IfStmt.getCond(const IfStmt* s) { return s.cond; }

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -160,7 +160,7 @@ public fn SrcLoc MemberExpr.getLoc(const MemberExpr* e, u32 ref_idx) {
 }
 
 public fn SrcRange MemberExpr.getRange(const MemberExpr* e, u32 ref_idx) {
-    SrcRange range = { e.getStartLoc(), e.getLoc(ref_idx) -2 } // cut of . and member
+    SrcRange range = { e.getStartLoc(), e.getLoc(ref_idx) - 1 } // cut off . and member
     return range;
 }
 
@@ -245,7 +245,11 @@ fn SrcLoc MemberExpr.getStartLoc(const MemberExpr* e) {
     return e.base.getLoc();
 }
 
-public fn SrcLoc MemberExpr.getEndLoc(const MemberExpr* e) {
+public fn SrcLoc MemberExpr.getLastLoc(const MemberExpr* e) {
+    return e.getLoc(e.getNumRefs() - 1);
+}
+
+fn SrcLoc MemberExpr.getEndLoc(const MemberExpr* e) {
     u32 last = e.getNumRefs() - 1;
     return e.getLoc(last) + cast<u32>(string.strlen(e.getName(last)));
 }

--- a/ast/while_stmt.c2
+++ b/ast/while_stmt.c2
@@ -16,6 +16,7 @@
 module ast;
 
 import ast_context;
+import src_loc local;
 import string_buffer;
 
 public type WhileStmt struct @(opaque) {
@@ -24,12 +25,12 @@ public type WhileStmt struct @(opaque) {
     Stmt* body;
 }
 
-public fn WhileStmt* WhileStmt.create(ast_context.Context* c,
+public fn WhileStmt* WhileStmt.create(ast_context.Context* c, SrcLoc loc,
                                         Stmt* cond,
                                         Stmt* body)
 {
     WhileStmt* s = c.alloc(sizeof(WhileStmt));
-    s.base.init(StmtKind.While, 0);
+    s.base.init(StmtKind.While, loc);
     s.cond = cond;
     s.body = body;
 #if AstStatistics
@@ -41,7 +42,7 @@ public fn WhileStmt* WhileStmt.create(ast_context.Context* c,
 fn Stmt* WhileStmt.instantiate(WhileStmt* s, Instantiator* inst) {
     Stmt* cond2 = s.cond.instantiate(inst);
     Stmt* body2 = s.body.instantiate(inst);
-    return cast<Stmt*>(WhileStmt.create(inst.c, cond2, body2));
+    return cast<Stmt*>(WhileStmt.create(inst.c, s.base.loc, cond2, body2));
 }
 
 fn void WhileStmt.print(const WhileStmt* s, string_buffer.Buf* out, u32 indent) {

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -815,12 +815,12 @@ public fn Stmt* Builder.actOnReturnStmt(Builder* b, SrcLoc loc, Expr* ret) {
     return cast<Stmt*>(ReturnStmt.create(b.context, loc, ret));
 }
 
-public fn Stmt* Builder.actOnIfStmt(Builder* b, Stmt* cond, Stmt* then, Stmt* else_stmt) {
-    return cast<Stmt*>(IfStmt.create(b.context, cond, then, else_stmt));
+public fn Stmt* Builder.actOnIfStmt(Builder* b, SrcLoc loc, Stmt* cond, Stmt* then, Stmt* else_stmt) {
+    return cast<Stmt*>(IfStmt.create(b.context, loc, cond, then, else_stmt));
 }
 
-public fn Stmt* Builder.actOnWhileStmt(Builder* b, Stmt* cond, Stmt* then) {
-    return cast<Stmt*>(WhileStmt.create(b.context, cond, then));
+public fn Stmt* Builder.actOnWhileStmt(Builder* b, SrcLoc loc, Stmt* cond, Stmt* then) {
+    return cast<Stmt*>(WhileStmt.create(b.context, loc, cond, then));
 }
 
 public fn Stmt* Builder.actOnForStmt(Builder* b,

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -436,6 +436,7 @@ fn Stmt* Parser.parseCondition(Parser* p) {
 }
 
 fn Stmt* Parser.parseIfStmt(Parser* p) {
+    SrcLoc loc = p.tok.loc;
     p.consumeToken();
 
     Stmt* cond = p.parseCondition();
@@ -447,7 +448,7 @@ fn Stmt* Parser.parseIfStmt(Parser* p) {
         else_stmt = p.parseStmt();
     }
 
-    return p.builder.actOnIfStmt(cond, then, else_stmt);
+    return p.builder.actOnIfStmt(loc, cond, then, else_stmt);
 }
 
 fn Stmt* Parser.parseReturnStmt(Parser* p) {
@@ -501,12 +502,13 @@ fn Stmt* Parser.parseForStmt(Parser* p) {
 }
 
 fn Stmt* Parser.parseWhileStmt(Parser* p) {
+    SrcLoc loc = p.tok.loc;
     p.consumeToken();
 
     Stmt* cond = p.parseCondition();
     Stmt* then = p.parseStmt();
 
-    return p.builder.actOnWhileStmt(cond, then);
+    return p.builder.actOnWhileStmt(loc, cond, then);
 }
 
 fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal) {

--- a/test/stmt/switch/switch_terminating.c2
+++ b/test/stmt/switch/switch_terminating.c2
@@ -47,8 +47,10 @@ fn void foo2(i32 x, bool cond) {
         if (cond)
             break;
         else break;
-    case 0: // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
-        if (cond)
+    case 6:
+        if (cond) return; else break;
+    case 0:
+        if (cond) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
             return;
     default:
         break;
@@ -57,8 +59,8 @@ fn void foo2(i32 x, bool cond) {
 
 fn void foo3(i32 x, bool cond) {
     switch (x) {
-    case 0: // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
-        while (cond)
+    case 0:
+        while (cond) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
             return;
     default:
         break;
@@ -75,12 +77,82 @@ fn void foo4(i32 x, bool cond) {
     }
 }
 
+fn void foo5(i32 x, bool cond) {
+    switch (x) {
+    case 0:
+        foo3(x, cond); // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+    default:
+        break;
+    }
+}
+
+fn void foo6(i32 x) {
+    switch (x) {
+    case 0:
+        // TODO: this should not be an error
+        while (true) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+            return;
+    default:
+        break;
+    }
+}
+
+fn void foo7(i32 x) {
+    switch (x) {
+    case 0:
+        // TODO: this should not be an error
+        for (;;) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+            return;
+    default:
+        break;
+    }
+}
+
+fn void foo8(i32 x) {
+    switch (x) {
+    case 0:
+        // TODO: this should not be an error but could be diagnosed as an infinite loop
+        while (true) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+            continue;
+    default:
+        break;
+    }
+}
+
+fn void foo9(i32 x) {
+    switch (x) {
+    case 0:
+        // TODO: this should not be an error but could be diagnosed as an infinite loop
+        for (;;) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+            continue;
+    default:
+        break;
+    }
+}
+
+fn void foo10(i32 x) {
+    switch (x) {
+    case 0:
+        // TODO: this should not be an error
+        if (1 < 2) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+            return;
+    default:
+        break;
+    }
+}
+
 public fn i32 main() {
     foo(0);
     foo1(0);
     foo2(0, false);
     foo3(0, false);
     foo4(0, false);
+    foo5(0, false);
+    foo6(0);
+    foo7(0);
+    foo8(0);
+    foo9(0);
+    foo10(0);
     return 0;
 }
 


### PR DESCRIPTION
* use more explicit location computation for missing return in function body
* add `Member.getLastLoc()` for the location of the last member name
* point to function/method name in function call errors
* add actual loc in `IfStmt` and `WhileStmt`
* fix corresponding tests, error should probably point to the case/default clause instead of the last statement and error message would be clearer as 'implicit fallthough is not allowed'