### PR TITLE
Compiler: fix sanitary feature definitions

### DIFF
--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -284,9 +284,9 @@ fn void Compiler.build(Compiler* c,
 
     c.addGlobalDefine("SYSTEM", c.targetInfo.getSystemName());
     c.addGlobalDefine("ARCH", c.targetInfo.getArchName());
-    if (opts.asan) c.addGlobalDefine("__ASAN__", "1");
-    if (opts.msan) c.addGlobalDefine("__MSAN__", "1");
-    if (opts.ubsan) c.addGlobalDefine("__UBSAN__", "1");
+    if (opts.asan) c.addFeature("__ASAN__", "1");
+    if (opts.msan) c.addFeature("__MSAN__", "1");
+    if (opts.ubsan) c.addFeature("__UBSAN__", "1");
 
     c.parser = c2_parser.create(sm,
                                 diags,
@@ -661,6 +661,11 @@ fn void Compiler.checkMain(Compiler* c) {
     }
 }
 
+fn void Compiler.addFeature(Compiler* c, const char* str, const char* value) {
+    // TODO: handle value
+    c.target.addFeature(c.auxPool.addStr(str, true));
+}
+
 fn void Compiler.addGlobalDefine(Compiler* c, const char* prefix, const char* tail) {
     char[32] tmp;
     stdio.snprintf(tmp, 32, "%s_%s", prefix, tail);
@@ -669,6 +674,5 @@ fn void Compiler.addGlobalDefine(Compiler* c, const char* prefix, const char* ta
         tmp[i] = (ch == '-') ? '_' : cast<char>(ctype.toupper(ch));
     }
 
-    c.target.addFeature(c.auxPool.addStr(tmp, true));
+    c.addFeature(tmp, "1");
 }
-

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -364,7 +364,7 @@ fn void parse_opts(i32 argc, char** argv, compiler.Options* comp_opts, Options* 
         exit(EXIT_FAILURE);
     }
     if (opts.use_qbe_backend && opts.use_ir_backend) {
-        console.error("only one backend can be selected");
+        console.error("c2c: only one backend can be selected");
         exit(EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
* add `Compiler.addFeature` to define a feature symbol
* fix definition of `__ASAN__`, `__MSAN__` and `__UBSAN__` when compiling with satinary options enabled.  Previous code used to define `__ASAN___1`.