### PR TITLE
Libraries: fix multiple library issues to compile the examples

### DIFF
--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -500,7 +500,14 @@ fn bool emitAsDefine(const VarDecl* vd) {
     const Expr* initExpr = vd.getInit();
     if (!initExpr) return false;
 
-    if (!canon.isArray()) {
+    if (canon.isArray()) {
+        ArrayType* at = canon.getArrayType();
+        QualType et = at.getElemType();
+        if (!et.isBuiltin()) return false;
+        if (et.isVolatile()) return false;
+        if (!et.isConst()) return false;
+        if (initExpr.isStringLiteral() && d.isExternal()) return true;
+    } else {
         if (!qt.isConst()) return false;
         if (qt.isVolatile()) return false;
         if (canon.isBuiltin()) return true;

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -154,7 +154,11 @@ fn void Generator.createMakefile(Generator* gen,
                     continue;
             }
             if (c.isStaticLib()) {
-                out.print(" -L%s/%s", c.getPath(), triplet);
+                if (gen.targetInfo.sys == target_info.System.Darwin) {
+                    out.print(" -L/opt/homebrew/lib");
+                } else {
+                    out.print(" -L%s/%s", c.getPath(), triplet);
+                }
                 // special case for static libc
                 if (c.getNameIdx() == libc_name) out.add(" --static");
             }

--- a/libs/libc/csignal.c2i
+++ b/libs/libc/csignal.c2i
@@ -48,8 +48,8 @@ const c_int SIGPWR      = 30;
 const c_int SIGSYS      = 31;
 const c_int SIGUNUSED   = 31;
 
-type SigactionHandler fn void(c_int);
-type SigActionAction fn void(c_int, Siginfo_t*, void*);
+type SigactionHandler fn void(i32);
+type SigActionAction fn void(i32, Siginfo_t*, void*);
 type SigActionRestorer fn void();
 
 type Siginfo_t struct @(cname="siginfo_t") {

--- a/libs/libc/sys_socket.c2i
+++ b/libs/libc/sys_socket.c2i
@@ -1,7 +1,8 @@
 module sys_socket;
 
 import c2 local;
-
+import unistd local;
+import libc_fcntl local;
 
 // From linux/in.h
 const c_int PF_UNIX     =  1;
@@ -45,12 +46,12 @@ type SocketType enum u32 @(cname="__socket_type") {
   SOCK_SEQPACKET = 5,   /* Sequenced, reliable, connection-based, datagrams of fixed maximum length.  */
   SOCK_DCCP      = 6,   /* Datagram Congestion Control Protocol.  */
   SOCK_PACKET    = 10,  /* Linux specific way of getting packets at the dev level.  For writing rarp and other similar things on the user level. */
-
-  /* Flags to be ORed into the type parameter of socket and socketpair and
-     used for the flags parameter of paccept.  */
-  SOCK_NONBLOCK  = 00004000,  /* Atomically mark descriptor(s) as non-blocking.  */
-  SOCK_CLOEXEC   = 02000000,  /* Atomically set close-on-exec flag for the new descriptor(s).  */
 }
+/* Flags to be ORed into the type parameter of socket and socketpair and
+   used for the flags parameter of paccept.  */
+const u32 SOCK_NONBLOCK  = 00004000;  /* Atomically mark descriptor(s) as non-blocking.  */
+const u32 SOCK_CLOEXEC   = 02000000;  /* Atomically set close-on-exec flag for the new descriptor(s).  */
+
 
 fn c_int socket(c_int domain, c_int type_, c_int protocol);
 
@@ -113,7 +114,35 @@ fn c_int connect(c_int sockfd, const Sockaddr* addr, u32 addrlen);
 
 fn c_int listen(c_int sockfd, c_int backlog);
 
+fn c_int accept(c_int sockfd, Sockaddr *addr, u32 *addrlen);
+
+#if SYSTEM_LINUX
+
 fn c_int accept4(c_int sockfd, Sockaddr* addr, u32* addrlen, c_int flags);
+
+#else
+
+fn c_int accept4(c_int sockfd, Sockaddr *addr, u32 *addrlen, c_int flags) {
+    c_int new_sockfd = accept(sockfd, addr, addrlen);
+    if (new_sockfd < 0) {
+        return -1;
+    }
+    if (flags & SOCK_CLOEXEC) {
+        if (fcntl(new_sockfd, F_SETFD, FD_CLOEXEC) == -1) {
+            close(new_sockfd);
+            return -1;
+        }
+    }
+    if (flags & SOCK_NONBLOCK) {
+        if (fcntl(new_sockfd, F_SETFL, O_NONBLOCK) == -1) {
+            close(new_sockfd);
+            return -1;
+        }
+    }
+    return new_sockfd;
+}
+
+#endif
 
 // NOTE: some c-prototypes need to be converted
 //int inet_aton(const char *cp, struct in_addr *inp);

--- a/libs/libc/unistd.c2i
+++ b/libs/libc/unistd.c2i
@@ -1,6 +1,7 @@
 module unistd;
 
 import c2 local;
+import libc_fcntl local;
 
 /* Standard file descriptors.  */
 const c_int STDIN_FILENO  = 0;
@@ -30,8 +31,37 @@ fn c_ssize write(c_int fd, const void* buf, c_size count);
 
 fn c_int pipe(c_int* pipefd);
 
+#if SYSTEM_LINUX
+
 //#ifdef_GNU_SOURCE             /* See feature_test_macros(7) */
 fn c_int pipe2(c_int* pipefd, c_int flags);
+
+#else
+
+fn c_int pipe2(c_int* pipefd, c_int flags) {
+    if (pipe(pipefd) < 0) {
+        return -1;
+    }
+    if (flags & O_CLOEXEC) {
+        if (fcntl(pipefd[0], F_SETFD, FD_CLOEXEC) == -1
+        ||  fcntl(pipefd[1], F_SETFD, FD_CLOEXEC) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+    }
+    if (flags & O_NONBLOCK) {
+        if (fcntl(pipefd[0], F_SETFD, O_NONBLOCK) == -1
+        ||  fcntl(pipefd[1], F_SETFD, O_NONBLOCK) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+#endif
 
 fn c_int unlink(const char* name);
 

--- a/libs/lua/lua.c2i
+++ b/libs/lua/lua.c2i
@@ -50,7 +50,7 @@ type Integer c_int @(cname="lua_integer");
 type Unsigned LUA_UNSIGNED @(cname="lua_Unsigned");
 type KContext LUA_KCONTEXT @(cname="lua_KContext");
 
-type CFunction fn c_int (State *L) @(cname="lua_CFunction");
+type CFunction fn i32 (State *L) @(cname="lua_CFunction");
 
 type KFunction fn c_int (State *L, c_int status, KContext ctx) @(cname="lua_KFunction");
 

--- a/libs/lua/lua_lib.c2i
+++ b/libs/lua/lua_lib.c2i
@@ -3,37 +3,37 @@ module lua_lib;
 import c2 local;
 import lua local;
 
-fn c_int luaopen_base(State *L);
+fn i32 luaopen_base(State *L);
 
-const c_char[] LUA_COLIBNAME = "coroutine";
-fn c_int luaopen_coroutine(State *L);
+const char[] LUA_COLIBNAME = "coroutine";
+fn i32 luaopen_coroutine(State *L);
 
-const c_char[] LUA_TABLIBNAME = "table";
-fn c_int luaopen_table(State *L);
+const char[] LUA_TABLIBNAME = "table";
+fn i32 luaopen_table(State *L);
 
-const c_char[] LUA_IOLIBNAME = "io";
-fn c_int luaopen_io(State *L);
+const char[] LUA_IOLIBNAME = "io";
+fn i32 luaopen_io(State *L);
 
-const c_char[] LUA_OSLIBNAME = "os";
-fn c_int luaopen_os(State *L);
+const char[] LUA_OSLIBNAME = "os";
+fn i32 luaopen_os(State *L);
 
-const c_char[] LUA_STRINGLIBNAME = "string";
-fn c_int luaopen_string(State *L);
+const char[] LUA_STRINGLIBNAME = "string";
+fn i32 luaopen_string(State *L);
 
-const c_char[] LUA_UTF8LIBNAME = "utf8";
-fn c_int luaopen_utf8(State *L);
+const char[] LUA_UTF8LIBNAME = "utf8";
+fn i32 luaopen_utf8(State *L);
 
-const c_char[] LUA_BITLIBNAME = "bit32";
-fn c_int luaopen_bit32(State *L);
+const char[] LUA_BITLIBNAME = "bit32";
+fn i32 luaopen_bit32(State *L);
 
-const c_char[] LUA_MATHLIBNAME = "math";
-fn c_int luaopen_math(State *L);
+const char[] LUA_MATHLIBNAME = "math";
+fn i32 luaopen_math(State *L);
 
-const c_char[] LUA_DBLIBNAME = "debug";
-fn c_int luaopen_debug(State *L);
+const char[] LUA_DBLIBNAME = "debug";
+fn i32 luaopen_debug(State *L);
 
-const c_char[] LUA_LOADLIBNAME = "package";
-fn c_int luaopen_package(State *L);
+const char[] LUA_LOADLIBNAME = "package";
+fn i32 luaopen_package(State *L);
 
 // open all previous libraries
 fn void luaL_openlibs(State* L);

--- a/test/c_generator/lib_lua.c2t
+++ b/test/c_generator/lib_lua.c2t
@@ -1,0 +1,28 @@
+// @recipe bin
+    $warnings no-unused
+    $backend c
+    $use lua static
+
+// @file{file1}
+module test;
+
+import stdio local;
+import lua_lib local;
+
+public fn i32 main(i32 argc, const char** argv) {
+    printf("%s\n", LUA_COLIBNAME);
+    return 0;
+}
+
+// @expect{atleast, cgen/build.c}
+
+#define LUA_COLIBNAME "coroutine"
+
+int32_t main(int32_t argc, const char** argv);
+
+int32_t main(int32_t argc, const char** argv)
+{
+    printf("%s\n", LUA_COLIBNAME);
+    return 0;
+}
+


### PR DESCRIPTION
* use standard types in some function types
* emulate `pipe2` and `accept4` on non Linux targets
* add `accept()` system call
* generate external constant strings as `#define`
* make socket options flags constants, not an enum