### PR TITLE
parser: disambiguate more casts on unary operators

### DIFF
--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -924,6 +924,11 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok, bool* bracke
             case PlusPlus:   // ambiguous: (x)++
             case MinusMinus: // ambiguous: (x)--
             case LParen:     // ambiguous: (func)(args)
+            case Amp:        // ambiguous: (func)&b
+            case Plus:       // ambiguous: (func)+b
+            case Minus:      // ambiguous: (func)-b
+            case Star:       // ambiguous: (func)*b
+                // for ambiguous combinations, rely on identifier case
                 // (A)(...) is a cast, (a)(...) is a function call
                 if (is_lower)
                     return 0;

--- a/test/expr/explicit_cast/explicit_casts_builtin.c2
+++ b/test/expr/explicit_cast/explicit_casts_builtin.c2
@@ -42,6 +42,12 @@ fn void test4(u64 a) {
 fn void test5(i32 a) {
     i32 b = cast<Alias>(a);
     i32 b1 = (Alias)(a);
+    i32 b2 = (Alias)a;
+    i32 b3 = (Alias)+a;
+    i32 b4 = (Alias)-a;
+    i32 b5 = (Alias)*&a;
+    i32 b6 = (Alias)~a;
+    i32 b7 = (Alias)!a;
 }
 
 fn void test6(i32 a) {

--- a/test/expr/explicit_cast/explicit_casts_pointer.c2
+++ b/test/expr/explicit_cast/explicit_casts_pointer.c2
@@ -9,6 +9,8 @@ type Enum enum u32 {
     A, B
 }
 
+type Ptr void*;
+
 type Func fn void(i32);
 
 fn void test1(void* a) {
@@ -24,5 +26,12 @@ fn void test2(void* a) {
 fn void test3(void* a) {
     Func b = cast<Func>(a);
     Func b1 = (Func)(a);
+}
+
+fn void test4(void* a) {
+    Ptr b = cast<Ptr>(a);
+    Ptr b1 = (Ptr)(a);
+    b = cast<Ptr>(&a);
+    b1 = (Ptr)&a;
 }
 


### PR DESCRIPTION
* disambiguate casts on unary operators `+`, `-`, `*` and `&` using identifier case.

Fixes #305