### PR TITLE
Analyser: fix crash bug on pointer dereference

### DIFF
--- a/analyser/conversion_checker_expr.c2
+++ b/analyser/conversion_checker_expr.c2
@@ -98,7 +98,7 @@ fn ExprWidth getExprWidth(const Expr* e) {
         QualType qt = e.getType();
         qt = qt.getCanonicalType();
         if (qt.isPointer()) {
-            result.width = 64; // TODO or 32
+            result.width = cast<u8>(ast.getWordSize() * 8);
             result.is_signed = false;
             return result;
         }
@@ -156,9 +156,18 @@ fn ExprWidth getUnaryOpWidth(const UnaryOperator* u) {
         w.is_signed = false;
         break;
     case Deref:
-        // must be pointer-type, return size of inner
-        // TODO
-        assert(0);
+        Expr* e = cast<Expr*>(u);
+        QualType qt = e.getType();
+        qt = qt.getCanonicalType();
+        if (qt.isPointer()) {
+            w.width = cast<u8>(ast.getWordSize() * 8);
+            w.is_signed = false;
+            break;
+        }
+        assert(qt.isBuiltin());
+        BuiltinType* bi = qt.getBuiltin();
+        w.width = cast<u8>(bi.getWidth());
+        w.is_signed = bi.isSigned();
         break;
     case Minus:
         w = getExprWidth(u.getInner());

--- a/test/expr/unary/digit_extraction.c2
+++ b/test/expr/unary/digit_extraction.c2
@@ -1,0 +1,92 @@
+// @warnings{no-unused}
+module test;
+
+// regression test for #302
+fn void test1(const u8* p) {
+   i32 i = *p++;
+}
+
+fn u8 get_digit(const char *p) {
+    u8 digit = *p;
+    u8 digit0 = '0';
+    return digit - digit0;
+}
+
+fn u8 get_digit_(const char *p) {
+    u8 digit0 = '0';
+    return *p - digit0;
+}
+
+fn u8 get_digit_1(const char *p) {
+    u8 digit0 = '0';
+    return (u8)*p - digit0;
+}
+
+fn u8 get_digit__(const char *p) {
+    u8 digit0 = '0';
+    return *p++ - digit0;
+}
+
+fn u8 get_digit0(const char *p) {
+    u8 digit = *p;
+    return digit - '0';
+}
+
+fn u8 get_digit0_(const char *p) {
+    u8 digit = *p++;
+    return digit - '0';
+}
+
+fn u8 get_digit1(const char *p) {
+    u8 digit;
+    digit = *p - '0';
+    return digit;
+}
+
+fn u8 get_digit2(const char *p) {
+    u8 digit;
+    digit = *p++ - '0';
+    return digit;
+}
+
+fn u8 get_digit3(const char *p) {
+    u8 digit = *p - '0';
+    return digit;
+}
+
+fn u8 get_digit4(const char *p) {
+    u8 digit = *p++ - '0';
+    return digit;
+}
+
+fn u8 get_digit_a(const char *p) {
+    u8 digit = p[0];
+    u8 digit0 = '0';
+    return digit - digit0;
+}
+
+fn u8 get_digit__a(const char *p) {
+    u8 digit0 = '0';
+    return p[0] - digit0;
+}
+
+fn u8 get_digit_1_a(const char *p) {
+    u8 digit0 = '0';
+    return (u8)p[0] - digit0;
+}
+
+fn u8 get_digit0_a(const char *p) {
+    u8 digit = p[0];
+    return digit - '0';
+}
+
+fn u8 get_digit1_a(const char *p) {
+    u8 digit;
+    digit = p[0] - '0';
+    return digit;
+}
+
+fn u8 get_digit3_a(const char *p) {
+    u8 digit = p[0] - '0';
+    return digit;
+}


### PR DESCRIPTION
* fix TODO `assert(0)` in `getUnaryOpWidth()`: compute actual width
* add regression tests

Fixes #302