### PR TITLE
c-generator: simplify enum definitions

### DIFF
--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -197,7 +197,16 @@ fn void Generator.emitDeclName(Generator* gen, string_buffer.Buf* out, const Dec
 
 fn void Generator.emitEnum(Generator* gen, string_buffer.Buf* out, Decl* d) {
     EnumTypeDecl* etd = cast<EnumTypeDecl*>(d);
-    out.add("typedef enum {\n");
+
+    // typedef enum types to their implementation type
+    out.add("typedef ");
+    gen.emitTypePre(out, etd.getImplType());
+    out.space();
+    gen.emitCName(out, d);
+    out.add(";\n");
+    out.add("enum ");
+    gen.emitCName(out, d);
+    out.add(" {\n");
     // set generated, otherwise constant self-ref goes wrong
     d.setGenerated();
     u32 num_constants = etd.getNumConstants();
@@ -218,30 +227,7 @@ fn void Generator.emitEnum(Generator* gen, string_buffer.Buf* out, Decl* d) {
         }
         out.add(",\n");
     }
-    // add max to ensure size is ok
-    QualType implType = etd.getImplType();
-    const BuiltinType* bi = implType.getBuiltin();
-    out.indent(1);
-    out.print("_%s_%s_max = ", gen.mod_name, d.getName());
-    switch (bi.getAlignment()) {
-    case 1:
-        out.add("255");
-        break;
-    case 2:
-        out.add("65535");
-        break;
-    case 4:
-        out.add("4294967295");
-        break;
-    case 8:
-        out.add("18446744073709551615");
-        break;
-    }
-    out.newline();
-
-    out.add("} __attribute__((packed)) ");
-    gen.emitCName(out, d);
-    out.add(";\n\n");
+    out.add("};\n\n");
 }
 
 const char*[] builtinType_cnames = {

--- a/test/c_generator/types/enum_func.c2t
+++ b/test/c_generator/types/enum_func.c2t
@@ -51,12 +51,12 @@ fn void test3() {
 
 // @expect{atleast, cgen/build.c}
 
-typedef enum {
+typedef uint8_t test_Foo;
+enum test_Foo {
    test_Foo_A,
    test_Foo_B,
    test_Foo_C,
-   _test_Foo_max = 255
-} __attribute__((packed)) test_Foo;
+};
 
 static void test_Foo_func1(test_Foo f);
 static void test_Foo_func2(const test_Foo f);

--- a/test/c_generator/types/full_enum.c2t
+++ b/test/c_generator/types/full_enum.c2t
@@ -21,12 +21,12 @@ fn void test1() {
 
 // @expect{atleast, cgen/build.c}
 
-typedef enum {
+typedef uint8_t file1_State;
+enum file1_State {
     file1_State_A,
     file1_State_B,
     file1_State_C,
-    _file1_State_max = 255
-} __attribute__((packed)) file1_State;
+};
 
 static void file2_test1(void);
 

--- a/test/c_generator/types/keep_same_order.c2t
+++ b/test/c_generator/types/keep_same_order.c2t
@@ -22,10 +22,10 @@ struct test_Point_ {
     int32_t x;
 };
 
-typedef enum {
+typedef int8_t test_State;
+enum test_State {
   test_State_A,
   test_State_B,
   test_State_C,
-  _test_State_max = 255
-} __attribute__((packed)) test_State;
+};
 

--- a/test/interface/incremental_enum.c2t
+++ b/test/interface/incremental_enum.c2t
@@ -27,12 +27,12 @@ const u32 Size = 3;
 
 // @expect{atleast, aa.h}
 
-typedef enum {
+typedef uint8_t aa_Enum;
+enum aa_Enum {
    aa_Enum_A,
    aa_Enum_B,
    aa_Enum_C,
-   _aa_Enum_max = 255
-} __attribute__((packed)) aa_Enum;
+};
 
 #define aa_Size 3
 

--- a/test/interface/multi_module.c2t
+++ b/test/interface/multi_module.c2t
@@ -49,11 +49,11 @@ typedef int32_t aa_AA;
 #define aa_FIRST 1
 
 // @expect{atleast, bb.h}
-typedef enum {
+typedef int8_t bb_Enum;
+enum bb_Enum {
     bb_Enum_One = aa_FIRST,
     bb_Enum_Two,
-    _bb_Enum_max = 255
-} __attribute__((packed)) bb_Enum;
+};
 
 aa_AA bb_bb1(aa_AA* arg1);
 

--- a/test/interface/multi_module_as.c2t
+++ b/test/interface/multi_module_as.c2t
@@ -50,9 +50,9 @@ typedef int32_t aa_AA;
 #define aa_FIRST 1
 
 // @expect{atleast, bb.h}
-typedef enum {
+typedef int8_t bb_Enum;
+enum bb_Enum {
     bb_Enum_One = aa_FIRST,
     bb_Enum_Two,
-    _bb_Enum_max = 255
-} __attribute__((packed)) bb_Enum;
+};
 

--- a/test/interface/multi_module_local.c2t
+++ b/test/interface/multi_module_local.c2t
@@ -49,11 +49,11 @@ typedef int32_t aa_AA;
 #define aa_FIRST 1
 
 // @expect{atleast, bb.h}
-typedef enum {
+typedef int8_t bb_Enum;
+enum bb_Enum {
     bb_Enum_One = aa_FIRST,
     bb_Enum_Two,
-    _bb_Enum_max = 255
-} __attribute__((packed)) bb_Enum;
+};
 
 aa_AA bb_bb1(aa_AA* arg1);
 

--- a/test/interface/public_by_enum_init.c2t
+++ b/test/interface/public_by_enum_init.c2t
@@ -26,8 +26,8 @@ type BB enum i8 {
 // @expect{atleast, bb.h}
 #include "aa.h"
 
-typedef enum {
-      bb_BB_BB1 = aa_AA,
-      _bb_BB_max = 255
-} __attribute__((packed)) bb_BB;
+typedef int8_t bb_BB;
+enum bb_BB {
+    bb_BB_BB1 = aa_AA,
+};
 


### PR DESCRIPTION
* typedef enum types to their implementation type
* this improves portability and fixes the tcc build