### PR TITLE
Compiler: use C2_TRACE instead of C2TRACE for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ testv: output/tester/tester
 
 trace: $(C2C)
 	$(C2C) c2c --trace-calls -o c2c_trace
-	C2TRACE="min=10;min2=1;mode=3;name=*;fd=2" output/c2c_trace/c2c_trace c2c --test 2> output/c2c/calls
+	C2_TRACE="min=10;min2=1;mode=3;name=*;fd=2" output/c2c_trace/c2c_trace c2c --test 2> output/c2c/calls
 
 errors:
 	@( grep -n 'error:' `find . -name build.log` | sed -E 's/build.log:[0-9]+://' ; true )

--- a/generator/c/c_generator_trace.c2
+++ b/generator/c/c_generator_trace.c2
@@ -268,7 +268,7 @@ fn void Generator.writeCalls(Generator* gen, string_buffer.Buf* out) {
             "}\n\n"
             );
     out.add("void __attribute__((destructor)) c2_trace_calls(void) {\n"
-            "    const char *p = getenv(\"C2TRACE\");\n"
+            "    const char *p = getenv(\"C2_TRACE\");\n"
             "    const char *pattern = 0;\n"
             "    const char *filename = 0;\n"
             "    const char *caller = 0;\n"


### PR DESCRIPTION
* renamed `C2TRACE` as `C2_TRACE` for consistency with other environment variables used in C2: `C2_LIBDIR`, `C2_PLUGINDIR`...