### PR TITLE
Syntax: add support for raw strings

### DIFF
--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -45,6 +45,7 @@ type Action enum u8 {
     RSQUARE,
     NEWLINE,
     EXCLAIM,
+    BQUOTE,
     DQUOTE,
     SQUOTE,
     POUND,
@@ -142,11 +143,12 @@ const Action[256] Char_lookup = {
     ['Y'] = Action.IDENT,
     ['Z'] = Action.IDENT,
     ['['] = Action.LSQUARE,
-    ['\\'] = Action.TABSPACE, // only in skipped parts, treat as whitespace
+    ['\\'] = Action.INVALID, // invalid in code
     [']'] = Action.RSQUARE,
     ['^'] = Action.CARET,
     ['_'] = Action.IDENT,   // for parsing libs
 // 96 - 111
+    ['`'] = Action.BQUOTE,
     ['a'] = Action.IDENT,
     ['b'] = Action.IDENT,
     ['c'] = Action.IDENT,
@@ -402,6 +404,9 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
             } else {
                 result.kind = Kind.Exclaim;
             }
+            return;
+        case BQUOTE:
+            t.lex_raw_string_literal(result);
             return;
         case DQUOTE:
             t.lex_string_literal(result);
@@ -1182,6 +1187,122 @@ fn void Tokenizer.lex_char_literal(Tokenizer* t, Token* result) {
     result.len = cast<u16>(t.cur - start);
 }
 
+fn void Tokenizer.lex_raw_string_literal(Tokenizer* t, Token* result) {
+    result.kind = Kind.StringLiteral;
+    result.raw = 1;
+    const char* start = t.cur;
+
+    t.buf.clear();
+    // count the number of backticks that serve as the rawstring delimiter
+    u32 count = 1;
+    while (*++t.cur == '`') count++;
+
+    const char* p = t.cur;
+    const char* bol = p;
+    u32 indent = 0;
+    bool at_bol = false;
+
+    // check for tagged multi-line, compute indent
+    if (count >= 3) {
+        // check if the rawstring is multi-line
+        for (; *p && *p != '\n'; p++) {
+            if (*p == '`' && !string.memcmp(p, start, count))
+                break;
+        }
+        if (*p == '\n') {
+            // is multi-line: skip tag line, contents starts here
+            p++;
+            t.cur = p;
+            at_bol = true;
+            // determine the indentation of the first non-blank line
+            for (;; p++) {
+                for (bol = p; *p == ' ' || *p == '\t'; p++) continue;
+                indent = cast<u32>(p - bol);
+                if (*p == '\r') p++;
+                if (*p != '\n') break;
+            }
+            // check if the ``` is on its own line
+            for (p = start;;) {
+                if (p == t.input_start || p[-1] == '\n') {
+                    // if ``` is on its own line, it determines the indentation
+                    bol = p;
+                    indent = cast<u32>(start - bol);
+                    break;
+                }
+                p--;
+                if (*p != ' ' && *p != '\t') break;
+            }
+            // bol[0...indent] is the block indentation
+        }
+    }
+    for (p = t.cur;;) {
+        if (at_bol) {
+            at_bol = false;
+            u32 i;
+            for (i = 0; i < indent && p[i] == bol[i]; i++) continue;
+            p += i;
+            t.cur = p;
+            if (i < indent) {
+                // if blank line or end line, just skip the insufficient indentation
+                if (*p == '\n' || *p == '\r' || !*p || !string.strncmp(p, start, count)) continue;
+                t.error(result, "raw string indentation error: expected %d %s%.*s", indent,
+                        *bol == '\t' ? "tab" : "space", indent > 1 ? 1 : 0, "s");
+                return;
+            }
+        }
+        while (*p && *p >= ' ' && *p < 0x7F && *p != '`')
+            p++;
+        t.buf.add2(t.cur, cast<u32>(p - t.cur));
+        t.cur = p;
+        switch (*p) {
+        case '\0':
+            t.cur = start;  // make error point to beginning of rawstring
+            t.error(result, "unterminated %s", "raw string");
+            return;
+        case '\t':  // accept TABs
+            p++;
+            continue;
+        case '\r':
+            if (p[1] != '\n') goto invalid;
+            p++;
+            fallthrough;
+        case '\n':
+            t.buf.add1('\n');
+            p++;
+            t.cur = p;
+            at_bol = true;
+            continue;
+        case '`':
+            u32 i;
+            for (i = 1; *++p == '`'; i++) continue;
+            if (i < count) continue;
+            // if extra backquotes, they are part of the rawstring
+            if (i > count) t.buf.add2(t.cur, i - count);
+            t.cur += i; // skip string terminator
+            u32 len = t.buf.size();
+            result.text_len = len;
+            result.text_idx = t.pool.add(t.buf.data(), len, true);
+            result.len = cast<u16>(t.cur - start);
+            return;
+        default:
+            if (*p >= 0x80) {
+                u32 cc;
+                u32 nc = utf8.decode(p, 4, &cc);
+                if (nc > 0) {
+                    p += nc;
+                    continue;
+                } else {
+                    t.error(result, "invalid UTF-8 sequence");
+                    return;
+                }
+            }
+        invalid:
+            t.error(result, "invalid character 0x%02X in %s", *p, "raw string");
+            return;
+        }
+    }
+}
+
 fn void Tokenizer.lex_string_literal(Tokenizer* t, Token* result) {
     result.kind = Kind.StringLiteral;
     const char* start = t.cur;
@@ -1771,6 +1892,9 @@ fn bool Tokenizer.skip_feature(Tokenizer* t, Token* result) {
         case '\'':
             p = skip_string_literal(p - 1);
             break;
+        case '`':
+            p = skip_raw_string_literal(p - 1);
+            break;
         case '/':
             if (*p == '/') {
                 p = skip_line_comment(p + 1);
@@ -1813,6 +1937,20 @@ fn const char *skip_string_literal(const char *p) {
         }
     }
     return p;   // TODO detect this code as unreachable
+}
+
+fn const char *skip_raw_string_literal(const char *p) {
+    u32 count;
+    for (count = 0; *p == '`'; count++) p++;
+
+    while (*p) {
+        if (*p++ == '`') {
+            u32 i;
+            for (i = 1; *p == '`'; i++) p++;
+            if (i >= count) break;
+        }
+    }
+    return p;
 }
 
 fn const char *skip_line_comment(const char *p) {

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -293,6 +293,7 @@ public type Token struct {
     Kind kind : 8;
     bool done : 1;
     u8 radix : 2;   // number_radix.Radix: for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
+    u8 raw : 1;     // for StringLiteral
     union {
         const char* error_msg;  // ERROR
         struct {           // StringLiteral, LineComment, BlockComment

--- a/test/parser/invalid_char_96.c2
+++ b/test/parser/invalid_char_96.c2
@@ -1,4 +1,4 @@
 // @warnings{no-unused}
 module test;
 
-`    // @error{invalid char '`'}
+\    // @error{invalid char '\'}

--- a/test/parser/raw_string.c2t
+++ b/test/parser/raw_string.c2t
@@ -1,0 +1,127 @@
+// @recipe lib static
+    $warnings no-unused
+    $backend c fast
+    $export foo
+
+// @file{file1}
+module foo;
+
+const char[] Basic = `abcd`;
+static_assert(5, sizeof(Basic));
+
+const char[] Esc = `foo\n`;
+static_assert(6, sizeof(Esc));
+
+const char[] Backtick1 = ``a`b``;
+static_assert(4, sizeof(Backtick1));
+
+const char[] Backtick2 = ```
+    `````;
+static_assert(3, sizeof(Backtick2));
+
+const char[] Text =
+    `first`
+    " second"
+    ` third`;
+
+static_assert(19, sizeof(Text));
+
+const char[] Text2 =
+    `foo\n`
+    ``bar\n``
+    ```faa\n```;
+static_assert(16, sizeof(Text2));
+
+// escape sequences are not parsed in raw strings
+const char[] Text3a = `\123`;
+static_assert(5, sizeof(Text3a));
+const char[] Text3 = `\1` `23`;
+static_assert(5, sizeof(Text3));
+
+// multi-line raw strings may contain newlines
+const char[] Text4 = `abc
+hgi`;
+static_assert(8, sizeof(Text4));
+
+const char[] Text4a = ``abc
+hgi``;
+static_assert(8, sizeof(Text4a));
+
+// tagged multi-line raw string
+const char[] Text4b = ```abc
+hgi```;
+static_assert(4, sizeof(Text4b));
+
+// multi-line raw string with indentation
+const char[] Text5 = ```
+    abc
+    hgi```;
+static_assert(8, sizeof(Text5));
+
+// multi-line raw string with indentation and trailing newline
+const char[] Text6 = ```
+    abc
+    hgi
+    ```;
+static_assert(9, sizeof(Text6));
+
+// tagged multi-line raw string with indentation and trailing newline
+const char[] Text7 = ```c2
+    if (abc)
+        return `x'"'`;
+
+    return "`'";
+    ```;
+static_assert(43, sizeof(Text7));
+
+// tagged multi-line raw string with extra indentation and trailing newline
+const char[] Text8 =
+    ```c2
+        if (abc)
+            return `x'"'`;
+
+        return "`'";
+    ```;
+static_assert(55, sizeof(Text8));
+
+// tagged multi-line raw string with spaces
+const char[] Text9 =
+    ```c2
+        
+        
+        ```;
+static_assert(15, sizeof(Text9));
+
+// other tagged multi-line raw string with spaces
+const char[] Text10 = ```c2
+        
+    ```;
+static_assert(6, sizeof(Text10));
+
+// other tagged multi-line raw string with tabs
+const char[] Text11 =
+	```c2
+		return 1;
+	```;
+static_assert(12, sizeof(Text11));
+
+// @expect{atleast, cgen/foo.c}
+#include "foo.h"
+static const char foo_Basic[5] = "abcd";
+static const char foo_Esc[6] = "foo\\n";
+static const char foo_Backtick1[4] = "a`b";
+static const char foo_Backtick2[3] = "``";
+static const char foo_Text[19] = "first second third";
+static const char foo_Text2[16] = "foo\\nbar\\nfaa\\n";
+static const char foo_Text3a[5] = "\\123";
+static const char foo_Text3[5] = "\\123";
+static const char foo_Text4[8] = "abc\nhgi";
+static const char foo_Text4a[8] = "abc\nhgi";
+static const char foo_Text4b[4] = "hgi";
+static const char foo_Text5[8] = "abc\nhgi";
+static const char foo_Text6[9] = "abc\nhgi\n";
+static const char foo_Text7[43] = "if (abc)\n    return `x'\"'`;\n\nreturn \"`'\";\n";
+static const char foo_Text8[55] = "    if (abc)\n        return `x'\"'`;\n\n    return \"`'\";\n";
+static const char foo_Text9[15] = "    \n    \n    ";
+static const char foo_Text10[6] = "    \n";
+static const char foo_Text11[12] = "\treturn 1;\n";

--- a/test/parser/raw_string_indent_error.c2
+++ b/test/parser/raw_string_indent_error.c2
@@ -1,0 +1,11 @@
+module test;
+
+// this one is OK
+const char* s1 = ```
+    Hello
+ ```;
+
+// this one has inconsistent indentation
+const char* s2 = ```
+    Hello
+  error```;   // @error{raw string indentation error: expected 4 spaces}

--- a/test/parser/raw_string_unterminated.c2
+++ b/test/parser/raw_string_unterminated.c2
@@ -1,0 +1,3 @@
+module test;
+
+const char* s = ```  // @error{unterminated raw string}


### PR DESCRIPTION
* raw strings are delimited with sequences of backquotes
* raw strings end with a sequence of at least the same length as the initial sequence. Shorter sequences are part of the string.
* backslashes are not interpreted and newlines are accepted
* multi-line raw strings with at least 3 backslashes are parsed as markdown-like blocks: the rest of the line is ignored, each of the following lines must start with at least the same indentation which is not part of the string.