### PR TITLE
Compiler: simplify IntegerLiteral, never negative

### DIFF
--- a/analyser_utils/ctv_analyser.c2
+++ b/analyser_utils/ctv_analyser.c2
@@ -75,10 +75,7 @@ public fn Value get_value(const Expr* e) {
     switch (e.getKind()) {
     case IntegerLiteral:
         const IntegerLiteral* i = cast<IntegerLiteral*>(e);
-        if (i.isSigned())
-            result.setSigned(cast<i64>(i.getValue()));
-        else
-            result.setUnsigned(i.getValue());
+        result.setUnsigned(i.getValue());
         break;
     case FloatLiteral:
         const FloatLiteral* f = cast<FloatLiteral*>(e);

--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -23,8 +23,7 @@ import number_radix local;
 type IntegerLiteralBits struct {
     u32 : NumExprBits;
     u32 radix : 2;      // number_radix.Radix enum
-    u32 is_signed : 1;
-    u32 src_len : 32 - NumExprBits - 2 - 1;
+    u32 src_len : 32 - NumExprBits - 2;
 }
 
 public type IntegerLiteral struct @(opaque) {
@@ -60,10 +59,6 @@ public fn bool IntegerLiteral.isDecimal(const IntegerLiteral* e) {
     return e.base.base.integerLiteralBits.radix == Radix.Default;
 }
 */
-
-public fn bool IntegerLiteral.isSigned(const IntegerLiteral* e) {
-    return e.base.base.integerLiteralBits.is_signed;
-}
 
 fn void printBinary(string_buffer.Buf* out, u64 value) {
     char[1+(64+2-1)/2+1] tmp;
@@ -104,30 +99,13 @@ fn void IntegerLiteral.print(const IntegerLiteral* e, string_buffer.Buf* out, u3
 public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffer.Buf* out) {
     switch (e.base.base.integerLiteralBits.radix) {
     case Radix.Default:
-        if (e.base.base.integerLiteralBits.is_signed) {
-            i64 sval = cast<i64>(e.val);
-            if (sval >= -2147483647 && sval <= 2147483647)
-                out.print("%d", sval);
-            else
-            if (sval == -2147483647-1)
-                out.print("(-2147483647-1)");
-            else
-            if (e.val == 0x8000000000000000)
-                out.print("(-9223372036854775807l-1)");
-            else
-                out.print("%dl", sval);
-        } else {
-            if (e.val > 4294967295)
-                out.print("%dlu", e.val);
-            else
-                out.print("%d", e.val);
-        }
+        out.print("%d", e.val);
+        if (e.val > 4294967295) out.add1('l');
         break;
     case Radix.Hex:
         out.print("0x%x", e.val);
         break;
     case Radix.Octal:
-        // FIXME: incorrect for negative values
         printOctal(out, e.val);
         break;
     case Radix.Binary:

--- a/generator/c/c_generator_pure_call.c2
+++ b/generator/c/c_generator_pure_call.c2
@@ -58,10 +58,7 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
     switch (e.getKind()) {
     case IntegerLiteral:
         const IntegerLiteral* i = cast<IntegerLiteral*>(e);
-        if (i.isSigned())
-            result.setSigned(cast<i64>(i.getValue()));
-        else
-            result.setUnsigned(i.getValue());
+        result.setUnsigned(i.getValue());
         break;
     case FloatLiteral:
         const FloatLiteral* f = cast<FloatLiteral*>(e);


### PR DESCRIPTION
* remove `is_signed` member and `isSigned()` method in `IntegerLiteral`
* simplify output, constant evaluator and generator