### PR TITLE
Compiler: rename some init functions as initialize to avoid name coll…

### DIFF
--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -241,9 +241,9 @@ fn void Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
     ForStmt* f = cast<ForStmt*>(s);
 
     ma.scope.enter(scope.Break | scope.Continue | scope.Decl | scope.Control);
-    Stmt** init_ = f.getInit2();
-    if (init_) {
-        QualType ct = ma.analyseCondition(init_, false);
+    Stmt** init = f.getInit2();
+    if (init) {
+        QualType ct = ma.analyseCondition(init, false);
         if (ct.isInvalid()) goto done;
     }
 

--- a/ast/for_stmt.c2
+++ b/ast/for_stmt.c2
@@ -27,10 +27,10 @@ public type ForStmt struct @(opaque) {
     Stmt* body;
 }
 
-public fn ForStmt* ForStmt.create(ast_context.Context* c, SrcLoc loc, Stmt* init_, Expr* cond, Expr* cont, Stmt* body) {
+public fn ForStmt* ForStmt.create(ast_context.Context* c, SrcLoc loc, Stmt* init, Expr* cond, Expr* cont, Stmt* body) {
     ForStmt* s = c.alloc(sizeof(ForStmt));
     s.base.init(StmtKind.For, loc);
-    s.init = init_;
+    s.init = init;
     s.cond = cond;
     s.cont = cont;
     s.body = body;

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -126,12 +126,12 @@ public fn Globals* getGlobals() { return globals; }
 // only used by plugins
 public fn void setGlobals(Globals* g) @(unused){
     globals = g;
-    attr.init(g.attr_name_indexes);
+    attr.initialize(g.attr_name_indexes);
 }
 
 
 // wordsize in bytes, must NOT be called from Plugin!
-public fn void init(Context* c, string_pool.Pool* astPool, u32 wordsize, bool use_color) {
+public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, bool use_color) {
     globals = stdlib.malloc(sizeof(Globals));
     globals.pointers.init(c);
     globals.string_types.init(c);
@@ -180,7 +180,7 @@ public fn void init(Context* c, string_pool.Pool* astPool, u32 wordsize, bool us
     }
 
     attr.register(astPool, globals.attr_name_indexes);
-    attr.init(globals.attr_name_indexes);
+    attr.initialize(globals.attr_name_indexes);
 }
 
 public fn void deinit(bool print_stats) {

--- a/ast_utils/attr.c2
+++ b/ast_utils/attr.c2
@@ -106,7 +106,7 @@ public fn void register(string_pool.Pool* pool, u32* indexes) {
 // Note: this is different per plugin!
 const u32* name_indexes;
 
-public fn void init(const u32* indexes) {
+public fn void initialize(const u32* indexes) {
     name_indexes = indexes;
 }
 

--- a/common/file/reader.c2
+++ b/common/file/reader.c2
@@ -28,31 +28,31 @@ const i32 Err_not_a_file = 2001;
 const i32 Err_read_error = 2002;
 
 public type Reader struct {
-    u8* region_;
+    u8* region;
     u32 size;
-    i32 errno_;
+    i32 error;
 }
 
 public fn bool Reader.open(Reader* file, const char* filename) {
-    file.region_ = nil;
+    file.region = nil;
     file.size = 0;
-    file.errno_ = 0;
+    file.error = 0;
 
     i32 fd = open(filename, O_RDONLY | O_BINARY);
     if (fd == -1) {
-        file.errno_ = errno;
+        file.error = errno;
         return false;
     }
 
     Stat statbuf;
     if (fstat(fd, &statbuf)) {
-        file.errno_ = errno;
+        file.error = errno;
         close(fd);
         return false;
     }
 
     if (statbuf.st_mode & S_IFMT != S_IFREG) {
-        file.errno_ = Err_not_a_file;
+        file.error = Err_not_a_file;
         close(fd);
         return false;
     }
@@ -67,20 +67,20 @@ public fn bool Reader.open(Reader* file, const char* filename) {
         // TODO: handle chunked or interrupted I/O
         i64 numread = read(fd, region, size);
         if (numread < 0) {
-            file.errno_ = errno;
+            file.error = errno;
             stdlib.free(region);
             close(fd);
             return false;
         }
         if (numread != size) {
-            file.errno_ = Err_read_error;
+            file.error = Err_read_error;
             stdlib.free(region);
             close(fd);
             return false;
         }
         region[size] = '\0';
     }
-    file.region_ = region;
+    file.region = region;
     file.size = size;
     close(fd);
     return true;
@@ -88,22 +88,22 @@ public fn bool Reader.open(Reader* file, const char* filename) {
 
 public fn void Reader.close(Reader* file) {
     if (file.size) {
-        stdlib.free(file.region_);
-        file.region_ = nil;
+        stdlib.free(file.region);
+        file.region = nil;
         file.size = 0;
     }
 }
 
 public fn bool Reader.isOpen(const Reader* file) {
-    return file.region_ != nil;
+    return file.region != nil;
 }
 
 public fn const u8* Reader.udata(Reader* file) @(unused) {
-    return file.region_;
+    return file.region;
 }
 
 public fn const char* Reader.data(Reader* file) @(unused) {
-    return cast<const char*>(file.region_);
+    return cast<const char*>(file.region);
 }
 
 public fn bool Reader.isEmpty(const Reader* file) @(unused) {
@@ -112,7 +112,7 @@ public fn bool Reader.isEmpty(const Reader* file) @(unused) {
 
 public fn const char* Reader.getError(const Reader* file) @(unused) {
     const char *msg;
-    switch (file.errno_) {
+    switch (file.error) {
     case Err_not_a_file:
         msg = "not a regular file";
         break;
@@ -120,7 +120,7 @@ public fn const char* Reader.getError(const Reader* file) @(unused) {
         msg = "read error";
         break;
     default:
-        msg = strerror(file.errno_);
+        msg = strerror(file.error);
         break;
     }
     return msg;

--- a/common/file/writer.c2
+++ b/common/file/writer.c2
@@ -23,27 +23,27 @@ import unistd local;
 const i32 Err_write_error = 2003;
 
 public type Writer struct {
-    i32 errno_;
+    i32 error;
 }
 
 public fn bool Writer.write(Writer* writer, const char* filename, const void* data, u32 len) {
-    writer.errno_ = 0;
+    writer.error = 0;
 
     i32 fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0660);
     if (fd == -1) {
-        writer.errno_ = errno;
+        writer.error = errno;
         return false;
     }
 
     // TODO: handle chunked or interrupted I/O
     i64 written = write(fd, data, len);
     if (written < 0) {
-        writer.errno_ = errno;
+        writer.error = errno;
         close(fd);
         return false;
     }
     if (written != len) {
-        writer.errno_ = Err_write_error;
+        writer.error = Err_write_error;
         close(fd);
         return false;
     }
@@ -54,12 +54,12 @@ public fn bool Writer.write(Writer* writer, const char* filename, const void* da
 
 public fn const char* Writer.getError(const Writer* file) @(unused) {
     const char *msg;
-    switch (file.errno_) {
+    switch (file.error) {
     case Err_write_error:
         msg = "write error";
         break;
     default:
-        msg = strerror(file.errno_);
+        msg = strerror(file.error);
         break;
     }
     return msg;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -295,7 +295,7 @@ fn void Compiler.build(Compiler* c,
                                 &c.kwinfo,
                                 target.getFeatures());
 
-    ast.init(c.context, c.astPool, c.targetInfo.intWidth / 8, color.useColor());
+    ast.initialize(c.context, c.astPool, c.targetInfo.intWidth / 8, color.useColor());
 
     c.analyser = module_analyser.create(c.diags,
                                         c.context,

--- a/libs/lua/lua.c2i
+++ b/libs/lua/lua.c2i
@@ -98,7 +98,7 @@ fn const c_char* typename(State *L, c_int tp) @(cname="lua_typename");
 fn Number tonumberx(State *L, c_int idx, c_int *isnum) @(cname="lua_tonumberx");
 fn Integer tointegerx(State *L, c_int idx, c_int *isnum) @(cname="lua_tointegerx");
 fn c_int toboolean(State *L, c_int idx) @(cname="lua_toboolean");
-fn const c_char* tolstring(State *L, c_int idx, c_size *len_) @(cname="lua_tolstring");
+fn const c_char* tolstring(State *L, c_int idx, c_size *len) @(cname="lua_tolstring");
 fn c_size rawlen(State* L, c_int idx) @(cname="lua_rawlen");
 fn CFunction tocfunction(State *L, c_int idx) @(cname="lua_tocfunction");
 fn void* touserdata(State *L, c_int idx) @(cname="lua_touserdata");
@@ -133,7 +133,7 @@ fn c_int compare(State *L, c_int idx1, c_int idx2, c_int op) @(cname="lua_compar
 fn void pushnil(State *L) @(cname="lua_pushnil");
 fn void pushnumber(State *L, Number n) @(cname="lua_pushnumber");
 fn void pushinteger(State *L, Integer n) @(cname="lua_pushinteger");
-fn const c_char* pushlstring(State *L, const c_char* s, c_size len_) @(cname="lua_pushlstring");
+fn const c_char* pushlstring(State *L, const c_char* s, c_size len) @(cname="lua_pushlstring");
 fn const c_char* pushstring(State *L, const c_char* s) @(cname="lua_pushstring");
 //fn const c_char* lua_pushvfstring(State *L, const c_char *fmt, va_list argp);
 fn const c_char *pushfstring(State *L, const c_char *fmt, ...) @(cname="lua_pushfstring");

--- a/libs/sdl2/sdl.c2i
+++ b/libs/sdl2/sdl.c2i
@@ -104,12 +104,12 @@ type ThreadFunction fn c_int (void* data);
 
 type CurrentBeginThreadArg fn c_uint (void*);
 
-type CurrentBeginThread fn usize (void*, c_uint, c_uint, CurrentBeginThreadArg func_,
+type CurrentBeginThread fn usize (void*, c_uint, c_uint, CurrentBeginThreadArg func,
     void* arg, c_uint, c_uint* threadID);
 
 type CurrentEndThread fn void (c_uint code);
 
-fn Thread* createThread(ThreadFunction func_, const char* name, void* data,
+fn Thread* createThread(ThreadFunction func, const char* name, void* data,
                           CurrentBeginThread beginThread, CurrentEndThread endThread)
                           @(cname="SDL_CreateThread");
 

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -827,11 +827,11 @@ public fn Stmt* Builder.actOnWhileStmt(Builder* b, SrcLoc loc, Stmt* cond, Stmt*
 
 public fn Stmt* Builder.actOnForStmt(Builder* b,
                                      SrcLoc loc,
-                                     Stmt* init_,
+                                     Stmt* init,
                                      Expr* cond,
                                      Expr* incr,
                                      Stmt* body) {
-    return cast<Stmt*>(ForStmt.create(b.context, loc, init_, cond, incr, body));
+    return cast<Stmt*>(ForStmt.create(b.context, loc, init, cond, incr, body));
 }
 
 public fn Stmt* Builder.actOnSwitchStmt(Builder* b,

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -474,13 +474,13 @@ fn Stmt* Parser.parseForStmt(Parser* p) {
     p.expectAndConsume(Kind.LParen);
 
     // init
-    Stmt* init_ = nil;
+    Stmt* init = nil;
     if (p.tok.kind != Kind.Semicolon) {
         // parseCondition
         if (p.isDeclaration()) {
-            init_ = p.parseDeclStmt(false, false);
+            init = p.parseDeclStmt(false, false);
         } else {
-            init_ = p.parseExpr().asStmt();
+            init = p.parseExpr().asStmt();
         }
     }
     p.expectAndConsume(Kind.Semicolon);
@@ -501,7 +501,7 @@ fn Stmt* Parser.parseForStmt(Parser* p) {
 
     Stmt* body = p.parseStmt();
 
-    return p.builder.actOnForStmt(loc, init_, cond, incr, body);
+    return p.builder.actOnForStmt(loc, init, cond, incr, body);
 }
 
 fn Stmt* Parser.parseWhileStmt(Parser* p) {

--- a/tools/tester/expect_file.c2
+++ b/tools/tester/expect_file.c2
@@ -77,7 +77,7 @@ public fn void ExpectFile.destroy(ExpectFile* f) {
 }
 
 public fn void ExpectFile.addLine(ExpectFile* f, u32 line_nr, const char* start, const char* end) {
-    bool consecutive_ = (f.lastLineNr + 1 == line_nr); // ignore for first one (always ok)
+    bool consecutive = (f.lastLineNr + 1 == line_nr); // ignore for first one (always ok)
 
     skipInitialWhitespace(&start, end);
     skipTrailingWhitespace(start, &end);
@@ -85,7 +85,7 @@ public fn void ExpectFile.addLine(ExpectFile* f, u32 line_nr, const char* start,
     if (strncmp(start, "//", 2) == 0) return;   // ignore comments
 
     f.lastLineNr = line_nr;
-    f.lines.add(start, end, consecutive_);
+    f.lines.add(start, end, consecutive);
 }
 
 fn bool ExpectFile.checkLine(ExpectFile* f, u32 line_nr, const char* start, const char* end) {
@@ -144,11 +144,11 @@ fn void ExpectFile.setExpected(ExpectFile* f) {
 #endif
 }
 
-public fn bool ExpectFile.check(ExpectFile* f, string_buffer.Buf* output_, const char* basedir) {
+public fn bool ExpectFile.check(ExpectFile* f, string_buffer.Buf* output, const char* basedir) {
     // TODO use constant
     char[128] fullname;
     sprintf(fullname, "%s%s", basedir, f.filename);
-    f.output = output_;
+    f.output = output;
     bool result = true;
 
     // check if file exists


### PR DESCRIPTION
…isions

* rename `ast.init` as `ast.initialize`
* rename `attr.init` as `attr.initialize`
* no longer use `init_` as function argument names
* no longer use `region_` or `errno_` in Reader and `Writer`
* no longer use `func_`, `len_`... which no longer clash with keywords