### PR TITLE
Compiler: fix C compilation warnings

### DIFF
--- a/ast/ast_evaluator.c2
+++ b/ast/ast_evaluator.c2
@@ -565,7 +565,7 @@ fn Cont GotoStmt.eval(GotoStmt* s, Evaluator* sf) {
 fn Cont CompoundStmt.eval(CompoundStmt* body, Evaluator* sf) {
     u32 count = body.getCount();
     Stmt** stmts = body.getStmts();
-    for (i32 i = 0; i < count; i++) {
+    for (u32 i = 0; i < count; i++) {
         Cont cont = stmts[i].eval(sf);
         if (cont != Cont.Normal)
             return cont;

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -527,7 +527,7 @@ fn void Expr.print(const Expr* e, string_buffer.Buf* out, u32 indent) {
 public fn void Expr.printLiteral(const Expr* e, string_buffer.Buf* out) {
     switch (e.getKind()) {
     case IntegerLiteral:
-        IntegerLiteral.printLiteral((IntegerLiteral*)e, out);
+        IntegerLiteral.printLiteral((IntegerLiteral*)e, out, false);
         return;
     case FloatLiteral:
         FloatLiteral.printLiteral((FloatLiteral*)e, out);

--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -94,15 +94,18 @@ fn void IntegerLiteral.print(const IntegerLiteral* e, string_buffer.Buf* out, u3
     e.base.printTypeBits(out);
     out.color(col_Value);
     out.space();
-    e.printLiteral(out);
+    e.printLiteral(out, false);
     out.newline();
 }
 
-public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffer.Buf* out) {
+public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffer.Buf* out, bool c_style) {
     switch (e.base.base.integerLiteralBits.radix) {
     case Radix.Default:
         out.print("%d", e.val);
-        if (e.val > 4294967295) out.add1('l');
+        if (c_style) {
+            if (e.val > 9223372036854775807) out.add1('u');
+            if (e.val > 4294967295) out.add1('l');
+        }
         break;
     case Radix.Hex:
         out.print("0x%x", e.val);

--- a/generator/c/c2i_generator_expr.c2
+++ b/generator/c/c2i_generator_expr.c2
@@ -22,7 +22,7 @@ fn void Generator.emitExpr(Generator* gen, const Expr* e) {
     string_buffer.Buf* out = gen.out;
     switch (e.getKind()) {
     case IntegerLiteral:
-        IntegerLiteral.printLiteral(cast<IntegerLiteral*>(e), out);
+        IntegerLiteral.printLiteral(cast<IntegerLiteral*>(e), out, false);
         return;
     case FloatLiteral:
         FloatLiteral.printLiteral(cast<FloatLiteral*>(e), out);

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -23,7 +23,7 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
     switch (e.getKind()) {
     case IntegerLiteral:
         IntegerLiteral* i = cast<IntegerLiteral*>(e);
-        i.printLiteral(out);
+        i.printLiteral(out, true);
         break;
     case FloatLiteral:
         FloatLiteral* f = cast<FloatLiteral*>(e);

--- a/generator/c/c_generator_trace.c2
+++ b/generator/c/c_generator_trace.c2
@@ -300,7 +300,7 @@ fn void Generator.writeCalls(Generator* gen, string_buffer.Buf* out) {
                 if (pos) { filename = p + pos; break; }
                 sscanf(p, " caller%*1[=]%n", &pos);
                 if (pos) { caller = p + pos; break; }
-                sscanf(p, "%*[^;=]%*1[=]%n%", &pos);
+                sscanf(p, "%*[^;=]%*1[=]%n", &pos);
                 break;
             }
             if (!pos) pattern = p;

--- a/libs/dl/dlfcn.c2i
+++ b/libs/dl/dlfcn.c2i
@@ -4,14 +4,14 @@ import c2 local;
 
 /* special values for the module handle */
 #if SYSTEM_LINUX
-const usize RTLD_NEXT      = cast<u64>(-1);
-const usize RTLD_DEFAULT   = cast<u64>(0);
+const usize RTLD_NEXT      = (void*)(usize)(-1);
+const usize RTLD_DEFAULT   = (void*)(usize)(0);
 #else
-const usize RTLD_NEXT      = cast<u64>(-1);	/* Search subsequent objects. */
-const usize RTLD_DEFAULT   = cast<u64>(-2);	/* Use default search algorithm. */
-const usize RTLD_SELF      = cast<u64>(-3);	/* Search the caller itself. */
+const usize RTLD_NEXT      = (void*)(usize)(-1);	/* Search subsequent objects. */
+const usize RTLD_DEFAULT   = (void*)(usize)(-2);	/* Use default search algorithm. */
+const usize RTLD_SELF      = (void*)(usize)(-3);	/* Search the caller itself. */
 #if SYSTEM_DARWIN
-const usize RTLD_MAIN_ONLY = cast<u64>(-5);
+const usize RTLD_MAIN_ONLY = (void*)(usize)(-5);
 #endif
 #endif
 

--- a/libs/libc/libc_dirent.c2i
+++ b/libs/libc/libc_dirent.c2i
@@ -20,8 +20,8 @@ fn Dirent *readdir(DIR *dirp);
 fn Dirent* readdir(DIR* dirp);
 #endif
 
-type FilterFn fn c_int(const Dirent*);
-type DirentCompareFn fn c_int(const Dirent**, const Dirent**);
+type FilterFn fn i32(const Dirent*);
+type DirentCompareFn fn i32(const Dirent**, const Dirent**);
 
 fn c_int scandir(const c_char* dirp, Dirent*** namelist,
                    FilterFn filter, DirentCompareFn compar);

--- a/libs/libc/stdlib.c2i
+++ b/libs/libc/stdlib.c2i
@@ -97,7 +97,7 @@ fn void abort() @(noreturn);
 type AtExitFn fn void();
 fn c_int atexit(AtExitFn __func);
 fn c_int at_quick_exit(AtExitFn __func);
-type OnExitFn fn void(c_int, void*);
+type OnExitFn fn void(i32, void*);
 fn c_int on_exit(OnExitFn __func, void* __arg);
 fn void exit(c_int __status) @(noreturn);
 fn void _exit(c_int __status) @(noreturn);
@@ -117,7 +117,7 @@ fn c_int system(const c_char* __command);
 fn c_char* realpath(const c_char* __name, c_char* __resolved);
 fn c_char* mktemp(c_char* __template);
 
-type StdlibCompareFn fn c_int(const void*, const void*) @(cname="__compar_fn_t");
+type StdlibCompareFn fn i32(const void*, const void*) @(cname="__compar_fn_t");
 fn void* bsearch(const void* __key, const void* __base, c_size __nmemb, c_size __size, StdlibCompareFn __compar);
 fn void qsort(void* __base, c_size __nmemb, c_size __size, StdlibCompareFn __compar);
 

--- a/libs/libc/sys_mman.c2i
+++ b/libs/libc/sys_mman.c2i
@@ -22,14 +22,10 @@ const u32 MAP_ANONYMOUS = 0x20;
 const u32 MAP_POPULATE  = 0x8000;
 #else
 // Same for Darwin, FreeBSD and OpenBSD
-const u32 MAP_SHARED = 0x01;
-const u32 MAP_PRIVATE = 0x02;
-const u32 MAP_FIXED = 0x10;
+const u32 MAP_SHARED    = 0x01;
+const u32 MAP_PRIVATE   = 0x02;
+const u32 MAP_FIXED     = 0x10;
 const u32 MAP_ANONYMOUS = 0x1000;
 #endif
 
-const usize MAP_FAILED  = cast<u64>(-1);
-//const void* MAP_FAILED  = -1;
-//const void* MAP_FAILED  = max_u64;
-//const void* MAP_FAILED  = max_u32;
-
+const usize MAP_FAILED = (void*)(usize)(-1);


### PR DESCRIPTION
* generate `u` suffix on integer literals larger than `INT64_MAX`
* improve dependencies in Makefile
* fix `StdlibCompareFn` and other function types to avoid typedef issue
* fix `MAP_FAILED` definition to avoid C warning
* add properly cast handle definitions in libs/dl/dlfcn.c2i to avoid C warnings