### PR TITLE
Parser: simplify semicolon handling

### DIFF
--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -151,6 +151,17 @@ fn void Parser.consumeToken(Parser* p) {
     // p.dump_token(&p.tok);
 }
 
+fn void Parser.consumeSemicolon(Parser* p, bool need_semi) {
+    if (need_semi) {
+        p.expectAndConsume(Kind.Semicolon);
+    } else {
+        if (p.tok.kind == Kind.Semicolon && p.tok.loc == p.prev_loc) {
+            p.diags.error(p.tok.loc, "semicolon is not accepted after initializer");
+            p.consumeToken();
+        }
+    }
+}
+
 fn void Parser.expectAndConsume(Parser* p, Kind kind) {
     if (p.tok.kind == kind) {
         p.consumeToken();
@@ -561,8 +572,8 @@ fn void Parser.parseArrayEntry(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
     p.consumeToken();   // +=
-    bool need_semi = true;
-    Expr* initValue = p.parseInitValue(&need_semi, false);
+    bool need_semi = (p.tok.kind != Kind.LBrace);
+    Expr* initValue = p.parseInitValue(false);
     p.consumeSemicolon(need_semi);
 
     p.builder.actOnArrayValue(name, loc, initValue);
@@ -594,7 +605,8 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
         if (p.tok.kind == Kind.Equal) {
             assignLoc = p.tok.loc;
             p.consumeToken();
-            initValue = p.parseInitValue(&need_semi, false);
+            need_semi = (p.tok.kind != Kind.LBrace);
+            initValue = p.parseInitValue(false);
         }
 
         Decl* d = p.builder.actOnGlobalVarDecl(name, loc, is_public, &ref, assignLoc, initValue);

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -628,21 +628,19 @@ fn Expr* Parser.parseElemsof(Parser* p) {
     return p.builder.actOnBuiltinExpr(loc, src_len, res, BuiltinExprKind.Elemsof);
 }
 
-fn Expr* Parser.parseInitValue(Parser* p, bool* need_semi, bool allow_designators) {
+fn Expr* Parser.parseInitValue(Parser* p, bool allow_designators) {
     switch (p.tok.kind) {
     case LBrace:
-        *need_semi = false;
         return p.parseInitList();
     case Dot:
         if (!allow_designators) p.error("designator not allowed here");
-        return p.parseFieldDesignator(need_semi);
+        return p.parseFieldDesignator();
     case LSquare:
         if (!allow_designators) p.error("designator not allowed here");
-        return p.parseArrayDesignator(need_semi);
+        return p.parseArrayDesignator();
     default:
         break;
     }
-    *need_semi = true;
     return p.parseAssignmentExpression();
 }
 
@@ -653,8 +651,7 @@ fn Expr* Parser.parseInitList(Parser* p) {
     ExprList values.init();
 
     while (p.tok.kind != Kind.RBrace) {
-        bool unused;
-        Expr* e = p.parseInitValue(&unused, true);
+        Expr* e = p.parseInitValue(true);
         values.add(e);
         if (p.tok.kind == Kind.Comma) {
             p.consumeToken();
@@ -673,7 +670,7 @@ fn Expr* Parser.parseInitList(Parser* p) {
     return e;
 }
 
-fn Expr* Parser.parseFieldDesignator(Parser* p, bool* need_semi) {
+fn Expr* Parser.parseFieldDesignator(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();   // .
     p.expectIdentifier();
@@ -681,12 +678,12 @@ fn Expr* Parser.parseFieldDesignator(Parser* p, bool* need_semi) {
     p.consumeToken();
 
     p.expectAndConsume(Kind.Equal);
-    Expr* value = p.parseInitValue(need_semi, false);
+    Expr* value = p.parseInitValue(false);
 
     return p.builder.actOnFieldDesignatedInit(loc, field, value);
 }
 
-fn Expr* Parser.parseArrayDesignator(Parser* p, bool* need_semi) {
+fn Expr* Parser.parseArrayDesignator(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();   // '['
 
@@ -694,7 +691,7 @@ fn Expr* Parser.parseArrayDesignator(Parser* p, bool* need_semi) {
     p.expectAndConsume(Kind.RSquare);
     p.expectAndConsume(Kind.Equal);
 
-    Expr* initValue = p.parseInitValue(need_semi, false);
+    Expr* initValue = p.parseInitValue(false);
     return p.builder.actOnArrayDesignatedInit(loc, designator, initValue);
 }
 

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -524,7 +524,6 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool a
         p.consumeToken();
     }
 
-    bool need_semi = true;
     TypeRefHolder ref.init();
     p.parseTypeSpecifier(&ref, true, true);
 
@@ -537,7 +536,6 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool a
 
         // TODO same as parseVarDecl()
         bool has_init_call = false;
-        need_semi = true;
         Expr* initValue = nil;
         SrcLoc assignLoc = 0;
 
@@ -545,7 +543,7 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool a
         case Equal:
             assignLoc = p.tok.loc;
             p.consumeToken();
-            initValue = p.parseInitValue(&need_semi, false);
+            initValue = p.parseInitValue(false);
             break;
         case Dot:
             if (p.tokenizer.lookahead(1, nil) == Kind.Identifier
@@ -588,17 +586,6 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool a
         p.expectAndConsume(Kind.Semicolon);
     }
     return p.builder.actOnDeclStmt(decls, num_decls);
-}
-
-fn void Parser.consumeSemicolon(Parser* p, bool need_semi) {
-    if (need_semi) {
-        p.expectAndConsume(Kind.Semicolon);
-    } else {
-        if (p.tok.kind == Kind.Semicolon && p.tok.loc == p.prev_loc) {
-            p.diags.error(p.tok.loc, "semicolon is not accepted after initializer");
-            p.consumeToken();
-        }
-    }
 }
 
 fn Stmt* Parser.parseExprStmt(Parser* p) {


### PR DESCRIPTION
* remove `need_semi` argument in `Parser.parseInitValue()`, `Parser.parseFieldDesignator()` and `Parser.parseArrayDesignator()`
* handle `need_semi` explicitly in `Parser.parseArrayEntry` and `Parser.parseVarDecl()`.
* move `Parser.consumeSemicolon` to c2_parser.c2