### PR TITLE
Compiler: add call tracing feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ test: output/tester/tester
 testv: output/tester/tester
 	@output/tester/tester -v test
 
+trace: $(C2C)
+	$(C2C) c2c --trace-calls -o c2c_trace
+	C2TRACE="min=10;min2=1;mode=3;name=*;fd=2" output/c2c_trace/c2c_trace c2c --test 2> output/c2c/calls
+
 errors:
 	@( grep -n 'error:' `find . -name build.log` | sed -E 's/build.log:[0-9]+://' ; true )
 

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -173,7 +173,7 @@ public fn bool CallExpr.hasAutoArgs(const CallExpr* e) {
     return e.base.base.callExprBits.has_auto_args;
 }
 
-fn SrcLoc CallExpr.getStartLoc(const CallExpr* e) {
+public fn SrcLoc CallExpr.getStartLoc(const CallExpr* e) {
     return e.func.getStartLoc();
 }
 

--- a/common/build_target.c2
+++ b/common/build_target.c2
@@ -153,6 +153,10 @@ public fn void Target.free(Target* t) {
 
 public fn u32 Target.getNameIdx(const Target* t) { return t.name_idx; }
 
+public fn void Target.setNameIdx(Target* t, u32 name_idx) {
+    t.name_idx = name_idx;
+}
+
 public fn u32 Target.numFiles(const Target* t) { return t.num_files; }
 
 public fn u32 Target.numAsmFiles(const Target* t) { return t.asm_file_count; }

--- a/common/string_utils.c2
+++ b/common/string_utils.c2
@@ -51,3 +51,20 @@ public fn bool endsWith(const char* text, const char* tail) @(unused) {
     usize tlen = strlen(tail);
     return (tlen <= len && !memcmp(text + len - tlen, tail, tlen));
 }
+
+public fn const char* getBasename(const char* s) {
+    const char* base = s;
+    while (*s) {
+        if (*s++ == '/') base = s;
+    }
+    return base;
+}
+
+public fn const char* getExtension(const char* s) {
+    const char* ext = nil;
+    for (; *s; s++) {
+        if (*s == '/') ext = nil;
+        if (*s == '.') ext = s;
+    }
+    return ext ? ext : s;
+}

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -78,6 +78,7 @@ public type Options struct {
     bool print_reports;
     bool show_libs;
     bool print_ir;
+    bool trace_calls;
     bool asan;
     bool msan;
     bool ubsan;
@@ -498,7 +499,8 @@ fn void Compiler.build(Compiler* c,
                              &asm_files,
                              c.target.hasAsserts(),
                              c.target.getFastBuild() | c.opts.fast_build,
-                             c.opts.asan, c.opts.msan, c.opts.ubsan, c.opts.test_mode);
+                             c.opts.asan, c.opts.msan, c.opts.ubsan,
+                             c.opts.test_mode, c.opts.trace_calls);
         asm_files.free();
         u64 gen4 = utils.now();
         console.log_time("C generation", gen4 - gen3);

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -51,8 +51,10 @@ type Options struct {
     bool no_plugins;
     bool use_qbe_backend;
     bool use_ir_backend;
+    bool trace_calls;
     const char* build_file;
     const char* other_dir;
+    const char* output_name;
     string_list.List targets;
     string_list.List files;
 }
@@ -178,6 +180,7 @@ const char[] Usage_help =
     "  -i                use IR backend\n"
     "  -I                use IR backend and print generated IR\n"
     "  -m                print modules\n"
+    "  -o [file]         force the output name for a single target\n"
     "  -q                use QBE backend (EXPERIMENTAL, only for single files)\n"
     "  -Q                use QBE backend and print generated QBE code\n"
     "  -r                print reports\n"
@@ -200,6 +203,7 @@ const char[] Usage_help =
     "  --showplugins     print available plugins\n"
     "  --targets         show available targets in recipe\n"
     "  --test            test mode (do not check for main() function)\n"
+    "  --trace-calls     generate code that traces function calls\n"
     "  --version         print version\n";
 
 fn void usage() {
@@ -246,6 +250,9 @@ fn i32 parse_long_opt(i32 i, i32 argc, char** argv, compiler.Options* comp_opts,
         break;
     case "test":
         comp_opts.test_mode = true;
+        break;
+    case "trace-calls":
+        opts.trace_calls = true;
         break;
     case "asan":
         comp_opts.asan = true;
@@ -321,6 +328,11 @@ fn void parse_opts(i32 argc, char** argv, compiler.Options* comp_opts, Options* 
                 case 'm':
                     comp_opts.print_modules = true;
                     break;
+                case 'o':
+                    if (i==argc-1) missing_arg(arg);
+                    i++;
+                    opts.output_name = argv[i];
+                    break;
                 case 'q':
                     opts.use_qbe_backend = true;
                     break;
@@ -355,8 +367,8 @@ fn void parse_opts(i32 argc, char** argv, compiler.Options* comp_opts, Options* 
 
     u32 num_targets = opts.targets.length();
     u32 num_files = opts.files.length();
-    if (num_targets > 1 && num_files) {
-        console.error("c2c: multiple targets cannot be combined with <files>");
+    if (num_targets && num_files) {
+        console.error("c2c: recipe targets cannot be combined with <files>");
         exit(EXIT_FAILURE);
     }
     if (opts.use_qbe_backend && num_files != 1) {
@@ -365,6 +377,10 @@ fn void parse_opts(i32 argc, char** argv, compiler.Options* comp_opts, Options* 
     }
     if (opts.use_qbe_backend && opts.use_ir_backend) {
         console.error("c2c: only one backend can be selected");
+        exit(EXIT_FAILURE);
+    }
+    if (opts.output_name && num_targets > 1) {
+        console.error("c2c: option -o can only be used for a single target");
         exit(EXIT_FAILURE);
     }
 }
@@ -437,14 +453,14 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
     }
 
     if (c.opts.files.length()) {
-        // TODO: specify target using -o or use first filename base as target name
-        u32 target_name = c.opts.targets.length() ?
-            c.opts.targets.get_idx(0) :
-            c.auxPool.addStr("dummy", true);
+        // use basename of first filename as target name
+        const char* basename = string_utils.getBasename(c.opts.files.get(0));
+        const char* ext = string_utils.getExtension(basename);
+        u32 target_idx = c.auxPool.add(basename, cast<u32>(ext - basename), true);
         build_target.BackEndKind backend = build_target.BackEndKind.C;
         if (c.opts.use_qbe_backend) backend = build_target.BackEndKind.QBE;
         if (c.opts.use_ir_backend) backend = build_target.BackEndKind.IR;
-        build_target.Target* t = c.recipe.addTarget(target_name, 0, build_target.Kind.Executable);
+        build_target.Target* t = c.recipe.addTarget(target_idx, 0, build_target.Kind.Executable);
         t.setBackEnd(backend);
 
         for (u32 i = 0; i < c.opts.files.length(); i++)
@@ -543,10 +559,24 @@ fn void Context.handle_plugins(Context* c) {
 
 fn bool Context.build_target(Context* c,
                              build_target.Target* target,
-                             const char* target_name) {
+                             const char* target_name)
+{
+    u32 num_errors = c.diags.getNumErrors();
     if (c.opts.force_warnings) target.enableWarnings();
 
-    console.log("building %s", target_name);
+    if (c.opts.output_name) {
+        console.log("building %s as %s", target_name, c.opts.output_name);
+        target_name = c.opts.output_name;
+        target.setNameIdx(c.auxPool.addStr(target_name, true));
+    } else {
+        console.log("building %s", target_name);
+    }
+
+    c.comp_opts.trace_calls = c.opts.trace_calls;
+    if (c.opts.trace_calls && target.getNoLibC()) {
+        c.comp_opts.trace_calls = false;
+        console.warn("c2c: disabling --trace-calls for nolibc target %s", target_name);
+    }
 
     // load target-specific plugins from recipe
     c.pl = target.getPlugins();
@@ -574,9 +604,10 @@ fn bool Context.build_target(Context* c,
 
     compiler.build(c.auxPool, c.sm, c.diags, c.build_info, target, &c.comp_opts, &c.pluginHandler);
 
+    // TODO unload target-specific plugins?
     // TODO fix build_file
     if (c.recipe_id != -1) c.sm.clear(c.recipe_id);
-    return c.diags.getNumErrors() != 0;
+    return c.diags.getNumErrors() > num_errors;
 }
 
 fn bool Context.build_targets(Context* c) {
@@ -589,7 +620,7 @@ fn bool Context.build_targets(Context* c) {
         u32 target_idx = target.getNameIdx();
         const char* target_name = c.auxPool.idx2str(target_idx);
         if (has_filter) {
-            if (!c.opts.targets.contains_idx(target_idx)) break;
+            if (!c.opts.targets.contains_idx(target_idx)) continue;
             c.opts.targets.del(target_idx);
         }
         if (c.opts.show_targets) {

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -60,8 +60,9 @@ fn void Fragment.free(Fragment* f) {
     stdlib.free(f);
 }
 
-
 type Generator struct {
+    string_pool.Pool* astPool;
+    string_pool.Pool* auxPool;
     string_buffer.Buf* out;
     const char* target;
     build_target.Kind target_kind;
@@ -76,6 +77,7 @@ type Generator struct {
     bool asan;
     bool msan;
     bool ubsan;
+    bool trace_calls;
 
     // set during generation
     bool cur_external;  // whether current component is external
@@ -98,6 +100,10 @@ type Generator struct {
     linked_list.Element free_list;
     linked_list.Element used_list;  // for c-file
     linked_list.Element header_fragments; // for header-file (if used)
+
+    TraceCallList calls;
+    StringList filenames;
+    StringList funcnames;
 }
 
 
@@ -764,6 +770,8 @@ fn void Generator.on_ast_decl(void* arg, AST* a) {
 fn void Generator.gen_func_proto(Generator* gen, FunctionDecl* fd, string_buffer.Buf* out) {
     Decl* d = cast<Decl*>(fd);
 
+    // TODO: add function definition location to gen.funcdata
+
     // template are generated as late as possible, since the Type might not be known yet
     if (fd.isTemplate()) return;
 
@@ -1142,6 +1150,7 @@ fn void Generator.init(Generator* gen,
     gen.imports.init(nil);  // note: cannot get string values! (not needed)
     gen.decls.init();
 
+    gen.astPool = astPool;
     gen.stdargName = astPool.addStr("stdarg", true);
 }
 
@@ -1155,6 +1164,9 @@ fn void Generator.free(Generator* gen) {
     gen.header.free();
     gen.imports.free();
     gen.decls.free();
+    gen.calls.free();
+    gen.filenames.free();
+    gen.funcnames.free();
 }
 
 fn void Generator.write(Generator* gen, const char* output_dir, const char* filename, string_buffer.Buf* buf) {
@@ -1182,7 +1194,7 @@ public fn void generate(string_pool.Pool* astPool,
                         string_list.List* asm_files,
                         bool enable_asserts,
                         bool fast_build, bool asan, bool msan, bool ubsan,
-                        bool test_mode)
+                        bool test_mode, bool trace_calls)
 {
     char[constants.Max_path] dir;
     stdio.sprintf(dir, "%s/%s", output_dir, Dir);
@@ -1194,11 +1206,13 @@ public fn void generate(string_pool.Pool* astPool,
 
     Generator gen;
     gen.init(astPool, target, kind, output_dir, dir, sm, build_info, mainFunc);
+    gen.auxPool = auxPool;
     gen.enable_asserts = enable_asserts;
     gen.fast_build = fast_build;
     gen.asan = asan;
     gen.msan = msan;
     gen.ubsan = ubsan;
+    gen.trace_calls = trace_calls;
     gen.targetInfo = targetInfo;
     gen.cgen_dir = dir;
     string_buffer.Buf* out = gen.out;
@@ -1236,7 +1250,9 @@ public fn void generate(string_pool.Pool* astPool,
 
     mainComp.visitModules(Generator.on_module, &gen);
 
-    if (!fast_build) {
+    if (fast_build) gen.out.clear();
+    if (gen.trace_calls) gen.writeCalls(gen.out);
+    if (!fast_build || gen.trace_calls) {
         gen.write(dir, "build.c", gen.out);
     }
 
@@ -1377,6 +1393,8 @@ fn void Generator.emit_external_header(Generator* gen, bool enable_asserts, cons
             "    return idx;\n"
             "}\n"
         );
+
+    if (gen.trace_calls) gen.writeCallExterns(out);
 
     out.add("#endif\n");
 }

--- a/generator/c/c_generator_call.c2
+++ b/generator/c/c_generator_call.c2
@@ -54,7 +54,14 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
             assert(func.getKind() == ExprKind.Member);
             MemberExpr* m = cast<MemberExpr*>(func);
             dest = m.getFullDecl();
-            gen.emitCNameMod(out, dest, dest.getModule());
+            if (gen.trace_calls) {
+                out.print("(c2_trace_counts[%d]++, ",
+                          gen.addCall(dest.getFullName(), call.getStartLoc()));
+                gen.emitCNameMod(out, dest, dest.getModule());
+                out.add1(')');
+            } else {
+                gen.emitCNameMod(out, dest, dest.getModule());
+            }
             out.lparen();
             if (is_tf) {
                 // Do auto-conversions if needed (Foo -> Foo*, Foo* -> Foo)
@@ -71,9 +78,14 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
                 gen.emitMemberExprBase(out, func);
             }
         } else {
+            bool no_trace = false;
             // can be Member or Identifier
             if (func.getKind() == ExprKind.Identifier) {
                 IdentifierExpr* i = cast<IdentifierExpr*>(func);
+                // do not trace calls to va_start, va_arg, va_end...
+                const char *name = i.getName();
+                if (name && name[0] == 'v' && name[1] == 'a' && name[2] == '_')
+                    no_trace = true;
                 dest = i.getDecl();
             } else if (func.getKind() == ExprKind.Member) {
                 MemberExpr* m = cast<MemberExpr*>(func);
@@ -82,7 +94,14 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
                 func.dump();
                 assert(0);
             }
-            gen.emitExpr(out, func);
+            if (gen.trace_calls && !no_trace) {
+                out.print("(c2_trace_counts[%d]++, ",
+                          gen.addCall(dest.getFullName(), call.getStartLoc()));
+                gen.emitExpr(out, func);
+                out.add1(')');
+            } else {
+                gen.emitExpr(out, func);
+            }
             out.lparen();
         }
     }

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -104,6 +104,9 @@ fn void Generator.createMakefile(Generator* gen,
             const ast.Module* m = allmodules.at(i);
             if (!m.isExternal() && m.isUsed()) out.print(" %s.o", m.getName());
         }
+        if (gen.trace_calls) {
+            out.add(" build.o");
+        }
         out.newline();
     } else {
         out.add("objects := build.o\n");

--- a/generator/c/c_generator_trace.c2
+++ b/generator/c/c_generator_trace.c2
@@ -1,0 +1,348 @@
+/* Copyright 2022-2025 Bas van den Berg, Charlie Gordon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module c_generator;
+
+import src_loc local;
+import source_mgr;
+import string_buffer;
+
+import string;
+import stdlib;
+
+type TraceCall struct {
+    u8 filename_idx;
+    u8 column;
+    u16 line;
+    u16 caller_idx;
+    u16 callee_idx;
+}
+
+type TraceCallList struct {
+    TraceCall* array;
+    u32 count;
+    u32 capacity;
+}
+
+fn u32 TraceCallList.add(TraceCallList *cl, TraceCall call) {
+    if (cl.count >= cl.capacity) {
+        cl.capacity += cl.capacity / 2 + 16;
+        TraceCall *array2 = stdlib.malloc(cl.capacity * sizeof(TraceCall));
+        if (cl.array) {
+            string.memcpy(array2, cl.array, cl.count * sizeof(TraceCall));
+            stdlib.free(cl.array);
+        }
+        cl.array = array2;
+    }
+    u32 index = cl.count++;
+    cl.array[index] = call;
+    return index;
+}
+
+fn void TraceCallList.free(TraceCallList* cl) {
+    if (cl.array) {
+        stdlib.free(cl.array);
+        cl.array = nil;
+        cl.count = 0;
+        cl.capacity = 0;
+    }
+}
+
+type StringList struct {
+    u32* hash_array;
+    u32 hash_count;
+    u32 hash_capacity;
+    char **strings;
+    u32 string_count;
+    u32 string_capacity;
+    const char *last_string;
+    u32 last_index;
+}
+
+fn void StringList.free(StringList* sl) {
+    if (sl.strings) {
+        for (u32 i = 0; i < sl.string_count; i++) {
+            stdlib.free(sl.strings[i]);
+        }
+        stdlib.free(sl.strings);
+        stdlib.free(sl.hash_array);
+        string.memset(sl, 0, sizeof(StringList));
+    }
+}
+
+fn u32 StringList.length(StringList* sl) {
+    return sl.string_count;
+}
+
+fn const char* StringList.get(StringList* sl, u32 i) {
+    return sl.strings[i];
+}
+
+const u32 HASH_INITIAL = 13;
+const u32 HASH_PRIME = 17;
+const u32 HASH_BUCKETS = 256;
+
+fn u32 StringList.add(StringList* sl, const char* s, bool check_last) {
+    if (check_last && s == sl.last_string) return sl.last_index;
+    sl.last_string = s;
+
+    // FNV-1a hash
+    u32 hash = HASH_INITIAL;
+    for (u32 i = 0; s[i]; i++) {
+        hash ^= s[i];
+        hash *= HASH_PRIME;
+    }
+    u32 bucket = hash % HASH_BUCKETS;
+    if (sl.hash_array) {
+        for (u32 i = bucket;; i--) {
+            u32 ii = sl.hash_array[i];
+            u32 n = cast<u16>(ii);
+            if (!string.strcmp(sl.strings[n], s)) return sl.last_index = n;
+            i = ii >> 16;
+            if (i == 0) break;
+        }
+    }
+    if (!sl.hash_capacity) {
+        sl.hash_capacity = HASH_BUCKETS + 32;
+        sl.hash_count = HASH_BUCKETS;
+        sl.hash_array = stdlib.calloc(sl.hash_capacity * sizeof(u32), 1);
+    }
+    u32 slot = sl.string_count;
+    if (sl.hash_array[bucket]) {
+        if (sl.hash_count >= sl.hash_capacity) {
+            sl.hash_capacity += sl.hash_capacity / 2;
+            u32 *hash_array2 = stdlib.malloc(sl.hash_capacity * sizeof(u32));
+            string.memcpy(hash_array2, sl.hash_array, sl.hash_count * sizeof(u32));
+            stdlib.free(sl.hash_array);
+            sl.hash_array = hash_array2;
+        }
+        u32 next = sl.hash_count++;
+        sl.hash_array[next] = sl.hash_array[bucket];
+        slot |= (next + 1) << 16;
+    }
+    sl.hash_array[bucket] = slot;
+#if 0
+    for (u32 i = sl.string_count; i-- > 0;) {
+        if (!string.strcmp(sl.strings[i], s)) return i;
+    }
+#endif
+    if (sl.string_count >= sl.string_capacity) {
+        sl.string_capacity += sl.string_capacity / 2 + 16;
+        char **strings2 = stdlib.malloc(sl.string_capacity * sizeof(char *));
+        if (sl.strings) {
+            string.memcpy(strings2, sl.strings, sl.string_count * sizeof(char *));
+            stdlib.free(sl.strings);
+        }
+        sl.strings = strings2;
+    }
+    u32 index = sl.string_count++;
+    sl.strings[index] = string.strdup(s);
+    return sl.last_index = index;
+}
+
+fn u32 Generator.addCall(Generator* gen, const char* funcname, SrcLoc loc) {
+    source_mgr.Location location = gen.sm.locate(loc);
+    TraceCall call = {
+        .filename_idx = cast<u8>(gen.filenames.add(location.filename, true)),
+        .column = cast<u8>(location.column),
+        .line = cast<u16>(location.line),
+        .callee_idx = cast<u16>(gen.funcnames.add(funcname, false)),
+        .caller_idx = cast<u16>(gen.cur_function ?
+                                gen.funcnames.add(gen.cur_function.asDecl().getFullName(), false) : 0),
+    }
+    return gen.calls.add(call);
+}
+
+fn void Generator.writeCalls(Generator* gen, string_buffer.Buf* out) {
+    if (!gen.trace_calls)
+        return;
+
+    out.add("static const char *c2_filenames[] = {\n");
+    u32 n = gen.filenames.length();
+    for (u32 i = 0; i < n; i++) {
+        out.print("    \"%s\",\n", gen.filenames.get(i));
+    }
+    out.add("};\n\n");
+
+    out.add("struct c2_func_t {\n"
+            "    unsigned count;\n"
+            "    unsigned short filename_idx;\n"
+            "    unsigned short line;\n"
+            "    const char *funcname;\n"
+            "};\n"
+            "static struct c2_func_t c2_func_data[] = {\n"
+            );
+    // TODO: store function definition location
+    n = gen.funcnames.length();
+    for (u32 i = 0; i < n; i++) {
+        out.print("    { 0, 0, 0, \"%s\" },\n", gen.funcnames.get(i));
+    }
+    out.add("};\n\n");
+
+    out.add("struct c2_trace_t {\n"
+            "    unsigned count;\n"
+            "    unsigned char filename_idx;\n"
+            "    unsigned char column;\n"
+            "    unsigned short line;\n"
+            "    unsigned short caller_idx;\n"
+            "    unsigned short callee_idx;\n"
+            "};\n"
+            "static struct c2_trace_t c2_trace_data[] = {\n"
+            );
+    for (u32 i = 0; i < gen.calls.count; i++) {
+        out.print("    { 0, %d, %d, %d, %d, %d },\n",
+                  gen.calls.array[i].filename_idx, gen.calls.array[i].column, gen.calls.array[i].line,
+                  gen.calls.array[i].caller_idx, gen.calls.array[i].callee_idx);
+    }
+    out.add("};\n\n");
+
+    out.add("static const unsigned c2_trace_length = sizeof(c2_trace_data) / sizeof(c2_trace_data[0]);\n"
+            "unsigned c2_trace_counts[sizeof(c2_trace_data) / sizeof(c2_trace_data[0])];\n\n"
+            );
+    out.add("char *getenv(const char *);\n"
+            "int dprintf(int fd, const char *format, ...);\n"
+            "int strcmp(const char *s1, const char *s2);\n"
+            "typedef unsigned long size_t;\n"
+            "void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));\n"
+            "int sscanf(const char *, const char *, ...);\n\n"
+            );
+    out.add("static int c2_match_name(const char *name, const char *pattern) {\n"
+            "    for (;;) {\n"
+            "        char c1, c2;\n"
+            "        while ((c1 = *name++) == (c2 = *pattern++)) {\n"
+            "            if (!c1) return 1;\n"
+            "        }\n"
+            "        if (c2 == '?') {\n"
+            "            if (c1) continue;\n"
+            "            return 0;\n"
+            "        }\n"
+            "        if (c2 == '*') {\n"
+            "            c2 = *pattern++;\n"
+            "            if (!c2 || c2 == ',' || c2 == ';') return 1;\n"
+            "            for (; c1; c1 = *name++) {\n"
+            "                if (c1 == c2 && c2_match_name(name, pattern)) return 1;\n"
+            "            }\n"
+            "            return 0;\n"
+            "        }\n"
+            "        return (!c1 && (c2 == ',' || c2 == ';'));\n"
+            "    }\n"
+            "}\n\n"
+            );
+    out.add("static int c2_cmp_funcs(const void *a, const void *b) {\n"
+            "    const struct c2_trace_t *aa = a;\n"
+            "    const struct c2_trace_t *bb = b;\n"
+            "    struct c2_func_t *fa = &c2_func_data[aa->callee_idx];\n"
+            "    struct c2_func_t *fb = &c2_func_data[bb->callee_idx];\n"
+            "    if (fa->count != fb->count) return fa->count < fb->count ? 1 : -1;\n"
+            "    if (fa != fb) return strcmp(fa->funcname, fb->funcname);\n"
+            "    return (aa->count < bb->count) - (aa->count > bb->count);\n"
+            "}\n\n"
+            );
+    out.add("static int c2_cmp_calls(const void *a, const void *b) {\n"
+            "    const struct c2_trace_t *aa = a;\n"
+            "    const struct c2_trace_t *bb = b;\n"
+            "    return (aa->count < bb->count) - (aa->count > bb->count);\n"
+            "}\n\n"
+            );
+    out.add("void __attribute__((destructor)) c2_trace_calls(void) {\n"
+            "    const char *p = getenv(\"C2TRACE\");\n"
+            "    const char *pattern = 0;\n"
+            "    if (!p || !*p) return;\n"
+            "    unsigned min = 1, min2 = 1;\n"
+            "    int pos = 0, mode = 3, fd = 1, indent = 2;\n"
+            "    for (; *p; p += pos) {\n"
+            "        pos = 0;\n"
+            "        sscanf(p, \" %n%*1[;] %n\", &pos, &pos);\n"
+            "        if (pos) continue;\n"
+            "        sscanf(p, \"min%*1[=]%u%n\", &min, &pos);\n"
+            "        if (pos) continue;\n"
+            "        sscanf(p, \"min2%*1[=]%u%n\", &min2, &pos);\n"
+            "        if (pos) continue;\n"
+            "        sscanf(p, \"indent%*1[=]%u%n\", &indent, &pos);\n"
+            "        if (pos) continue;\n"
+            "        sscanf(p, \"mode%*1[=]%d%n\", &mode, &pos);\n"
+            "        if (pos) continue;\n"
+            "        sscanf(p, \"fd%*1[=]%d%n\", &fd, &pos);\n"
+            "        if (pos) continue;\n"
+            "        sscanf(p, \"name%*1[=]%n\", &pos);\n"
+            "        if (pos) {\n"
+            "            pattern = p + pos;\n"
+            "            while (p[pos] && p[pos] != ';') pos++;\n"
+            "            continue;\n"
+            "        }\n"
+            "        sscanf(p, \"%*s%*1[=]%n%*[^;]%n\", &pos, &pos);\n"
+            "        if (pos) continue;\n"
+            "        break;\n"
+            "    }\n"
+            "    if (!mode) return;\n"
+            "    if (!pattern) pattern = p;\n"
+            "    if (!*pattern) pattern = \"*\";\n"
+            "    unsigned *counts = c2_trace_counts;\n"
+            "    struct c2_trace_t* data = c2_trace_data;\n"
+            "    unsigned n = c2_trace_length;\n"
+            "    for (unsigned i = 0; i < n; i++) {\n"
+            "        data[i].count = counts[i];\n"
+            "        c2_func_data[data[i].callee_idx].count += counts[i];\n"
+            "    }\n"
+            "    if (mode == 2) {\n"
+            "        qsort(data, n, sizeof(*data), c2_cmp_calls);\n"
+            "        indent = 0;\n"
+            "        min2 = min;\n"
+            "    } else {\n"
+            "        qsort(data, n, sizeof(*data), c2_cmp_funcs);\n"
+            "    }\n"
+            "    struct c2_func_t *last = 0;\n"
+            "    int show = 0;\n"
+            "    for (unsigned i = 0; i < n; i++) {\n"
+            "        struct c2_trace_t *cp = &data[i];\n"
+            "        struct c2_func_t *func = &c2_func_data[cp->callee_idx];\n"
+            "        unsigned count1 = func->count;\n"
+            "        unsigned count2 = cp->count;\n"
+            "        if (count1 < min) continue;\n"
+            "        if (func != last) {\n"
+            "            show = 0;\n"
+            "            for (const char *p = pattern; *p;) {\n"
+            "                if (c2_match_name(func->funcname, p)) {\n"
+            "                    show = mode & 2;\n"
+            "                    if (mode & 1) {\n"
+            "                        dprintf(fd, \"%.*s%s: %u call%.*s\\n\", show, \"\\n\",\n"
+            "                                func->funcname, count1, count1 != 1, \"s\");\n"
+            "                    }\n"
+            "                    break;\n"
+            "                }\n"
+            "                char c;\n"
+            "                while ((c = *p++) != 0 && c != ',' && c != ';') continue;\n"
+            "                if (c != ',') break;\n"
+            "            }\n"
+            "            last = func;\n"
+            "        }\n"
+            "        if (show && count2 >= min2) {\n"
+            "            dprintf(fd, \"%*s%s:%d:%d: %s: %u call%.*s from %s\\n\",\n"
+            "                    indent, \"\",\n"
+            "                    c2_filenames[cp->filename_idx], cp->line, cp->column,\n"
+            "                    func->funcname, count2, count2 != 1, \"s\",\n"
+            "                    c2_func_data[cp->caller_idx].funcname);\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+            );
+}
+
+fn void Generator.writeCallExterns(Generator* gen, string_buffer.Buf* out) {
+    out.add("extern unsigned c2_trace_counts[];\n"
+            "extern void c2_trace_calls(void);\n"
+            "extern int atexit(void (*func)(void));\n"
+            );
+}

--- a/recipe.txt
+++ b/recipe.txt
@@ -249,6 +249,7 @@ executable c2c
     generator/c/c_generator_pure_call.c2
     generator/c/c_generator_special.c2
     generator/c/c_generator_stmt.c2
+    generator/c/c_generator_trace.c2
     generator/c/dep_finder.c2
 
     generator/generator_utils.c2


### PR DESCRIPTION
* add `--trace-calls` command line option
* generate code that counts function and method calls
* selectively output statistics based on `C2TRACE` environment variable
* syntax: C2TRACE="[min=val,][mask=val,][name=]pattern" where:
  * min=val specifies the minimum number of calls to output (default=1)
  * mask=val specifies what to output (1:functions, 2:calls, 3:both)
  * name=pattern is a comma separated list of shell glob expressions to filter the function names to output