### PR TITLE
Compiler: add min and max enum properties

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -75,6 +75,8 @@ public type Analyser struct @(opaque) {
 
     u32 check_idx;
     init_checker.Checker[4] init_checkers;
+    u32 min_idx;
+    u32 max_idx;
 }
 
 public fn Analyser* create(diagnostics.Diags* diags,
@@ -93,6 +95,8 @@ public fn Analyser* create(diagnostics.Diags* diags,
     ma.allmodules = allmodules;
     ma.warnings = warnings;
     /* zero initialization is OK for ma.labels and ma.init_checkers */
+    ma.min_idx = astPool.addStr("min", true);
+    ma.max_idx = astPool.addStr("max", true);
     return ma;
 }
 

--- a/analyser/module_analyser_member.c2
+++ b/analyser/module_analyser_member.c2
@@ -110,7 +110,7 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
 
                 // check if constant/enum-function (by first casing)
                 const char* last = m.getLastMemberName();
-                if (ctype.isupper(last[0])) {   // search for constants
+                if (ctype.isupper(last[0]) || name_idx == ma.min_idx || name_idx == ma.max_idx) {   // search for constants
                     if (valtype != ValType.NValue) {    // variable of Enum type (eg Enum a; a.x)
                         // TODO reset msg to normal invalid base
                         // TODO use range
@@ -118,12 +118,21 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
                         ma.error(baseLoc, "invalid member reference base (enum constant/variable)");
                         return QualType_Invalid;
                     }
-                    EnumConstantDecl* ecd = etd.findConstant(name_idx);
-                    if (!ecd) {
-                        ma.error(loc, "enum '%s' has no constant '%s'", d.getFullName(), m.getLastMemberName());
-                        return QualType_Invalid;
+                    EnumConstantDecl* ecd;
+                    if (name_idx == ma.min_idx) {
+                        EnumConstantDecl** constants = etd.getConstants();
+                        ecd = constants[0];
+                    } else
+                    if (name_idx == ma.max_idx) {
+                        EnumConstantDecl** constants = etd.getConstants();
+                        ecd = constants[etd.getNumConstants() - 1];
+                    } else {
+                        ecd = etd.findConstant(name_idx);
+                        if (!ecd) {
+                            ma.error(loc, "enum '%s' has no constant '%s'", d.getFullName(), m.getLastMemberName());
+                            return QualType_Invalid;
+                        }
                     }
-
                     d = cast<Decl*>(ecd);
                     if (!d.isChecked()) {
                         ma.error(loc, "circular definition using enum constant '%s'", d.getName());

--- a/ast/statistics.c2
+++ b/ast/statistics.c2
@@ -81,6 +81,7 @@ fn void Stats.dump(const Stats* s) {
     printf("--- Types ---\n");
     u32 typesTotal = 0;
     u32 typesCount = 0;
+    //for (u32 i = TypeKind.min; i <= TypeKind.max; i++) {
     for (u32 i=enum_min(TypeKind); i<=enum_max(TypeKind); i++) {
         const Stat* ss = &s.types[i];
         printf("  %20s  %6d  %7d\n", typeKind_names[i], ss.count, ss.size);
@@ -92,6 +93,7 @@ fn void Stats.dump(const Stats* s) {
     printf("--- Expressions ---\n");
     u32 exprTotal = 0;
     u32 exprCount = 0;
+    //for (u32 i = ExprKind.min; i <= ExprKind.max; i++) {
     for (u32 i=enum_min(ExprKind); i<=enum_max(ExprKind); i++) {
         const Stat* ss = &s.exprs[i];
         printf("  %20s  %6d  %7d\n", exprKind_names[i], ss.count, ss.size);
@@ -103,6 +105,7 @@ fn void Stats.dump(const Stats* s) {
     printf("--- Statements ---\n");
     u32 stmtTotal = 0;
     u32 stmtCount = 0;
+    //for (u32 i = StmtKind.min; i <= StmtKind.max; i++) {
     for (u32 i=enum_min(StmtKind); i<=enum_max(StmtKind); i++) {
         const Stat* ss = &s.stmts[i];
         printf("  %20s  %6d  %7d\n", stmtKind_names[i], ss.count, ss.size);
@@ -114,6 +117,7 @@ fn void Stats.dump(const Stats* s) {
     printf("--- Decls ---\n");
     u32 declTotal = 0;
     u32 declCount = 0;
+    //for (u32 i = DeclKind.min; i <= DeclKind.max; i++) {
     for (u32 i=enum_min(DeclKind); i<=enum_max(DeclKind); i++) {
         const Stat* ss = &s.decls[i];
         printf("  %20s  %6d  %7d\n", declKind_names[i], ss.count, ss.size);

--- a/test/builtins/enum_invalids.c2
+++ b/test/builtins/enum_invalids.c2
@@ -11,4 +11,6 @@ type Enum enum i8 {
 Enum ee;
 i32 ok1 = enum_min(ee);
 i32 ok2 = enum_min(Enum);
+i32 ok3 = Enum.min;
+i32 ok4 = Enum.max;
 

--- a/test/builtins/enum_pointer.c2
+++ b/test/builtins/enum_pointer.c2
@@ -9,3 +9,6 @@ fn void test2() {
     i32* a = &enum_min(Enum); // @error{cannot take the address of an rvalue of type 'i8'}
 }
 
+fn void test3() {
+    i32* a = &Enum.min; // @error{cannot take the address of an enum constant}
+}

--- a/test/builtins/enum_type_conversion1.c2
+++ b/test/builtins/enum_type_conversion1.c2
@@ -12,3 +12,12 @@ const u32 F = enum_max(Enum1);
 
 static_assert(A, -2);
 static_assert(B, 10);
+static_assert(F, 10);
+
+const i8 A1 = Enum1.min;
+const i8 B1 = Enum1.max;
+const u32 F1 = Enum1.max;
+
+static_assert(A1, -2);
+static_assert(B1, 10);
+static_assert(F1, 10);

--- a/test/builtins/enum_type_conversion2.c2
+++ b/test/builtins/enum_type_conversion2.c2
@@ -6,4 +6,5 @@ type Enum2 enum u32 {
 }
 
 const i8 C = enum_min(Enum2);    // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
+const i8 D = Enum2.min;          // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
 

--- a/test/builtins/enum_type_conversion3.c2
+++ b/test/builtins/enum_type_conversion3.c2
@@ -6,4 +6,5 @@ type Enum2 enum u32 {
 }
 
 const i8 D = enum_max(Enum2);    // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
+const i8 E = Enum2.max;          // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
 

--- a/test/builtins/enum_type_conversion4.c2
+++ b/test/builtins/enum_type_conversion4.c2
@@ -7,4 +7,5 @@ type Enum1 enum i8 {
 }
 
 const u32 E = enum_min(Enum1);  // @error{constant value -2 out-of-bounds for type 'u32', range [0, 4294967295]}
+const u32 F = Enum1.min;        // @error{constant value -2 out-of-bounds for type 'u32', range [0, 4294967295]}
 

--- a/test/builtins/enum_type_conversion5.c2
+++ b/test/builtins/enum_type_conversion5.c2
@@ -11,4 +11,5 @@ type Enum2 enum u32 {
 }
 
 const i8 G = enum_max(Enum2) - enum_min(Enum1); // @error{constant value 302 out-of-bounds for type 'i8', range [-128, 127]}
+const i8 H = Enum2.max - Enum1.min;             // @error{constant value 302 out-of-bounds for type 'i8', range [-128, 127]}
 

--- a/test/builtins/enum_type_not_unused.c2
+++ b/test/builtins/enum_type_not_unused.c2
@@ -2,7 +2,9 @@ module test;
 
 type Enum enum i8 {
     A,  // @warning{unused enum constant 'A'}
+    B,
 }
 
-const i8 Max = enum_max(Enum);    // @warning{unused variable 'test.Max'}
+const i8 Max = Enum.max;         // @warning{unused variable 'test.Max'}
+const i8 Min = enum_min(Enum);    // @warning{unused variable 'test.Min'}
 

--- a/test/builtins/enum_var_not_unused.c2
+++ b/test/builtins/enum_var_not_unused.c2
@@ -1,10 +1,12 @@
 module test;
 
 type Enum enum i8 {
+    B,
     A,  // @warning{unused enum constant 'A'}
 }
 
 Enum e;
 
+const i8 Min = Enum.min;       // @warning{unused variable 'test.Min'}
 const i8 Max = enum_max(e);    // @warning{unused variable 'test.Max'}
 


### PR DESCRIPTION
* add `min` and `max` properties for `enum` types.
* `MyEnum.min` is an alias for the smallest `MyEnum` enum constant, with the same implementation type.
* `MyEnum.max` is an alias for the largest `MyEnum` enum constant, with the same implementation type.
* this could replace `enum_min` and `enum_max`, whose type is not well defined.
* update tests