### PR TITLE
Compiler: add init calls

### DIFF
--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -303,7 +303,8 @@ fn QualType Analyser.analyseDeclStmt(Analyser* ma, Stmt* s) {
     ma.checkName(d, false);
 
     Expr** initExpr = vd.getInit2();
-    if (initExpr) {
+    bool has_init_call = vd.hasInitCall();
+    if (!has_init_call && initExpr) {
         ma.analyseInitExpr(initExpr, res, vd.getAssignLoc());
         if (vd.hasLocalQualifier()) {
             Expr* e = vd.getInit();
@@ -333,6 +334,10 @@ fn QualType Analyser.analyseDeclStmt(Analyser* ma, Stmt* s) {
 
     d.setChecked();
     ma.has_error = ma.has_error | ma.scope.add(d);
+    if (has_init_call) {
+        Expr* e = *initExpr;
+        ma.analyseExpr(&e, false, 0);
+    }
     return res;
 }
 

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -40,6 +40,7 @@ type VarDeclBits struct {
     u32 kind : 3;
     u32 has_init_or_bitfield : 1;
     u32 has_local : 1; // local variables only
+    u32 has_init_call : 1; // local variables only
     u32 attr_weak : 1; // globals only
     u32 addr_used : 1;
     u32 auto_file : 1;  // for parameters only
@@ -228,6 +229,14 @@ public fn void VarDecl.setLocal(VarDecl* d, bool has_local) {
     d.base.varDeclBits.has_local = has_local;
 }
 
+public fn void VarDecl.setInitCall(VarDecl* d, bool has_init_call) {
+    d.base.varDeclBits.has_init_call = has_init_call;
+}
+
+public fn bool VarDecl.hasInitCall(VarDecl* d) {
+    return d.base.varDeclBits.has_init_call;
+}
+
 public fn void VarDecl.setAttrWeak(VarDecl* d) {
     d.base.varDeclBits.attr_weak = 1;
 }
@@ -282,6 +291,7 @@ fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
     if (d.base.varDeclBits.auto_file) out.add(" auto_file");
     if (d.base.varDeclBits.auto_line) out.add(" auto_line");
     if (d.base.varDeclBits.printf_format) out.add(" printf_format");
+    if (d.base.varDeclBits.has_init_call) out.add(" init_call");
     d.base.printBits(out);
     d.base.printAttrs(out);
     out.color(col_Value);

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -29,7 +29,11 @@ fn void Generator.emitVarDecl(Generator* gen, VarDecl* vd, string_buffer.Buf* ou
     d.setGenerated();
     Expr* ie = vd.getInit();
     if (ie && emit_init) {
-        out.add(" = ");
+        if (vd.hasInitCall()) {
+            out.add("; ");
+        } else {
+            out.add(" = ");
+        }
         gen.emitExpr(out, ie);
     }
 }

--- a/parser/ast_builder.c2
+++ b/parser/ast_builder.c2
@@ -292,7 +292,8 @@ public fn Stmt* Builder.actOnVarDeclStmt(Builder* b,
                                            const TypeRefHolder* ref,
                                            SrcLoc assignLoc,
                                            Expr* initValue,
-                                           bool has_local)
+                                           bool has_local,
+                                           bool has_init_call)
 {
     VarDecl* d = VarDecl.create(b.context,
                                 VarDeclKind.LocalVar,
@@ -304,6 +305,7 @@ public fn Stmt* Builder.actOnVarDeclStmt(Builder* b,
                                 assignLoc,
                                 initValue);
     d.setLocal(has_local);
+    d.setInitCall(has_init_call);
 
     return cast<Stmt*>(DeclStmt.create(b.context, d));
 }

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -589,6 +589,9 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
 
     p.parseOptionalAttributes();
 
+    if (p.tok.kind == Kind.Dot)
+        p.error("global variables cannot have an init call");
+
     if (p.tok.kind == Kind.Equal) {
         assignLoc = p.tok.loc;
         p.consumeToken();

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -126,6 +126,9 @@ fn bool Parser.isTypeSpec(Parser* p) {
             lookahead++;
             break;
         case Dot:
+            if (state == 4) {
+                return true; // init call
+            }
             if (state == 0) {
                 kind = p.tokenizer.lookahead(lookahead+1, nil);
                 if (kind != Kind.Identifier) {
@@ -530,6 +533,7 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal) {
     p.consumeToken();
 
     // TODO same as parseVarDecl()
+    bool has_init_call = false;
     bool need_semi = true;
     Expr* initValue = nil;
     SrcLoc assignLoc = 0;
@@ -540,6 +544,26 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal) {
         p.consumeToken();
         initValue = p.parseInitValue(&need_semi, false);
         break;
+    case Dot:
+        if (p.tokenizer.lookahead(1, nil) == Kind.Identifier
+        &&  p.tokenizer.lookahead(2, nil) == Kind.LParen) {
+            if (has_local)
+                p.error("local qualified variables cannot have an init call");
+            if (!checkSemi)
+                p.error("cannot use an init call inside a condition");
+            p.consumeToken();
+            Ref[2] refs;
+            refs[0].loc = loc;
+            refs[0].name_idx = name;
+            refs[1].loc = p.tok.loc;
+            refs[1].name_idx = p.tok.name_idx;
+            Expr* func = p.builder.actOnMemberExpr(nil, refs, 2);
+            p.consumeToken();
+            initValue = p.parseCallExpr(func);
+            has_init_call = true;
+            break;
+        }
+        break;
     case LSquare:
         p.error("array indices should go after type");
         break;
@@ -547,7 +571,7 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal) {
         break;
     }
 
-    Stmt* s = p.builder.actOnVarDeclStmt(name, loc, &ref, assignLoc, initValue, has_local);
+    Stmt* s = p.builder.actOnVarDeclStmt(name, loc, &ref, assignLoc, initValue, has_local, has_init_call);
     if (checkSemi && need_semi) {
         p.expectAndConsume(Kind.Semicolon);
     }

--- a/test/init/init_call_bad_for.c2
+++ b/test/init/init_call_bad_for.c2
@@ -1,0 +1,12 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+fn void test4() {
+    for (Foo foo.init(1); false;)  // @error{cannot use an init call inside a condition}
+        return;
+}

--- a/test/init/init_call_bad_global.c2
+++ b/test/init/init_call_bad_global.c2
@@ -1,0 +1,9 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+Foo f.init(1);  // @error{global variables cannot have an init call}

--- a/test/init/init_call_bad_if.c2
+++ b/test/init/init_call_bad_if.c2
@@ -1,0 +1,12 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+fn void test2() {
+    if (Foo foo.init(1))  // @error{cannot use an init call inside a condition}
+        return;
+}

--- a/test/init/init_call_bad_local.c2
+++ b/test/init/init_call_bad_local.c2
@@ -1,0 +1,12 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+fn void test1() {
+    Foo foo.init(1);  // This one is OK
+    local Foo foo1.init(1);  // @error{local qualified variables cannot have an init call}
+}

--- a/test/init/init_call_bad_non_existent.c2
+++ b/test/init/init_call_bad_non_existent.c2
@@ -1,0 +1,11 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+fn void test7() {
+    Foo foo.from_int(1);  // @error{no member named 'from_int' in struct 'test.Foo'}
+}

--- a/test/init/init_call_bad_static.c2
+++ b/test/init/init_call_bad_static.c2
@@ -1,0 +1,11 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn i32 Foo.init(i32 v) { return v + 1; }
+
+fn void test6() {
+    Foo foo.init(1);  // @error{cannot access static type-function through variable}
+}

--- a/test/init/init_call_bad_while.c2
+++ b/test/init/init_call_bad_while.c2
@@ -1,0 +1,12 @@
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+fn void test3() {
+    while (Foo foo.init(1))  // @error{cannot use an init call inside a condition}
+        return;
+}

--- a/test/init/init_call_ok.c2t
+++ b/test/init/init_call_ok.c2t
@@ -1,0 +1,38 @@
+// @recipe bin
+    $warnings no-unused
+    $backend c
+
+// @file{file1}
+module test;
+
+type Foo struct {
+    i32 v;
+}
+
+fn void Foo.init(Foo* f, i32 v) { f.v = v; }
+
+public fn i32 main() {
+    Foo foo.init(1);
+    return foo.v;
+}
+// @expect{atleast, cgen/build.c}
+typedef struct test_Foo_ test_Foo;
+
+struct test_Foo_ {
+   int32_t v;
+};
+
+static void test_Foo_init(test_Foo* f, int32_t v);
+int32_t main(void);
+
+static void test_Foo_init(test_Foo* f, int32_t v)
+{
+   f->v = v;
+}
+
+int32_t main(void)
+{
+   test_Foo foo; test_Foo_init(&foo, 1);
+   return foo.v;
+}
+


### PR DESCRIPTION
* local variables can have a member call in the definition to define the object and call the initializer in a single statement. eg: `TypeRefHolder rtype.init();`, `Point p.init(x, y);`...