### PR TITLE
Parser: accept trailing comma in function argument lists

### DIFF
--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -458,7 +458,7 @@ fn bool Parser.parseFunctionParams(Parser* p, DeclList* params, bool is_public) 
     bool is_variadic = false;
 
     // VarDeclList args
-    while (1) {
+    while (p.tok.kind != Kind.RParen) {
         VarDecl* decl = p.parseParamDecl(is_public);
         params.add(decl.asDecl());
 

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -389,8 +389,6 @@ fn Expr* Parser.parseCallExpr(Parser* p, Expr* func) {
 
         args.add(p.parseExpr());
 
-        if (p.tok.kind == Kind.RParen) break;
-
         if (p.tok.kind != Kind.Comma) break;
         p.consumeToken();
     }
@@ -412,8 +410,8 @@ fn Expr* Parser.parseTemplateCallExpr(Parser* p, Expr* func, const TypeRefHolder
 
         args.add(p.parseExpr());
 
-        if (p.tok.kind == Kind.RParen) break;
-        p.expectAndConsume(Kind.Comma);
+        if (p.tok.kind != Kind.Comma) break;
+        p.consumeToken();
     }
     SrcLoc endLoc = p.tok.loc + 1;
     p.expectAndConsume(Kind.RParen);

--- a/test/functions/trailing_comma.c2
+++ b/test/functions/trailing_comma.c2
@@ -1,0 +1,33 @@
+// @warnings{no-unused}
+module test;
+
+fn void test1(
+              i32 a,  // first argument
+              i32 b,  // second argument
+              i32 c,  // third argument
+              i32 d,  // fourth argument
+              ) {
+     test1(1,
+           2,
+           3,
+           4,
+           );
+}
+
+fn void test2(
+              i32 a,  // first argument
+              i32 b,  // second argument
+#if __ASAN__
+              i32 c,  // third argument
+              i32 d,  // fourth argument
+#endif
+              ) {
+     test2(1,
+           2,
+#if __ASAN__
+           3,
+           4,
+#endif
+           );
+}
+


### PR DESCRIPTION
* accept trailing comma in function argument list definition
* accept trailing comma in template function calls
* add tests