### PR TITLE
Analyser: simplify fallthrough analysis

### DIFF
--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -133,9 +133,8 @@ fn void Analyser.analyseContinueStmt(Analyser* ma, Stmt* s) {
 }
 
 fn void Analyser.analyseFallthroughStmt(Analyser* ma, Stmt* s) {
-    if (!ma.scope.allowFallthrough()) {
-        ma.error(s.getLoc(), "'fallthrough' statement cannot be used here");
-    }
+    // fallthrough are only allowed as case statements handled in `ma.analyseCase`
+    ma.error(s.getLoc(), "'fallthrough' statement cannot be used here");
 }
 
 fn void Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -68,9 +68,6 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
         SwitchCase* c = cases[i];
         bool is_last = (i+1 == numCases);
 
-        u32 flags = scope.Decl | scope.Break;
-        if (!is_last) flags |= scope.Fallthrough;
-
         if (c.isDefault()) {
             if (defaultCase) {
                 ma.error(c.getLoc(), "multiple default labels");
@@ -83,8 +80,8 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
             defaultCase = c;
         }
 
-        ma.scope.enter(flags);
-        ok &= ma.analyseCase(c, checker, etd, is_string);
+        ma.scope.enter(scope.Decl | scope.Break);
+        ok &= ma.analyseCase(c, checker, etd, is_string, is_last);
         ma.scope.exit(ma.has_error);
     }
 
@@ -132,7 +129,8 @@ fn bool Analyser.analyseCase(Analyser* ma,
                              SwitchCase* c,
                              init_checker.Checker* checker,
                              EnumTypeDecl* etd,
-                             bool is_string) {
+                             bool is_string,
+                             bool is_last) {
     bool is_default = c.isDefault();
     if (!is_default) {
         if (!ma.analyseCaseCondition(c, checker, etd, is_string)) return false;
@@ -146,18 +144,17 @@ fn bool Analyser.analyseCase(Analyser* ma,
     bool has_decls = false;
     for (u32 i = 0; i < count; i++) {
         Stmt* st = c.getStmt(i);
-        ma.analyseStmt(st, true);
-        if (ma.has_error) return false;
-
-        if (st.isDecl()) has_decls = true;
-
-        if (st.isFallthrough()) {
+        if (st.isFallthrough() && !is_last) {
             c.setHasFallthrough();
-            if ((i+1 != count)) {
+            if (i + 1 != count) {
                 ma.error(st.getLoc(), "'fallthrough' statement must be last statement in case");
                 return false;
             }
+            continue;
         }
+        ma.analyseStmt(st, true);
+        if (ma.has_error) return false;
+        if (st.isDecl()) has_decls = true;
     }
     if (has_decls) c.setHasDecls();
 
@@ -408,11 +405,9 @@ fn bool isTerminatingStmt(const Stmt* s, bool is_default) {
         // TODO: check if unreachable
         break;
     case Break:
-        return true;
     case Continue:
-        return true;
     case Fallthrough:
-        return !is_default;
+        return true;
     case Label:
         const LabelStmt* ls = cast<LabelStmt*>(s);
         const Stmt* stmt = ls.getStmt();

--- a/analyser/scope.c2
+++ b/analyser/scope.c2
@@ -31,7 +31,6 @@ public const u32 Continue    = 0x4;
 public const u32 Decl        = 0x8;
 public const u32 Control     = 0x10;      // TODO remove?
 //public const u32 Block       = 0x20;
-public const u32 Fallthrough = 0x40;
 const u32 Unreachable = 0x80;    // set after return/goto/break/continue/no-return func
 // TODO use hasDecls instead of checking every Stmt?
 //public const u32 HasDecls  = 0x80;
@@ -247,12 +246,6 @@ public fn bool Scope.allowContinue(const Scope* s) {
     assert(s.lvl);
     const Level* top = &s.levels[s.lvl-1];
     return (top.flags & Continue);
-}
-
-public fn bool Scope.allowFallthrough(const Scope* s) {
-    assert(s.lvl);
-    const Level* top = &s.levels[s.lvl-1];
-    return (top.flags & Fallthrough);
 }
 
 public fn bool Scope.inFunction(const Scope* s) {

--- a/test/stmt/bad_break.c2
+++ b/test/stmt/bad_break.c2
@@ -1,0 +1,11 @@
+// @warnings{no-unused}
+module test;
+
+fn void foo(i32 a) {
+    break;    // @error{'break' statement not in loop or switch statement}
+}
+
+fn void foo1(i32 a, i32 b) {
+    if (b)
+        break;    // @error{'break' statement not in loop or switch statement}
+}

--- a/test/stmt/bad_continue.c2
+++ b/test/stmt/bad_continue.c2
@@ -1,0 +1,17 @@
+// @warnings{no-unused}
+module test;
+
+fn void foo(i32 a) {
+    continue;    // @error{'continue' statement not in loop statement}
+}
+
+fn void foo1(i32 a, i32 b) {
+    switch (a) {
+    case 1:
+        if (b)
+            continue;    // @error{'continue' statement not in loop statement}
+        break;
+    case 2:
+        break;
+    }
+}

--- a/test/stmt/bad_fallthrough.c2
+++ b/test/stmt/bad_fallthrough.c2
@@ -1,0 +1,17 @@
+// @warnings{no-unused}
+module test;
+
+fn void foo(i32 a) {
+    fallthrough;    // @error{'fallthrough' statement cannot be used here}
+}
+
+fn void foo1(i32 a, i32 b) {
+    switch (a) {
+    case 1:
+        if (b)
+            fallthrough;    // @error{'fallthrough' statement cannot be used here}
+        break;
+    case 2:
+        break;
+    }
+}


### PR DESCRIPTION
* `fallthrough` statement should only be used as the last statement in a `case` statement list except in the final one.
* remove Fallthrough scope flag
* add tests