### PR TITLE
Fix external array definitions:

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -563,7 +563,7 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
                 return;
             }
         } else {
-            if (!init_expr) {
+            if (!init_expr && !d.isExternal()) {
                 ma.error(d.getLoc(), "array-type variable '%s' needs an explicit size or an initializer", d.getFullName());
                 return;
             }

--- a/analyser/module_analyser_builtin.c2
+++ b/analyser/module_analyser_builtin.c2
@@ -59,6 +59,13 @@ fn QualType Analyser.analyseSizeof(Analyser* ma, BuiltinExpr* e) {
         if (qt.isInvalid()) return QualType_Invalid;
 
         // TODO extract to function
+        if (qt.isArray()) {
+            const ArrayType* at = qt.getArrayTypeOrNil();
+            if (at && !at.hasSize()) {
+                ma.error(inner.getLoc(), "sizeof cannot be used on arrays of unknown length");
+                return QualType_Invalid;
+            }
+        }
         if (qt.isStruct()) {
             StructType* st = qt.getStructType();
             const StructTypeDecl* std = st.getDecl();
@@ -95,6 +102,10 @@ fn QualType Analyser.analyseElemsof(Analyser* ma, BuiltinExpr* b) {
 
     const ArrayType* at = qt.getArrayTypeOrNil();
     if (at) {
+        if (!at.hasSize()) {
+            ma.error(inner.getLoc(), "elemsof cannot be used on arrays of unknown length");
+            return QualType_Invalid;
+        }
         b.setUValue(at.getSize());
         return builtins[BuiltinKind.UInt32];
     }

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -248,7 +248,7 @@ fn bool BuiltinType.isVoid(const BuiltinType* b) {
     return b.base.builtinTypeBits.kind == BuiltinKind.Void;
 }
 
-fn const char* BuiltinType.kind2str(const BuiltinType* b) {
+public fn const char* BuiltinType.kind2str(const BuiltinType* b) {
     return builtinType_names[b.getKind()];
 }
 

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -548,7 +548,7 @@ public fn void Expr.printLiteral(const Expr* e, string_buffer.Buf* out) {
         IdentifierExpr.printLiteral((IdentifierExpr*)e, out);
         return;
     case Type:
-        TypeExpr.printLiteral((TypeExpr*)e, out, false);
+        TypeExpr.printLiteral((TypeExpr*)e, out);
         return;
     case Call:
         CallExpr.printLiteral((CallExpr*)e, out);

--- a/ast/module.c2
+++ b/ast/module.c2
@@ -29,6 +29,7 @@ public type Module struct @(opaque) {
     bool is_external;
     bool is_internal; // currently only for c2 module
     bool is_direct; // otherwise indirectly loaded via library.
+    bool is_foreign; // module identifiers are not mangled
     bool is_exported;
     bool is_loaded; // the file(s) parsed. For external libs
     ModuleType* mt;
@@ -48,6 +49,7 @@ public fn Module* Module.create(ast_context.Context* c, u32 name_idx, bool is_ex
     m.mt = ModuleType.create(c, m);
     m.name_idx = name_idx;
     m.is_external = is_external;
+    m.is_foreign = is_external;    // default for external modules
     m.is_internal = false;
     m.is_direct = is_direct;
     m.is_loaded = false;
@@ -75,6 +77,9 @@ public fn void Module.setInternal(Module* m) @(unused) { m.is_internal = true; }
 public fn bool Module.isInternal(const Module* m) { return m.is_internal; }
 
 public fn bool Module.isExternal(const Module* m) { return m.is_external; }
+
+public fn void Module.setForeign(Module* m, bool is_foreign) { m.is_foreign = is_foreign; }
+public fn bool Module.isForeign(const Module* m) { return m.is_foreign; }
 
 public fn void Module.setLoaded(Module* m) { m.is_loaded = true; }
 public fn bool Module.isLoaded(const Module* m) { return m.is_loaded; }

--- a/ast/type_expr.c2
+++ b/ast/type_expr.c2
@@ -74,6 +74,6 @@ fn void TypeExpr.print(const TypeExpr* e, string_buffer.Buf* out, u32 indent) {
     out.newline();
 }
 
-fn void TypeExpr.printLiteral(const TypeExpr* e, string_buffer.Buf* out, bool decay) {
-    e.typeRef.printLiteral(out, true, decay);
+fn void TypeExpr.printLiteral(const TypeExpr* e, string_buffer.Buf* out) {
+    e.typeRef.printLiteral(out, true);
 }

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -332,7 +332,7 @@ public fn Expr** TypeRef.getArray2(TypeRef* r, u32 idx) {
     return &arrays[idx];
 }
 
-public fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool print_prefix, bool decay) {
+fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool print_prefix) {
     if (r.isConst()) out.add("const ");
     if (r.isVolatile()) out.add("volatile ");
 
@@ -350,25 +350,18 @@ public fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bo
 
     for (u32 i=0; i<r.flags.num_ptrs; i++) out.add1('*');
 
-    // note: convert arrays into pointers
-    if (r.flags.incr_array) out.add("*");
+    if (r.flags.incr_array) out.add("[+]");
 
-    if (decay) {
-        // TODO: this seems incorrect: char[10][10] does not decay as char**
-        for (u32 i = 0; i < r.flags.num_arrays; i++) {
-            out.add("*");
-        }
-    } else {
-        for (u32 i = 0; i < r.flags.num_arrays; i++) {
-            out.add1('[');
-            const Expr* a = r.getArray(i);
-            // note: a can be nil, when[]
-            if (a) a.printLiteral(out);
-            out.add1(']');
-        }
+    for (u32 i = 0; i < r.flags.num_arrays; i++) {
+        out.add1('[');
+        const Expr* a = r.getArray(i);
+        // note: a can be nil, when[]
+        if (a) a.printLiteral(out);
+        out.add1(']');
     }
 }
 
+#if 0
 public type ExprPrinter fn void(void* arg, const Expr* e, string_buffer.Buf* out);
 
 // Prints arrays as arrays
@@ -390,16 +383,22 @@ public fn void TypeRef.printLiteral2(const TypeRef* r, string_buffer.Buf* out, b
 
     for (u32 i=0; i<r.flags.num_ptrs; i++) out.add1('*');
 
-    if (r.flags.incr_array) out.add("*");
+    if (r.flags.incr_array) out.add("[+]");
 
     for (u32 i=0; i<r.flags.num_arrays; i++) {
         out.add1('[');
         const Expr* a = r.getArray(i);
         // note: a can be nil, when[]
-        if (a) print_expr(arg, a, out);
+        if (a) {
+            if (print_expr)
+                print_expr(arg, a, out);
+            else
+                a.printLiteral(out);
+        }
         out.add1(']');
     }
 }
+#endif
 
 fn void TypeRef.print(const TypeRef* r, string_buffer.Buf* out, bool filled) {
     // eg. const test.Foo*[10]

--- a/common/component.c2
+++ b/common/component.c2
@@ -63,6 +63,7 @@ public type Component struct @(opaque) {
     u32 linkname;   // into auxPool
     Kind kind;
     bool is_direct; // only for external, if used directly (otherwise sub-dep)
+    bool is_foreign;        // only for external
     bool available_static;  // only for external
     bool available_dynamic; // only for external
 
@@ -114,6 +115,14 @@ public fn void Component.setPath(Component* c, u32 dirname) {
 
 public fn const char* Component.getPath(const Component* c) {
     return c.auxPool.idx2str(c.dirname_idx);
+}
+
+public fn void Component.setForeign(Component* c, bool is_foreign) {
+    c.is_foreign = is_foreign;
+}
+
+public fn bool Component.getForeign(const Component* c) {
+    return c.is_foreign;
 }
 
 public fn void Component.setLinkName(Component* c, const char* name) {

--- a/compiler/compiler_libs.c2
+++ b/compiler/compiler_libs.c2
@@ -113,7 +113,9 @@ fn void Compiler.open_lib(Compiler* c, Component* comp) {
     for (u32 i=0; i<mods.length(); i++) {
         u32 mod_name = mods.get_idx(i);
         ast.Module* m = comp.getOrAddModule(mod_name);
-        if (!m) {
+        if (m) {
+            m.setForeign(comp.getForeign());
+        } else {
             m = c.allmodules.find(mod_name);
             Component* other = c.find_component(m);
             assert(other);

--- a/compiler/manifest.c2
+++ b/compiler/manifest.c2
@@ -24,6 +24,7 @@ import yaml;
 
 import stdlib;
 import stdio local;
+import string local;
 
 fn const yaml.Node* get_checked(yaml.Parser* parser, const char* path) {
     const yaml.Node* node = parser.findNode(path);
@@ -69,6 +70,10 @@ fn bool getYamlInfo(yaml.Parser* parser,
     }
 
     comp.setKind(kind_static, kind_dynamic);
+
+    const char* language = parser.getScalarValue("info.language");
+    // component is foreign unless language is specified as c2 or native
+    comp.setForeign(!language || (strcasecmp(language, "c2") && strcasecmp(language, "native")));
 
     iter = parser.getNodeChildIter(modulesNode);
     while (!iter.done()) {

--- a/generator/c/c2i_generator_decl.c2
+++ b/generator/c/c2i_generator_decl.c2
@@ -55,7 +55,7 @@ fn void Generator.emitVarDecl(Generator* gen, const Decl* d, u32 indent) {
     VarDecl* v = cast<VarDecl*>(d);
 
     out.indent(indent);
-    gen.emitTypeRef(v.getTypeRef());
+    gen.emitType(d.getType());
     out.space();
     if (d.getName()) out.add(d.getName());
 
@@ -73,17 +73,103 @@ fn void Generator.emitVarDecl(Generator* gen, const Decl* d, u32 indent) {
     // Note: dont add ';' because it could also be a function argument
 }
 
-fn void Generator.emitTypeRef(Generator* gen, const TypeRef* ref) {
-    // Note: arrays are converted to pointers
-    const Decl* d = ref.getUserDecl();
-    bool is_external = false;
-    if (d) is_external = (d.getModule() != gen.mod);
+fn void Generator.emitDeclName(Generator* gen, string_buffer.Buf* out, Decl* d) {
+    if (!d.isVariable()) {
+        Module* mod = d.getModule();
+        if (mod != gen.mod) {
+            // TODO potentially needed if ambigous
+            out.add(mod.getName());
+            out.add1('.');
+        }
+        if (d.isFunction()) {
+            FunctionDecl* fd = cast<FunctionDecl*>(d);
+            Ref* prefix = fd.getPrefix();
+            if (prefix) {
+                out.add(ast.idx2name(prefix.name_idx));
+                out.add1('.');
+            }
+        }
+        if (d.isEnumConstant()) {
+            QualType qt = d.getType();
+            EnumType* et = cast<EnumType*>(qt.getType());
+            out.add(et.getName());
+            out.add1('.');
+        }
+    }
+    out.add(d.getName());
+}
 
-    // On globals print arrays as pointers, on inline function bodies, print as [..]
+fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType qt) {
+    Decl* decl = nil;
+
+    if (qt.isConst()) out.add("const ");
+    if (qt.isVolatile()) out.add("volatile ");
+
+    switch (qt.getKind()) {
+    case Builtin:
+        BuiltinType* bt = cast<BuiltinType*>(qt.getType());
+        out.add(bt.kind2str());
+        return;
+    case Pointer:
+        PointerType* pt = cast<PointerType*>(qt.getType());
+        gen.emitTypePre(out, pt.getInner());
+        out.add1('*');
+        return;
+    case Array:
+        ArrayType* at = cast<ArrayType*>(qt.getType());
+        gen.emitTypePre(out, at.getElemType());
+        return;
+    case Struct:
+        StructType* st = cast<StructType*>(qt.getType());
+        StructTypeDecl* std = st.getDecl();
+        if (std.hasAttrNoTypeDef()) {
+            out.add(std.isStruct() ? "struct " : "union ");
+        }
+        decl = cast<Decl*>(st.getDecl());
+        break;
+    case Enum:
+        EnumType* et = cast<EnumType*>(qt.getType());
+        decl = cast<Decl*>(et.getDecl());
+        break;
+    case Function:
+        FunctionType* ft = cast<FunctionType*>(qt.getType());
+        decl = cast<Decl*>(ft.getDecl());
+        break;
+    case Alias:
+        AliasType* at = cast<AliasType*>(qt.getType());
+        decl = cast<Decl*>(at.getDecl());
+        break;
+    case Module:
+        assert(0);
+        return;
+    }
+    gen.emitDeclName(out, decl);
+}
+
+fn void Generator.emitTypePost(Generator* gen, string_buffer.Buf* out, QualType qt) {
+    if (!qt.isArray()) return;
+    ArrayType* at = cast<ArrayType*>(qt.getType());
+
+    out.add1('[');
+    if (at.hasSize()) out.print("%d", at.getSize());
+    out.add1(']');
+    gen.emitTypePost(out, at.getElemType());
+}
+
+fn void Generator.emitType(Generator* gen, QualType qt) {
+    gen.emitTypePre(gen.out, qt);
+    gen.emitTypePost(gen.out, qt);
+}
+
+#if 0
+fn void Generator.emitTypeRef(Generator* gen, const TypeRef* ref) {
+    const Decl* d = ref.getUserDecl();
+    bool is_external = d && d.getModule() != gen.mod;
+
     if (gen.in_body) {
         ref.printLiteral2(gen.out, is_external, print_expr, gen);
     } else {
-        ref.printLiteral(gen.out, is_external, true);
+        ref.printLiteral(gen.out, is_external);
     }
 }
 
@@ -91,6 +177,7 @@ fn void print_expr(void* arg, const Expr* e, string_buffer.Buf* out) {
     Generator* gen = arg;
     gen.emitExpr(e);
 }
+#endif
 
 fn void Generator.emitEnumType(Generator* gen, const Decl* d) {
     string_buffer.Buf* out = gen.out;
@@ -121,7 +208,7 @@ fn void Generator.emitFunctionDecl(Generator* gen, const Decl* d, bool as_type) 
     FunctionDecl* fd = cast<FunctionDecl*>(d);
 
     if (!as_type) out.add("fn ");
-    gen.emitTypeRef(fd.getReturnTypeRef());
+    gen.emitType(fd.getRType());
     if (!as_type) {
         out.space();
         const char* prefix = fd.getPrefixName();
@@ -167,7 +254,8 @@ fn void Generator.emitAliasTypeDecl(Generator* gen, const Decl* d) {
     string_buffer.Buf* out = gen.out;
     AliasTypeDecl* a = cast<AliasTypeDecl*>(d);
     out.print("type %s ", d.getName());
-    gen.emitTypeRef(a.getTypeRef());
+    QualType qt = a.asDecl().getType();
+    gen.emitType(qt.getCanonicalType());
     out.add(";\n");
 }
 

--- a/generator/c/c2i_generator_stmt.c2
+++ b/generator/c/c2i_generator_stmt.c2
@@ -187,9 +187,9 @@ fn void Generator.emitStmt(Generator* gen, ast.Stmt* s, u32 indent, bool newline
             VarDecl* vd = ds.getDecl(i);
             Decl* d = cast<Decl*>(vd);
 
-            //if (vd.hasLocalQualifier()) out.add("local ");
             if (i == 0) {
-                gen.emitTypeRef(vd.getTypeRef());
+                if (vd.hasLocalQualifier()) out.add("local ");
+                gen.emitType(d.getType());
             } else {
                 out.add1(',');
             }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -153,7 +153,7 @@ fn void Generator.emitCName(Generator* gen, string_buffer.Buf* out, const Decl* 
 }
 
 fn void Generator.emitCNameMod(Generator* /*gen*/, string_buffer.Buf* out, const Decl* d, Module* mod) {
-    if (d.isExternal()) {
+    if (d.isExternal() && d.getModule().isForeign()) {
         const char* cname = d.getCName();
         if (cname) {
             out.add(cname);
@@ -264,17 +264,6 @@ const char*[] builtinType_cnames = {
 
 static_assert(elemsof(BuiltinKind), elemsof(builtinType_cnames));
 
-fn void Generator.emitGlobalVarTypePre(Generator* gen, string_buffer.Buf* out, QualType qt) {
-    if (gen.cur_external && qt.isArray()) {
-        // convert to pointer
-        ArrayType* at = cast<ArrayType*>(qt.getType());
-        gen.emitGlobalVarTypePre(out, at.getElemType());
-        out.add1('*');
-    } else {
-        gen.emitTypePre(out, qt);
-    }
-}
-
 fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType qt) {
     Decl* decl = nil;
 
@@ -322,12 +311,6 @@ fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType q
     }
 
     gen.emitCNameMod(out, decl, decl.getModule());
-}
-
-fn void Generator.emitGlobalVarTypePost(Generator* gen, string_buffer.Buf* out, QualType qt) {
-    if (!qt.isArray()) return;
-    if (gen.cur_external) return;
-    gen.emitTypePost(out, qt);
 }
 
 fn void Generator.emitTypePost(Generator* gen, string_buffer.Buf* out, QualType qt) {
@@ -526,10 +509,29 @@ fn void Generator.emitConstExpr(Generator* gen, string_buffer.Buf* out, Expr* e)
     gen.need_const_expr--;
 }
 
+fn void Generator.emitGlobalVarDeclCommon(Generator* gen, string_buffer.Buf* out, Decl* d) {
+    const char* cdef = d.getCDef();
+    if (cdef) {
+        out.add(cdef);
+    } else {
+        QualType qt = d.getType();
+        gen.emitTypePre(out, qt);
+        out.space();
+        gen.emitCName(out, d);
+        gen.emitTypePost(out, qt);
+    }
+    VarDecl* vd = cast<VarDecl*>(d);
+    if (vd.hasAttrWeak()) out.add(" __attribute__((weak))");
+
+    const char* section = d.getSection();
+    if (section) {
+        out.space();
+        gen.emitSectionAttr(out, section);
+    }
+}
+
 fn bool Generator.emitGlobalVarDecl(Generator* gen, string_buffer.Buf* out, Decl* d) {
     VarDecl* vd = cast<VarDecl*>(d);
-
-    QualType qt = d.getType();
 
     // emit 'simple'-constants as a defines
     if (emitAsDefine(vd)) {
@@ -554,65 +556,37 @@ fn bool Generator.emitGlobalVarDecl(Generator* gen, string_buffer.Buf* out, Decl
     */
 
     bool emit_header = gen.fast_build && d.isPublic();
+    if (emit_header) {
+        // generate extern declaration to header file
+        Fragment* f = gen.getFragment();
+        f.buf.add("extern ");
+        gen.emitGlobalVarDeclCommon(f.buf, d);
+        f.buf.add(";\n");
+        gen.addFragment(f, true);
+    }
 
     if (gen.cur_external) {
+        // generate extern declaration for interface file
         out.add("extern ");
-    } else {
+        gen.emitGlobalVarDeclCommon(out, d);
+        out.add(";\n");
+        return false;    // put this part in .c file
+    }
+
+    if (!d.isExternal()) {
+        // generate definition to c file
         if (!d.isExported() && !emit_header) out.add("static ");
-    }
-
-    const char* cdef = d.getCDef();
-    if (cdef) {
-        out.add(cdef);
-    } else {
-        gen.emitGlobalVarTypePre(out, qt);
-        out.space();
-        gen.emitCName(out, d);
-        gen.emitGlobalVarTypePost(out, qt);
-    }
-    if (vd.hasAttrWeak()) out.add(" __attribute__((weak))");
-
-    const char* section = d.getSection();
-    if (section) {
-        out.space();
-        gen.emitSectionAttr(out, section);
-    }
-
-    if (!gen.cur_external) {
+        gen.emitGlobalVarDeclCommon(out, d);
         out.add(" = ");
         Expr* ie = vd.getInit();
         if (ie) {
             gen.emitConstExpr(out, ie);
         } else {
-            // auto-initialize
-            gen.emitAutoInit(out, qt);
+            // auto-initialize (only required for embedded targets)
+            gen.emitAutoInit(out, d.getType());
         }
+        out.add(";\n\n");
     }
-    out.add(";\n\n");
-
-    if (emit_header) {
-        Fragment* f = gen.getFragment();
-        out = f.buf;
-
-        out.add("extern ");
-        if (cdef) {
-            out.add(cdef);
-        } else {
-            gen.emitGlobalVarTypePre(out, qt);
-            out.space();
-            gen.emitCName(out, d);
-            gen.emitGlobalVarTypePost(out, qt);
-        }
-        if (vd.hasAttrWeak()) out.add(" __attribute__((weak))");
-
-        if (section) {
-            out.space();
-            gen.emitSectionAttr(out, section);
-        }
-        out.add(";\n");
-        gen.addFragment(f, true);
-    }
-
     return false;    // put this part in .c file
 }
 
@@ -682,6 +656,7 @@ fn void Generator.emitGlobalDecl(Generator* gen, Decl* d) {
         string_buffer.Buf* out = gen.getBuf(d.isPublic());
         gen.gen_func_proto(fd, out);
         if (fd.isInline()) {
+            d.setGenerated();  // for recursive inline functions
             out.newline();
             string_buffer.Buf* saved = gen.out;
             gen.out = out;

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -162,7 +162,10 @@ fn void Generator.createMakefile(Generator* gen,
                 // special case for static libc
                 if (c.getNameIdx() == libc_name) out.add(" --static");
             }
-            if (linkname) out.print(" -l%s", linkname);
+            if (linkname) {
+                out.print(" -L../../%s", linkname);
+                out.print(" -l%s", linkname);
+            }
         }
         out.add(" $(LDFLAGS2)\n");
         out.newline();
@@ -186,7 +189,7 @@ fn void Generator.createMakefile(Generator* gen,
         out.print("../%s: $(objects) $(headers)\n", target_name);
 
         if (gen.targetInfo.sys == target_info.System.Darwin) {
-            out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s $(LDFLAGS2)\n", target_name);
+            out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o $$(dirname $$(pwd))/%s $(LDFLAGS2)\n", target_name);
         } else {
             out.print("\t\t$(CC) $(LDFLAGS) $(objects) -shared -o ../%s -Wl,-soname,%s.1 -Wl,--version-script=exports.version $(LDFLAGS2)\n",
                 target_name, target_name);

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -125,7 +125,7 @@ fn const char* Generator.createSymbolName(Generator* gen, const Decl* d) {
     string_buffer.Buf* out = gen.name_buf;
     out.clear();
 
-    if (d.isExternal()) {
+    if (d.isExternal() && d.getModule().isForeign()) {
         const char* cname = d.getCName();
         if (cname) {
             out.add(cname);

--- a/libs/c2/c2_test.c2i
+++ b/libs/c2/c2_test.c2i
@@ -1,0 +1,4 @@
+module c2_test;
+
+// array declaration with unknown length
+char[] test_array;

--- a/libs/c2/manifest.yaml
+++ b/libs/c2/manifest.yaml
@@ -1,7 +1,7 @@
 
 info:
 #    name: "C2 library"
-    language: c2
+    language: c
     type: library
     kinds:
         - static
@@ -22,3 +22,4 @@ modules:
     - f32
     - f64
     - varargs
+    - c2_test

--- a/test/c_generator/functions/inline/inline_prefix.c2t
+++ b/test/c_generator/functions/inline/inline_prefix.c2t
@@ -30,7 +30,7 @@ import test2;
 const u32 Max = 3;
 
 fn void myfunc(const test2.Point* p) {
-   test2.Point[Max] points;
+   test2.Point[3] points;
    points[1] = *p;
 }
 

--- a/test/interface/incremental_array.c2t
+++ b/test/interface/incremental_array.c2t
@@ -17,12 +17,12 @@ public const u32 Size = elemsof(b);
 // @expect{complete, aa.c2i}
 module aa;
 
-i32* b;
+i32[3] b;
 
 const u32 Size = 3;
 
 // @expect{atleast, aa.h}
-extern int32_t* aa_b;
+extern int32_t aa_b[3];
 
 #define aa_Size 3
 

--- a/test/interface/multi_dimension_array.c2t
+++ b/test/interface/multi_dimension_array.c2t
@@ -8,22 +8,20 @@ module aa;
 
 public i32[10][20] array;
 
-public const u32 Columns = elemsof(array);
-public const u32 Row = elemsof(array[0]);
+public const u32 Rows = elemsof(array);
+public const u32 Columns = elemsof(array[0]);
 
 // @expect{complete, aa.c2i}
 module aa;
 
-i32** array;
+i32[10][20] array;
 
-const u32 Columns = 10;
-const u32 Row = 20;
+const u32 Rows = 10;
+const u32 Columns = 20;
 
 // @expect{atleast, aa.h}
 
-extern int32_t** aa_array;
+extern int32_t aa_array[10][20];
 
-#define aa_Columns 10
-
-#define aa_Row 20
-
+#define aa_Rows 10
+#define aa_Columns 20

--- a/test/interface/public_by_array_expr.c2t
+++ b/test/interface/public_by_array_expr.c2t
@@ -19,14 +19,14 @@ public const u32 Size = elemsof(b);
 module bb;
 import aa;
 
-i32* b;
+i32[10] b;
 
 const u32 Size = 10;
 
 // @expect{atleast, bb.h}
 #include "aa.h"
 
-extern int32_t* bb_b;
+extern int32_t bb_b[10];
 
 #define bb_Size 10
 

--- a/test/vars/array_nosize.c2
+++ b/test/vars/array_nosize.c2
@@ -1,6 +1,17 @@
+// @warnings{no-unused}
 module test;
+
+import c2_test;
 
 fn void test1() {
     i32[] a;    // @error{array-type variable 'a' needs an explicit size or an initializer}
+}
+
+fn void test2() {
+    u32 count = elemsof(c2_test.test_array);    // @error{elemsof cannot be used on arrays of unknown length}
+}
+
+fn void test3() {
+    u32 size = sizeof(c2_test.test_array);    // @error{sizeof cannot be used on arrays of unknown length}
 }
 


### PR DESCRIPTION
* accept array definitions without length in interface files
* reject `elemsof` on arrays of unknown length
* fix external array definitions in C generator
* fix test/interface/incremental_array.c2t: fix external array definition
* fix test/interface/public_by_array_expr.c2t: fix external array definition
* fix test/interface/muti_dimensional_array.c2t: `Row` and `Columns` definitions were reversed, 2D external array definition in C was incorrect