### PR TITLE
Parser: fix missing initializations

### DIFF
--- a/ast/asm_stmt.c2
+++ b/ast/asm_stmt.c2
@@ -71,18 +71,18 @@ public fn AsmStmt* AsmStmt.create(ast_context.Context* c,
     s.asm_string = (StringLiteral*)str;
 
     u8* tail = (u8*)s.constraints;
-    if (constraints.size()) {
-        u32 sz = constraints.size() * sizeof(Expr*);
+    if (s.num_constraints) {
+        u32 sz = s.num_constraints * sizeof(Expr*);
         string.memcpy(tail, constraints.getExprs(), sz);
         tail += sz;
     }
-    if (exprs.size()) {
-        u32 sz = exprs.size() * sizeof(Expr*);
+    if (s.num_exprs) {
+        u32 sz = s.num_exprs * sizeof(Expr*);
         string.memcpy(tail, exprs.getExprs(), sz);
         tail += sz;
     }
-    if (clobbers.size()) {
-        u32 sz = clobbers.size() * sizeof(Expr*);
+    if (s.num_clobbers) {
+        u32 sz = s.num_clobbers * sizeof(Expr*);
         string.memcpy(tail, clobbers.getExprs(), sz);
         tail += sz;
     }

--- a/ast/builtin_expr.c2
+++ b/ast/builtin_expr.c2
@@ -80,7 +80,7 @@ public fn BuiltinExpr* BuiltinExpr.create(ast_context.Context* c, SrcLoc loc, u3
 }
 
 public fn BuiltinExpr* BuiltinExpr.createOffsetOf(ast_context.Context* c, SrcLoc loc, u32 src_len, Expr* typeExpr, Expr* member) {
-    const u32 size  =sizeof(BuiltinExpr) + sizeof(OffsetOfData);
+    const u32 size = sizeof(BuiltinExpr) + sizeof(OffsetOfData);
     BuiltinExpr* e = c.alloc(size);
     e.base.init(ExprKind.Builtin, loc, true, true, false, ValType.RValue);
     e.base.base.builtinExprBits.kind = BuiltinExprKind.OffsetOf;
@@ -101,6 +101,7 @@ public fn BuiltinExpr* BuiltinExpr.createToContainer(ast_context.Context* c, Src
     e.base.base.builtinExprBits.kind = BuiltinExprKind.ToContainer;
     e.base.base.builtinExprBits.src_len = src_len;
     e.inner = typeExpr;
+    e.value.setUnsigned(0);
     e.container[0].member = member;
     e.container[0].pointer = pointer;
 #if AstStatistics

--- a/ast/enum_type_decl.c2
+++ b/ast/enum_type_decl.c2
@@ -102,6 +102,7 @@ public fn EnumConstantDecl** EnumTypeDecl.getConstants(EnumTypeDecl* d) {
 }
 
 public fn void EnumTypeDecl.setIncrConstants(EnumTypeDecl* d, ast_context.Context* c, IdentifierExpr** constants, u32 count) {
+    assert(count);
     const u32 size = count * sizeof(EnumConstantDecl*);
     EnumConstantDecl** decls = c.alloc(size);
 
@@ -137,7 +138,7 @@ public fn EnumConstantDecl* EnumTypeDecl.getConstant(const EnumTypeDecl* d, u32 
 
 public fn void EnumTypeDecl.setEnumFunctions(EnumTypeDecl* d, ast_context.Context* c, FunctionDecl** funcs, u32 count) {
     const u32 size = count * sizeof(FunctionDecl*);
-    void* dest = c.alloc(size);
+    FunctionDecl** dest = c.alloc(size);
     string.memcpy(dest, funcs, size);
     d.enum_functions = dest;
     d.num_enum_functions = count;

--- a/ast/explicit_cast_expr.c2
+++ b/ast/explicit_cast_expr.c2
@@ -42,8 +42,8 @@ public fn ExplicitCastExpr* ExplicitCastExpr.create(ast_context.Context* c,
     e.base.init(ExprKind.ExplicitCast, loc, 0, 0, 0, ValType.NValue);
     e.base.base.explicitCastExprBits.c_style = c_style;
     e.base.base.explicitCastExprBits.src_len = src_len;
-    e.dest_type = QualType_Invalid;
     e.inner = inner;
+    e.dest_type = QualType_Invalid;
     e.dest.init(ref);
 #if AstStatistics
     Stats.addExpr(ExprKind.ExplicitCast, size);
@@ -59,6 +59,7 @@ fn Expr* ExplicitCastExpr.instantiate(ExplicitCastExpr* e, Instantiator* inst) {
     ExplicitCastExpr* e2 = inst.c.alloc(size);
     e2.base = e.base;
     e2.inner = e.inner.instantiate(inst);
+    e2.dest_type = QualType_Invalid;
     e2.dest.instantiate(&e.dest, inst);
     return (Expr*)e2;
 }

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -70,12 +70,10 @@ public type FunctionDecl struct @(opaque) {
     u16 instance_idx;     // template functions only
     u32 template_name;    // index into string pool
     SrcLoc template_loc;
-    // NOTE: 4 bytes padding here (can be used for flags)
     union {
         FunctionDeclFlags flags;
         u32 flagBits;
     }
-
     Ref prefix;
     TypeRef rtype;        // return type as in code. note: variable size!
     //VarDecl*[0] params; // tail-allocated;
@@ -101,21 +99,22 @@ public fn FunctionDecl* FunctionDecl.create(ast_context.Context* c,
     d.base.functionDeclBits.is_variadic = is_variadic;
     d.base.functionDeclBits.call_kind = prefix ? CallKind.StaticTypeFunc : CallKind.Normal;
     d.base.functionDeclBits.is_type = is_type;
-    d.flagBits = 0;
+    d.body = nil;
+    d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
     d.attr_printf_arg = 0;
     d.instance_idx = 0;
     d.template_name = 0;
     d.template_loc = 0;
-    d.rt = QualType_Invalid;
+    d.flagBits = 0;
+    d.prefix = {};
     d.rtype.init(rtype);
-    d.body = nil;
-    u8* tail = d.rtype.getPointerAfter();
     if (prefix) {
         d.base.functionDeclBits.has_prefix = 1;
         d.prefix = *prefix;
     }
     if (num_params) {
+        VarDecl** tail = d.rtype.getPointerAfter();
         string.memcpy(tail, params, num_params * sizeof(VarDecl*));
     }
 
@@ -146,18 +145,18 @@ public fn FunctionDecl* FunctionDecl.createTemplate(ast_context.Context* c,
     d.base.functionDeclBits.call_kind = CallKind.Normal;
     d.base.functionDeclBits.is_template = 1;
     d.base.functionDeclBits.is_type  = false;
-    d.flagBits = 0;
+    d.body = nil;
+    d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
     d.attr_printf_arg = 0;
     d.instance_idx = 0;
     d.template_name = template_name;
     d.template_loc = template_loc;
-    d.rt = QualType_Invalid;
+    d.flagBits = 0;
+    d.prefix = {};
     d.rtype.init(rtype);
-    d.body = nil;
-    u8* tail = d.rtype.getPointerAfter();
-
     if (num_params) {
+        VarDecl** tail = d.rtype.getPointerAfter();
         string.memcpy(tail, params, num_params * sizeof(VarDecl*));
     }
 
@@ -176,11 +175,11 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
 
     bool rtype_matches = fd.rtype.matchesTemplate(fd.template_name);
     u32 extra = rtype_matches ? inst.ref.getExtraSize() : fd.rtype.getExtraSize();
-
-    u32 size = sizeof(FunctionDecl) + fd.num_params * sizeof(VarDecl*) + extra;
+    u32 num_params = fd.num_params;
+    u32 size = sizeof(FunctionDecl) + num_params * sizeof(VarDecl*) + extra;
     FunctionDecl* fd2 = inst.c.alloc(size);
     // copy members
-    string.memcpy(&fd2.base, &fd.base, sizeof(Decl));
+    fd2.base = fd.base;
     // note: the instantiation is no longer a template function (otherwise ignored by analyseFunctionProto)
     fd2.base.functionDeclBits.is_template = 0;
     FunctionType* ftype = FunctionType.create(inst.c, fd2);
@@ -200,9 +199,9 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
     fd2.prefix = fd.prefix;
     fd2.rtype.instantiate(&fd.rtype, inst);
 
-    VarDecl** src = (VarDecl**)fd.rtype.getPointerAfter();
-    VarDecl** dst = (VarDecl**)fd2.rtype.getPointerAfter();
-    for (u32 i=0; i<fd2.num_params; i++) {
+    VarDecl** src = fd.rtype.getPointerAfter();
+    VarDecl** dst = fd2.rtype.getPointerAfter();
+    for (u32 i = 0; i < num_params; i++) {
         dst[i] = src[i].instantiate(inst);
     }
 
@@ -339,9 +338,7 @@ public fn u32 FunctionDecl.getNumParams(const FunctionDecl* d) {
 }
 
 public fn VarDecl** FunctionDecl.getParams(const FunctionDecl* d) {
-    u8* tail = d.rtype.getPointerAfter();
-    VarDecl** params = (VarDecl**)tail;
-    return params;
+    return d.rtype.getPointerAfter();
 }
 
 public fn u32 FunctionDecl.getNumAutoArgs(const FunctionDecl* d) {
@@ -457,7 +454,6 @@ fn void FunctionDecl.print(const FunctionDecl* d, string_buffer.Buf* out, u32 in
     out.space();
     out.color(col_Value);
 
-    const u8* tail = d.rtype.getPointerAfter();
     if (d.hasPrefix()) {
         out.add(d.prefix.getName());
         out.add1('.');
@@ -473,7 +469,7 @@ fn void FunctionDecl.print(const FunctionDecl* d, string_buffer.Buf* out, u32 in
 
     //d.rtype.print(out, true,);
 
-    VarDecl** params = (VarDecl**)tail;
+    VarDecl** params = d.getParams();
     for (u32 i=0; i<d.num_params; i++) {
         params[i].print(out, indent + 1);
     }
@@ -494,8 +490,7 @@ fn void FunctionDecl.printType(const FunctionDecl* d, string_buffer.Buf* out) {
     }
     out.add(" (");
 
-    const u8* tail = d.rtype.getPointerAfter();
-    VarDecl** params = (VarDecl**)tail;
+    VarDecl** params = d.getParams();
     for (u32 i=0; i<d.num_params; i++) {
         if (i != 0) out.add(", ");
         params[i].printType(out);

--- a/ast/function_type.c2
+++ b/ast/function_type.c2
@@ -26,7 +26,6 @@ public type FunctionType struct @(opaque) {
 fn FunctionType* FunctionType.create(ast_context.Context* c, FunctionDecl* decl) {
     FunctionType* t = c.alloc(sizeof(FunctionType));
     t.base.init(TypeKind.Function);
-    t.decl = nil;
     t.decl = decl;
 
     t.base.setCanonicalType(QualType.create(&t.base));

--- a/ast/init_list_expr.c2
+++ b/ast/init_list_expr.c2
@@ -37,8 +37,8 @@ public fn InitListExpr* InitListExpr.create(ast_context.Context* c, SrcLoc loc, 
     u32 size = sizeof(InitListExpr) + num_values * sizeof(Expr*);
     InitListExpr* e = c.alloc(size);
     e.base.init(ExprKind.InitList, loc, 0, 0, 0, ValType.RValue);
-    e.num_values = num_values;
     e.endLoc = endLoc;
+    e.num_values = num_values;
     if (num_values) {
         string.memcpy(e.values, values, num_values * sizeof(Expr*));
     }
@@ -53,8 +53,8 @@ fn Expr* InitListExpr.instantiate(InitListExpr* e, Instantiator* inst) {
     u32 size = sizeof(InitListExpr) + num_values * sizeof(Expr*);
     InitListExpr* e2 = inst.c.alloc(size);
     e2.base = e.base;
-    e2.num_values = num_values;
     e2.endLoc = e.endLoc;
+    e2.num_values = num_values;
     for (u32 i=0; i<num_values; i++) {
         e2.values[i] = e.values[i].instantiate(inst);
     }

--- a/ast/static_assert.c2
+++ b/ast/static_assert.c2
@@ -21,6 +21,7 @@ import src_loc local;
 
 public type StaticAssert struct @(opaque) {
     u32 ast_idx;    // into globals.ast_list, 0 means nil
+    u32 loc;
     Expr* lhs;
     Expr* rhs;
 }
@@ -33,6 +34,7 @@ public fn StaticAssert* StaticAssert.create(ast_context.Context* c,
 {
     StaticAssert* d = c.alloc(sizeof(StaticAssert));
     d.ast_idx = ast_idx;
+    d.loc = loc;
     d.lhs = lhs;
     d.rhs = rhs;
 #if AstStatistics

--- a/ast/struct_type_decl.c2
+++ b/ast/struct_type_decl.c2
@@ -107,7 +107,6 @@ public fn StructTypeDecl* StructTypeDecl.create(ast_context.Context* c,
     layout.alignment = 0;
     layout.attr_alignment = 1;
 
-    u32* member_offsets = (u32*)&d.members[d.num_members];
     if (num_members) {
         string.memcpy(d.members, members, num_members * sizeof(Decl*));
         string.memset(layout.member_offsets, 0, num_members * sizeof(u32));
@@ -224,7 +223,7 @@ public fn bool StructTypeDecl.hasAttrNoTypeDef(const StructTypeDecl* d) {
 
 public fn void StructTypeDecl.setStructFunctions(StructTypeDecl* d, ast_context.Context* c, FunctionDecl** funcs, u32 count) {
     const u32 size = count * sizeof(FunctionDecl*);
-    void* dest = c.alloc(size);
+    FunctionDecl** dest = c.alloc(size);
     string.memcpy(dest, funcs, size);
     d.struct_functions = dest;
     d.num_struct_functions = count;

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -122,7 +122,6 @@ public fn VarDecl* VarDecl.createStructMember(ast_context.Context* c,
     VarDecl* d = c.alloc(size);
     d.base.init(DeclKind.Variable, name, loc, is_public, QualType_Invalid, ast_idx);
     d.base.varDeclBits.kind = VarDeclKind.StructMember;
-
     if (name == 0) d.base.setUsed();  // set unnamed member to used
     d.typeRef.init(ref);
     if (bitfield) {
@@ -157,16 +156,14 @@ fn VarDecl* VarDecl.instantiate(const VarDecl* vd, Instantiator* inst)
     vd2.typeRef.instantiate(&vd.typeRef, inst);
 
     if (vd.base.varDeclBits.has_init_or_bitfield) {
-        void* tail1 = vd.typeRef.getPointerAfter();
-        void* tail2 = vd2.typeRef.getPointerAfter();
         if (vd.isStructMember()) {
-            BitFieldInfo* info1 = (BitFieldInfo*)tail1;
-            BitFieldInfo* info2 = (BitFieldInfo*)tail2;
+            BitFieldInfo* info1 = vd.typeRef.getPointerAfter();
+            BitFieldInfo* info2 = vd2.typeRef.getPointerAfter();
             info2.loc = info1.loc;
             info2.expr = info1.expr.instantiate(inst);
         } else {
-            VarDeclInit* init1 = tail1;
-            VarDeclInit* init2 = tail2;
+            VarDeclInit* init1 = vd.typeRef.getPointerAfter();
+            VarDeclInit* init2 = vd2.typeRef.getPointerAfter();
             init2.loc = init1.loc;
             init2.expr = init1.expr.instantiate(inst);
         }


### PR DESCRIPTION
* add missing initialisation in AST nodes
* improve node init order consistency
* simplify expressions
* try and avoid `void*` pointers to ensure type correctness