### PR TITLE
Compiler: fix bitfield layout for packed and unpacked structs and unions

### DIFF
--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -62,8 +62,12 @@ fn void Analyser.analyseStructMembers(Analyser* ma, StructTypeDecl* d) {
                 // canonical must be builtin type/enum
                 QualType qt = member.getType();
                 u32 type_width = qt.getBitFieldWidth();
+                const char* name = vd.getName();
                 if (type_width == 0) {
-                    ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has invalid type", vd.getName());
+                    if (name)
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has invalid type", name);
+                    else
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "unnamed bit-field has invalid type");
                     return;
                 }
 
@@ -76,30 +80,41 @@ fn void Analyser.analyseStructMembers(Analyser* ma, StructTypeDecl* d) {
                 }
                 Value value = ctv_analyser.get_value(bitfield);
                 if (value.isZero()) {
-                    ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "zero width for bit-field '%s'", vd.getName());
+                    if (name)
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "zero width for bit-field '%s'", name);
+                    else
+                    if (d.isUnion())
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "zero width bit-field not allowed in union");
+                    // keep going
+                }
+                if (value.isNegative()) {
+                    if (name)
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has negative width", name);
+                    else
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "unnamed bit-field has negative width");
                     // keep going
                 }
                 u32 field_width = value.as_u32();
                 vd.setBitfieldWidth((u8)field_width);
 
                 if (qt.isEnum() && field_width < type_width) {
-                    ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has insufficient bits for enum '%s'", vd.getName(), qt.diagName());
+                    if (name)
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has insufficient bits for enum '%s'", name, qt.diagName());
+                    else
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "unnamed bit-field has insufficient bits for enum '%s'", qt.diagName());
                     return;
                 }
 
                 if (field_width > type_width) {
-                    const char* name = vd.getName();
                     if (name) {
                         ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "width of bit-field '%s' (%d bits) exceeds the width of its type (%d bit%s)",
                             name, field_width, type_width, type_width > 1 ? "s" : "");
                     } else {
-                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "width of anonymous bit-field (%d bits) exceeds the width of its type (%d bit%s)",
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "width of unnamed bit-field (%d bits) exceeds the width of its type (%d bit%s)",
                             field_width, type_width, type_width > 1 ? "s" : "");
                     }
                     return;
                 }
-                // width of bit-field 'i' (17 bits) exceeds the width of its type (16 bits)
-                // width of anonymous bit-field (17 bits) exceeds the width of its type (16 bits)
             }
 
             member.setChecked();

--- a/analyser/size_analyser.c2
+++ b/analyser/size_analyser.c2
@@ -17,151 +17,156 @@ module size_analyser;
 
 import ast local;
 
+//import stdio local;
+//import string local;
+
 public type TypeSize struct {
     u32 size;
     u32 align;
-    u32 bitfield_size;      // u8 field : 3; .  size = 3    Node: size in bits
-    u32 bitfield_width;     // u8 field : 3; . width = 8    Note: width in bits (8/16/32/64)
 }
 
 fn TypeSize sizeOfUnion(StructTypeDecl* s) {
-    TypeSize result = { 0, 1, 0, 0 };
-    //bool packed = s.isPacked();
-    result.align = s.getAttrAlignment();
+    bool packed = s.isPacked();
+    u32 max_size = 0;
+    u32 max_align = s.getAttrAlignment();
+    if (!max_align) max_align = 1;
     //printf("SIZEOF  UNION %s packed=%d  aligned=%d\n", s.getName(), packed, alignment);
-    // TODO handle packed
 
     u32 num_members = s.getNumMembers();
     Decl** members = s.getMembers();
-    for (u32 i=0; i<num_members; i++) {
+    for (u32 i = 0; i < num_members; i++) {
         Decl* d = members[i];
-        TypeSize m_size = sizeOfType(d.getType());
+        TypeSize member = sizeOfType(d.getType());
         // TODO handle un-packed sub-structs
-        if (m_size.size > result.size) result.size = m_size.size;
-        if (m_size.align > result.align) result.align = m_size.align;
+        u32 size = member.size;     // byte size of the current member
+        u32 align = member.align;   // alignment for the current member
+        if (packed) align = 1;
+        if (d.isVariable()) {
+            // Note: bitfield size/alignment is size of largest named member type used as base
+            VarDecl* vd = (VarDecl*)d;
+            BitFieldLayout* bit_layout = vd.getBitfieldLayout();
+            if (bit_layout) {
+                // Note: bit_layout.bit_width was already set in analyser
+                u32 bit_size = bit_layout.bit_width;
+                // In PCC layout only named bit-fields influence the alignment
+                if (packed) size = (bit_size + 7) / 8;
+                if (!d.getNameIdx()) align = 1;
+            }
+        }
+        if (max_align < align) max_align = align;
+        if (max_size < size) max_size = size;
     }
-    return result;
+    return { .size = max_size, .align = max_align };
 }
 
 public fn TypeSize sizeOfStruct(StructTypeDecl* s) {
     if (s.isUnion()) return sizeOfUnion(s);
 
-    // TODO refactor to struct we can pass along and do operations on (like end-bitfield)
-    TypeSize result = { 0, 1, 0, 0 };
-
     bool packed = s.isPacked();
-    result.align = s.getAttrAlignment();
-    //printf("SIZEOF STRUCT %s packed=%d  aligned=%d\n", s.asDecl().getName(), packed, result.align);
+    u32 max_align = s.getAttrAlignment();
+    if (!max_align) max_align = 1;
+    u32 pos = 0;       // byte position of the next member
+    u32 bit_pos = 0;   // bit offset of the next bitfield member
+    //const char* name = s.asDecl().getName();
+    //if (!name) name = "";
+    //bool trace = false;   // patch with actual filter based on name
+    //if (trace) printf("Layout struct %s  packed=%d  aligned=%d {\n", name, packed, max_align);
     u32 num_members = s.getNumMembers();
     Decl** members = s.getMembers();
-    if (packed) {
-        for (u32 i=0; i<num_members; i++) {
-            Decl* d = members[i];
-            TypeSize member = sizeOfType(d.getType());
-            // TODO handle un-packed sub-structs?
-            //printf("  @%03u member %s   size %d  align %d (bitfield %d/%d)\n", result.size, d.getName(), member.size, member.align, member.bitfield_size, member.bitfield_width);
-            //if (vd) { vd.setOffset(result.size);
-            s.setMemberOffset(i, result.size);
-            result.size += member.size;
+    for (u32 i = 0; i < num_members; i++) {
+        Decl* d = members[i];
+        // Note: doesn't analyze the bit-field
+        TypeSize member = sizeOfType(d.getType());
+        // TODO handle un-packed sub-structs
+        u32 size = member.size;     // byte size of the current member
+        u32 align = member.align;   // alignment for the current member
+        if (packed) align = 1;
+
+        BitFieldLayout* bit_layout = nil;
+        if (d.isVariable()) {
+            // Note: bitfield size/alignment is size of largest named member type used as base
+            VarDecl* vd = (VarDecl*)d;
+            bit_layout = vd.getBitfieldLayout();
         }
-    } else {
-        for (u32 i=0; i<num_members; i++) {
-            Decl* d = members[i];
-            //printf("FIELD[%d]  size %d align %d  bit %d / %d\n", i, result.size, result.align, result.bitfield_size, result.bitfield_width);
-            // Note: doesn't analyze the bit-field
-            TypeSize member = sizeOfType(d.getType());
-            if (member.align > result.align) result.align = member.align;
-
-            VarDecl* vd = d.isVariable() ? (VarDecl*)d : nil;
-            BitFieldLayout* bit_layout = nil;
-            if (vd) {
-                // Note: bitfield size/alignment is size of largest member type used as base
-                bit_layout = vd.getBitfieldLayout();
-                if (bit_layout) {
-                    // Note: bit_layout.bit_width was already set in analyser
-                    member.bitfield_size = bit_layout.bit_width;
-                    member.bitfield_width = member.size * 8;
-                    member.size = 0;
-                    member.align = 0;   // calculate at end
-                }
-            }
-            if (result.bitfield_width && member.align != 0) {   // no bitfield anymore, finalize last one
-                // TODO end last bitfield, add size etc
-                //printf("    end bitfield\n");
-                u32 bytesize = (result.bitfield_size + 7) / 8;
-                // TODO padding
-                result.size += bytesize;
-                if (bytesize > result.align) result.align = bytesize;
-                //printf("    setting bitfields size %d  align %d\n", result.size, result.align);
-                result.bitfield_width = 0;
-                result.bitfield_size = 0;
-            }
-            if (member.align > 1) {
-                if (member.align > result.align) result.align = member.align;
-                u32 rest = result.size % member.align;
-                if (rest != 0) {
-                    u32 pad = member.align - rest;
-                    //printf("  @%03u pad %d\n", result.size, pad);
-                    result.size += pad;
-                }
-            }
-            //const char* name = d.getName();
-            //printf("  @%03u member %s   size %d  align %d (bitfield %d/%d)\n", result.size, name ? name : "(nil)", member.size, member.align, member.bitfield_size, member.bitfield_width);
-
-            s.setMemberOffset(i, result.size);
-            if (bit_layout) {
-                //printf("    bit-fields %d / %d\n", result.bitfield_size, result.bitfield_width);
-                u32 total_bitsize = result.bitfield_size + member.bitfield_size;
-                if (total_bitsize > member.bitfield_width) {
-                    u32 bytesize = (result.bitfield_size + 7) / 8;
-                    //printf("    new field (bytesize %d)\n", bytesize);
-                    member.align = bytesize;
-                    if (bytesize > 1) {
-                        u32 rest = result.size % bytesize;
-                        if (rest != 0) {
-                            u32 pad = member.align - rest;
-                            //printf("  @%03d pad %d\n", result.size, pad);
-                            result.size += pad;
-                        }
-                    }
-                    result.size += bytesize;
-                    s.setMemberOffset(i, result.size);  // update from above
-                    // Note: keep bit_layout.bit_offset at 0
-                    //if (bytesize > result.align) result.align = bytesize;
-                    result.bitfield_size = member.bitfield_size;
-                    result.bitfield_width = member.bitfield_width;
-                } else {
-                    bit_layout.bit_offset = (u8)result.bitfield_size;
-                    result.bitfield_size = total_bitsize;
-                    result.bitfield_width = member.bitfield_width;
-                }
+        //if (trace) {
+        //    name = d.getName();
+        //    printf("    FIELD[%d]  name=%s size=%d pos=%d bit_pos=%d", i, name ? name : "", size, pos, bit_pos);
+        //}
+        if (bit_layout) {
+            /* A bit-field: layout is more complicated.  there are two options:
+               PCC (GCC) compatible and MS compatible (ignored for now0.
+               In GCC layout a bit-field is placed adjacent to the preceding bit-fields, except if:
+               - it has zero-width
+               - an individual alignment was given
+               - it would overflow its base type container and there is no packing
+             */
+            // Note: bit_layout.bit_width was already set in analyser
+            u32 bit_size = bit_layout.bit_width;
+            // In PCC layout only named bitfields influence the alignment
+            if (!d.getNameIdx()) align = 1;
+            if (max_align < align) max_align = align;
+            //if (trace) printf("  bitfield bit_size=%d align=%d", bit_size, align);
+            if (bit_size == 0) {
+                // complete current storage unit
+                pos += (bit_pos + 7) / 8;
+                // align for this member using the original type alignment because
+                // packing does not affect zero-width bitfields
+                pos = (pos + member.align - 1) & -member.align;
+                //if (trace) printf(" -> new unit  offset=%d bit_offset=0\n", pos);
+                // Note: keep bit_layout.bit_offset at 0
+                bit_pos = 0;
             } else {
-                result.size += member.size;
+                u32 a8 = align * 8;
+                u32 ofs = ((pos * 8 + bit_pos) % a8 + bit_size + a8 - 1) / a8;
+                //if (trace) printf(" ofs=%d", ofs);
+                if (ofs > size / align && !packed) {
+                    // complete current storage unit
+                    pos += (bit_pos + 7) / 8;
+                    // align for this member
+                    pos = (pos + align - 1) & -align;
+                    //if (trace) printf(" -> new unit  offset=%d bit_offset=0\n", pos);
+                    // Note: keep bit_layout.bit_offset at 0
+                    bit_pos = bit_size;
+                } else {
+                    // skip storage units
+                    while (bit_pos >= a8) {
+                        pos += align;
+                        bit_pos -= a8;
+                    }
+                    bit_layout.bit_offset = (u8)bit_pos;
+                    //if (trace) printf(" -> offset=%d bit_offset=%d\n", pos, bit_pos);
+                    bit_pos += bit_size;
+                }
+                // in pcc mode, long long bitfields have type int if they fit
+                if (size == 8 && bit_size <= 32) size = 4;
             }
-            //printf("  . size %d  align %d bitfield (%d/%d)\n", result.size, result.align, result.bitfield_size, result.bitfield_width);
+            s.setMemberOffset(i, pos);
+        } else {
+            //if (trace) printf(" align=%d", align);
+            if (max_align < align) max_align = align;
+            // no bitfield anymore, finalize last one
+            pos += (bit_pos + 7) / 8;
+            bit_pos = 0;
+            // align for this member
+            pos = (pos + align - 1) & -align;
+            //if (trace) printf(" -> offset=%d\n", pos);
+            s.setMemberOffset(i, pos);
+            pos += size;
         }
-        if (result.bitfield_width) {
-            //printf("  done, bit-fields %d / %d\n", result.bitfield_size, result.bitfield_width);
-            u32 bytesize = (result.bitfield_size + 7) / 8;
-            // TODO padding before
-            result.size += bytesize;
-            //if (bytesize > result.align) result.align = bytesize;
-            //printf("    setting size %d  align %d\n", result.size, result.align);
-        }
-        u32 rest = result.size % result.align;
-        if (rest != 0) {
-            u32 pad = result.align - rest;
-            //printf("  @%03u pad %d\n", result.size, pad);
-            result.size += pad;
-        }
+        //if (trace) printf("  // pos=%d bit_pos=%d max_align=%d\n", pos, bit_pos, max_align);
     }
-    //printf("  . FINAL size %d  align %d\n", result.size, result.align);
-    return result;
+    //if (trace) printf("}  done  pos=%d bit_pos=%d\n", pos, bit_pos);
+    // complete the last bitfield if any
+    pos += (bit_pos + 7) / 8;
+    // pad structure for required alignment
+    pos = (pos + max_align - 1) & -max_align;
+    //if (trace) printf("  final size %d  align %d\n", pos, max_align);
+    return { .size = pos, .align = max_align };
 }
 
 public fn TypeSize sizeOfType(QualType qt) {
 
-    TypeSize result = { 0, 1, 0, 0 };
+    TypeSize result = { 0, 1, };
 
     if (qt.isInvalid()) return result;
 

--- a/test/types/struct/bitfield_demote.c2
+++ b/test/types/struct/bitfield_demote.c2
@@ -6,5 +6,5 @@ type A struct {
     u16 : 2;
     u8 : 1;
 }
-static_assert(2, sizeof(A));
+static_assert(1, sizeof(A));
 

--- a/test/types/struct/bitfield_exceeds_width_u8.c2
+++ b/test/types/struct/bitfield_exceeds_width_u8.c2
@@ -2,6 +2,6 @@
 module test;
 
 type A struct {
-    u8 : 11;        // @error{width of anonymous bit-field (11 bits) exceeds the width of its type (8 bits)}
+    u8 : 11;        // @error{width of unnamed bit-field (11 bits) exceeds the width of its type (8 bits)}
 }
 

--- a/test/types/struct/bitfield_middle_nonbitfield.c2
+++ b/test/types/struct/bitfield_middle_nonbitfield.c2
@@ -27,7 +27,7 @@ type B2 struct {
     u16 second;
     u32 : 3;
 }
-static_assert(8, sizeof(B2));
+static_assert(6, sizeof(B2));
 
 type C struct {
     u32 : 2;

--- a/test/types/struct/bitfield_mix.c2
+++ b/test/types/struct/bitfield_mix.c2
@@ -6,7 +6,7 @@ type A1 struct {
     u16 : 3;
     u32 : 4;
 }
-static_assert(4, sizeof(A1));
+static_assert(1, sizeof(A1));
 
 type A2 struct {
     u8 first;
@@ -20,14 +20,14 @@ type A3 struct {
     u16 : 9;
     u32 : 2;
 }
-static_assert(4, sizeof(A3));
+static_assert(2, sizeof(A3));
 
 type A4 struct {
     u8 : 3;
     u8 : 6;
     u16 : 3;
 }
-static_assert(4, sizeof(A4));
+static_assert(3, sizeof(A4));
 
 type A5 struct {
     u8 : 3;
@@ -48,7 +48,7 @@ type A7 struct {
     u8 : 3;
     u16 : 6;
 }
-static_assert(4, sizeof(A7));
+static_assert(3, sizeof(A7));
 
 type B struct {
     u16 : 2;
@@ -69,5 +69,5 @@ type C struct {
     u32 : 31;
     u32 : 2;
 }
-static_assert(12, sizeof(C));
+static_assert(6, sizeof(C));
 

--- a/test/types/struct/bitfield_overflow.c2
+++ b/test/types/struct/bitfield_overflow.c2
@@ -27,5 +27,5 @@ type C struct {
     u32 : 31;
     u32 : 2;
 }
-static_assert(12, sizeof(C));
+static_assert(6, sizeof(C));
 

--- a/test/types/struct/bitfield_single.c2
+++ b/test/types/struct/bitfield_single.c2
@@ -9,15 +9,15 @@ static_assert(1, sizeof(A));
 type B struct {
     u16 : 1;
 }
-static_assert(2, sizeof(B));
+static_assert(1, sizeof(B));
 
 type C struct {
     u32 : 1;
 }
-static_assert(4, sizeof(C));
+static_assert(1, sizeof(C));
 
 type D struct {
     u32 : 24;
 }
-static_assert(4, sizeof(D));
+static_assert(3, sizeof(D));
 

--- a/test/types/struct/bitfield_smaller.c2
+++ b/test/types/struct/bitfield_smaller.c2
@@ -5,18 +5,18 @@ type B struct {
     u16 : 1;
     u16 : 7;
 }
-static_assert(2, sizeof(B));
+static_assert(1, sizeof(B));
 
 type C struct {
     u32 : 1;
     u32 : 7;
 }
-static_assert(4, sizeof(C));
+static_assert(1, sizeof(C));
 
 type D struct {
     u32 : 1;
     u32 : 7;
     u32 : 8;
 }
-static_assert(4, sizeof(D));
+static_assert(2, sizeof(D));
 

--- a/test/types/struct/bitfield_substruct.c2
+++ b/test/types/struct/bitfield_substruct.c2
@@ -17,7 +17,7 @@ type B struct {
     }
     u16 : 1;
 }
-static_assert(6, sizeof(B));
+static_assert(3, sizeof(B));
 
 type C struct {
     u32 : 1;
@@ -26,5 +26,5 @@ type C struct {
     }
     u32 : 1;
 }
-static_assert(12, sizeof(C));
+static_assert(3, sizeof(C));
 

--- a/test/types/struct/bitfield_validator.c2
+++ b/test/types/struct/bitfield_validator.c2
@@ -1,0 +1,1160 @@
+// @warnings{no-unused}
+module test;
+
+import stdio local;
+import string local;
+
+const u8 A8 = 0xAA;
+const u8 F5 = 0x1F;
+const u8 F6 = 0x3F;
+const u8 F8 = 0xFF;
+const u16 F9 = 0x1FF;
+const u16 F16 = 0xFFFF;
+const u32 F24 = 0xFFFFFF;
+const u32 F32 = 0xFFFFFFFF;
+const u64 F64 = 0xFFFFFFFFFFFFFFFF;
+
+type S__b1 struct { u8 : 1; }
+type S__w1 struct { u16 : 1; }
+type S__d1 struct { u32 : 1; }
+type S__q1 struct { u64 : 1; }
+type S__b1_p struct @(packed) { u8 : 1; }
+type S__w1_p struct @(packed) { u16 : 1; }
+type S__d1_p struct @(packed) { u32 : 1; }
+type S__q1_p struct @(packed) { u64 : 1; }
+
+static_assert(1, sizeof(S__b1));
+static_assert(1, sizeof(S__w1));
+static_assert(1, sizeof(S__d1));
+static_assert(1, sizeof(S__q1));
+static_assert(1, sizeof(S__b1_p));
+static_assert(1, sizeof(S__w1_p));
+static_assert(1, sizeof(S__d1_p));
+static_assert(1, sizeof(S__q1_p));
+
+type S_b1 struct { u8 m : 1; }
+type S_w1 struct { u16 m : 1; }
+type S_d1 struct { u32 m : 1; }
+type S_q1 struct { u64 m : 1; }
+type S_b1_p struct @(packed) { u8 m : 1; }
+type S_w1_p struct @(packed) { u16 m : 1; }
+type S_d1_p struct @(packed) { u32 m : 1; }
+type S_q1_p struct @(packed) { u64 m : 1; }
+
+static_assert(1, sizeof(S_b1));
+static_assert(2, sizeof(S_w1));
+static_assert(4, sizeof(S_d1));
+static_assert(8, sizeof(S_q1));
+static_assert(1, sizeof(S_b1_p));
+static_assert(1, sizeof(S_w1_p));
+static_assert(1, sizeof(S_d1_p));
+static_assert(1, sizeof(S_q1_p));
+
+#if 1
+type S_b1_b0_b1 struct { u8 m : 1; u8 : 0; u8 b : 1; }
+type S_w1_w0_w1 struct { u16 m : 1; u16 : 0; u16 b : 1; }
+type S_d1_d0_d1 struct { u32 m : 1; u32 : 0; u32 b : 1; }
+type S_q1_q0_q1 struct { u64 m : 1; u64 : 0; u64 b : 1; }
+type S_b1_b0_b1_p struct @(packed) { u8 m : 1; u8 : 0; u8 b : 1; }
+type S_w1_w0_w1_p struct @(packed) { u16 m : 1; u16 : 0; u16 b : 1; }
+type S_d1_d0_d1_p struct @(packed) { u32 m : 1; u32 : 0; u32 b : 1; }
+type S_q1_q0_q1_p struct @(packed) { u64 m : 1; u64 : 0; u64 b : 1; }
+
+static_assert(2, sizeof(S_b1_b0_b1));
+static_assert(4, sizeof(S_w1_w0_w1));
+static_assert(8, sizeof(S_d1_d0_d1));
+static_assert(16, sizeof(S_q1_q0_q1));
+static_assert(2, sizeof(S_b1_b0_b1_p));
+static_assert(3, sizeof(S_w1_w0_w1_p));
+static_assert(5, sizeof(S_d1_d0_d1_p));
+static_assert(9, sizeof(S_q1_q0_q1_p));
+#endif
+
+type S_b1_b_b1 struct { u8 a : 1; u8 m; u8 b : 1; }
+type S_w1_b_w1 struct { u16 a : 1; u8 m; u16 b : 1; }
+type S_d1_b_d1 struct { u32 a : 1; u8 m; u32 b : 1; }
+type S_q1_b_q1 struct { u64 a : 1; u8 m; u64 b : 1; }
+type S_b1_b_b1_p struct @(packed) { u8 a : 1; u8 m; u8 b : 1; }
+type S_w1_b_w1_p struct @(packed) { u16 a : 1; u8 m; u16 b : 1; }
+type S_d1_b_d1_p struct @(packed) { u32 a : 1; u8 m; u32 b : 1; }
+type S_q1_b_q1_p struct @(packed) { u64 a : 1; u8 m; u64 b : 1; }
+
+static_assert(3, sizeof(S_b1_b_b1));
+static_assert(4, sizeof(S_w1_b_w1));
+static_assert(4, sizeof(S_d1_b_d1));
+static_assert(8, sizeof(S_q1_b_q1));
+static_assert(3, sizeof(S_b1_b_b1_p));
+static_assert(3, sizeof(S_w1_b_w1_p));
+static_assert(3, sizeof(S_d1_b_d1_p));
+static_assert(3, sizeof(S_q1_b_q1_p));
+
+type S_b1_b_b1_b_b1 struct { u8 a : 1; u8 m; u8 b : 1; u8 n; u8 c : 1; }
+type S_w1_b_w1_b_w1 struct { u16 a : 1; u8 m; u16 b : 1; u8 n; u16 c : 1; }
+type S_d1_b_d1_b_d1 struct { u32 a : 1; u8 m; u32 b : 1; u8 n; u32 c : 1; }
+type S_q1_b_q1_b_q1 struct { u64 a : 1; u8 m; u64 b : 1; u8 n; u64 c : 1; }
+type S_b1_b_b1_b_b1_p struct @(packed) { u8 a : 1; u8 m; u8 b : 1; u8 n; u8 c : 1; }
+type S_w1_b_w1_b_w1_p struct @(packed) { u16 a : 1; u8 m; u16 b : 1; u8 n; u16 c : 1; }
+type S_d1_b_d1_b_d1_p struct @(packed) { u32 a : 1; u8 m; u32 b : 1; u8 n; u32 c : 1; }
+type S_q1_b_q1_b_q1_p struct @(packed) { u64 a : 1; u8 m; u64 b : 1; u8 n; u64 c : 1; }
+
+static_assert(5, sizeof(S_b1_b_b1_b_b1));
+static_assert(6, sizeof(S_w1_b_w1_b_w1));
+static_assert(8, sizeof(S_d1_b_d1_b_d1));
+static_assert(8, sizeof(S_q1_b_q1_b_q1));
+static_assert(5, sizeof(S_b1_b_b1_b_b1_p));
+static_assert(5, sizeof(S_w1_b_w1_b_w1_p));
+static_assert(5, sizeof(S_d1_b_d1_b_d1_p));
+static_assert(5, sizeof(S_q1_b_q1_b_q1_p));
+
+type S_b_b struct { u8 a; u8 m; }
+type S_b_w struct { u8 a; u16 m; }
+type S_b_d struct { u8 a; u32 m; }
+type S_b_q struct { u8 a; u64 m; }
+type S_b_b_p struct @(packed) { u8 a; u8 m; }
+type S_b_w_p struct @(packed) { u8 a; u16 m; }
+type S_b_d_p struct @(packed) { u8 a; u32 m; }
+type S_b_q_p struct @(packed) { u8 a; u64 m; }
+
+static_assert(2, sizeof(S_b_b));
+static_assert(4, sizeof(S_b_w));
+static_assert(8, sizeof(S_b_d));
+static_assert(16, sizeof(S_b_q));
+static_assert(2, sizeof(S_b_b_p));
+static_assert(3, sizeof(S_b_w_p));
+static_assert(5, sizeof(S_b_d_p));
+static_assert(9, sizeof(S_b_q_p));
+
+type S_b_b_b struct { u8 a; u8 m; u8 b; }
+type S_b_w_b struct { u8 a; u16 m; u8 b; }
+type S_b_d_b struct { u8 a; u32 m; u8 b; }
+type S_b_q_b struct { u8 a; u64 m; u8 b; }
+type S_b_b_b_p struct @(packed) { u8 a; u8 m; u8 b; }
+type S_b_w_b_p struct @(packed) { u8 a; u16 m; u8 b; }
+type S_b_d_b_p struct @(packed) { u8 a; u32 m; u8 b; }
+type S_b_q_b_p struct @(packed) { u8 a; u64 m; u8 b; }
+
+static_assert(3, sizeof(S_b_b_b));
+static_assert(6, sizeof(S_b_w_b));
+static_assert(12, sizeof(S_b_d_b));
+static_assert(24, sizeof(S_b_q_b));
+static_assert(3, sizeof(S_b_b_b_p));
+static_assert(4, sizeof(S_b_w_b_p));
+static_assert(6, sizeof(S_b_d_b_p));
+static_assert(10, sizeof(S_b_q_b_p));
+
+type S_b_b1 struct { u8 a; u8 m : 1; }
+type S_b_w1 struct { u8 a; u16 m : 1; }
+type S_b_d1 struct { u8 a; u32 m : 1; }
+type S_b_q1 struct { u8 a; u64 m : 1; }
+type S_b_b1_p struct @(packed) { u8 a; u8 m : 1; }
+type S_b_w1_p struct @(packed) { u8 a; u16 m : 1; }
+type S_b_d1_p struct @(packed) { u8 a; u32 m : 1; }
+type S_b_q1_p struct @(packed) { u8 a; u64 m : 1; }
+
+static_assert(2, sizeof(S_b_b1));
+static_assert(2, sizeof(S_b_w1));
+static_assert(4, sizeof(S_b_d1));
+static_assert(8, sizeof(S_b_q1));
+static_assert(2, sizeof(S_b_b1_p));
+static_assert(2, sizeof(S_b_w1_p));
+static_assert(2, sizeof(S_b_d1_p));
+static_assert(2, sizeof(S_b_q1_p));
+
+type S_b1_b1 struct { u8 a : 1; u8 m : 1; }
+type S_b1_w1 struct { u8 a : 1; u16 m : 1; }
+type S_b1_d1 struct { u8 a : 1; u32 m : 1; }
+type S_b1_q1 struct { u8 a : 1; u64 m : 1; }
+type S_b1_b1_p struct @(packed) { u8 a : 1; u8 m : 1; }
+type S_b1_w1_p struct @(packed) { u8 a : 1; u16 m : 1; }
+type S_b1_d1_p struct @(packed) { u8 a : 1; u32 m : 1; }
+type S_b1_q1_p struct @(packed) { u8 a : 1; u64 m : 1; }
+
+static_assert(1, sizeof(S_b1_b1));
+static_assert(2, sizeof(S_b1_w1));
+static_assert(4, sizeof(S_b1_d1));
+static_assert(8, sizeof(S_b1_q1));
+static_assert(1, sizeof(S_b1_b1_p));
+static_assert(1, sizeof(S_b1_w1_p));
+static_assert(1, sizeof(S_b1_d1_p));
+static_assert(1, sizeof(S_b1_q1_p));
+
+type S_b_b1_b struct { u8 a; u8 m : 1; u8 b; }
+type S_b_w1_b struct { u8 a; u16 m : 1; u8 b; }
+type S_b_d1_b struct { u8 a; u32 m : 1; u8 b; }
+type S_b_q1_b struct { u8 a; u64 m : 1; u8 b; }
+type S_b_b1_b_p struct @(packed) { u8 a; u8 m : 1; u8 b; }
+type S_b_w1_b_p struct @(packed) { u8 a; u16 m : 1; u8 b; }
+type S_b_d1_b_p struct @(packed) { u8 a; u32 m : 1; u8 b; }
+type S_b_q1_b_p struct @(packed) { u8 a; u64 m : 1; u8 b; }
+
+static_assert(3, sizeof(S_b_b1_b));
+static_assert(4, sizeof(S_b_w1_b));
+static_assert(4, sizeof(S_b_d1_b));
+static_assert(8, sizeof(S_b_q1_b));
+static_assert(3, sizeof(S_b_b1_b_p));
+static_assert(3, sizeof(S_b_w1_b_p));
+static_assert(3, sizeof(S_b_d1_b_p));
+static_assert(3, sizeof(S_b_q1_b_p));
+
+type S_b1_b1_b1 struct { u8 a : 1; u8 m : 1; u8 b : 1; }
+type S_b1_w1_b1 struct { u8 a : 1; u16 m : 1; u8 b : 1; }
+type S_b1_d1_b1 struct { u8 a : 1; u32 m : 1; u8 b : 1; }
+type S_b1_q1_b1 struct { u8 a : 1; u64 m : 1; u8 b : 1; }
+type S_b1_b1_b1_p struct @(packed) { u8 a : 1; u8 m : 1; u8 b : 1; }
+type S_b1_w1_b1_p struct @(packed) { u8 a : 1; u16 m : 1; u8 b : 1; }
+type S_b1_d1_b1_p struct @(packed) { u8 a : 1; u32 m : 1; u8 b : 1; }
+type S_b1_q1_b1_p struct @(packed) { u8 a : 1; u64 m : 1; u8 b : 1; }
+
+static_assert(1, sizeof(S_b1_b1_b1));
+static_assert(2, sizeof(S_b1_w1_b1));
+static_assert(4, sizeof(S_b1_d1_b1));
+static_assert(8, sizeof(S_b1_q1_b1));
+static_assert(1, sizeof(S_b1_b1_b1_p));
+static_assert(1, sizeof(S_b1_w1_b1_p));
+static_assert(1, sizeof(S_b1_d1_b1_p));
+static_assert(1, sizeof(S_b1_q1_b1_p));
+
+type S_b5_b5_b5 struct { u8 a : 5; u8 m : 5; u8 b : 5; }
+type S_b5_w5_b5 struct { u8 a : 5; u16 m : 5; u8 b : 5; }
+type S_b5_d5_b5 struct { u8 a : 5; u32 m : 5; u8 b : 5; }
+type S_b5_q5_b5 struct { u8 a : 5; u64 m : 5; u8 b : 5; }
+type S_b5_b5_b5_p struct @(packed) { u8 a : 5; u8 m : 5; u8 b : 5; }
+type S_b5_w5_b5_p struct @(packed) { u8 a : 5; u16 m : 5; u8 b : 5; }
+type S_b5_d5_b5_p struct @(packed) { u8 a : 5; u32 m : 5; u8 b : 5; }
+type S_b5_q5_b5_p struct @(packed) { u8 a : 5; u64 m : 5; u8 b : 5; }
+
+static_assert(3, sizeof(S_b5_b5_b5));
+static_assert(2, sizeof(S_b5_w5_b5));
+static_assert(4, sizeof(S_b5_d5_b5));
+static_assert(8, sizeof(S_b5_q5_b5));
+static_assert(2, sizeof(S_b5_b5_b5_p));
+static_assert(2, sizeof(S_b5_w5_b5_p));
+static_assert(2, sizeof(S_b5_d5_b5_p));
+static_assert(2, sizeof(S_b5_q5_b5_p));
+
+type S_d24 struct { u32 m : 24; }
+type S_d24_p struct @(packed) { u32 m : 24; }
+type S_d24_d24 struct { u32 a : 24; u32 m : 24; }
+type S_d24_d24_p struct @(packed) { u32 a : 24; u32 m : 24; }
+type S_d24_d24_d24 struct { u32 a : 24; u32 m : 24; u32 b : 24; }
+type S_d24_d24_d24_p struct @(packed) { u32 a : 24; u32 m : 24; u32 b : 24; }
+type S_d24_d24_d24_d24 struct { u32 a : 24; u32 m : 24; u32 b : 24; u32 c : 24; }
+type S_d24_d24_d24_d24_p struct @(packed) { u32 a : 24; u32 m : 24; u32 b : 24; u32 c : 24; }
+type S_b_d24 struct { u8 a; u32 m : 24; }
+type S_b_d24_p struct @(packed) { u8 a; u32 m : 24; }
+type S_b_d24_b struct { u8 a; u32 m : 24; u8 b; }
+type S_b_d24_b_p struct @(packed) { u8 a; u32 m : 24; u8 b; }
+
+static_assert(4, sizeof(S_d24));
+static_assert(3, sizeof(S_d24_p));
+static_assert(8, sizeof(S_d24_d24));
+static_assert(6, sizeof(S_d24_d24_p));
+static_assert(12, sizeof(S_d24_d24_d24));
+static_assert(9, sizeof(S_d24_d24_d24_p));
+static_assert(16, sizeof(S_d24_d24_d24_d24));
+static_assert(12, sizeof(S_d24_d24_d24_d24_p));
+static_assert(4, sizeof(S_b_d24));
+static_assert(4, sizeof(S_b_d24_p));
+static_assert(8, sizeof(S_b_d24_b));
+static_assert(5, sizeof(S_b_d24_b_p));
+
+type S_d9 struct { u32 m : 9; }
+type S_d9_p struct @(packed) { u32 m : 9; }
+type S_b_d9 struct { u8 a; u32 m : 9; }
+type S_b_d9_p struct @(packed) { u8 a; u32 m : 9; }
+type S_b_d9_b struct { u8 a; u32 m : 9; u8 b; }
+type S_b_d9_b_p struct @(packed) { u8 a; u32 m : 9; u8 b; }
+
+static_assert(4, sizeof(S_d9));
+static_assert(2, sizeof(S_d9_p));
+static_assert(4, sizeof(S_b_d9));
+static_assert(3, sizeof(S_b_d9_p));
+static_assert(4, sizeof(S_b_d9_b));
+static_assert(4, sizeof(S_b_d9_b_p));
+
+type U_b1 union { u8 m : 1; }
+type U_w1 union { u16 m : 1; }
+type U_d1 union { u32 m : 1; }
+type U_q1 union { u64 m : 1; }
+type U_b1_p union @(packed) { u8 m : 1; }
+type U_w1_p union @(packed) { u16 m : 1; }
+type U_d1_p union @(packed) { u32 m : 1; }
+type U_q1_p union @(packed) { u64 m : 1; }
+
+static_assert(1, sizeof(U_b1));
+static_assert(2, sizeof(U_w1));
+static_assert(4, sizeof(U_d1));
+static_assert(8, sizeof(U_q1));
+static_assert(1, sizeof(U_b1_p));
+static_assert(1, sizeof(U_w1_p));
+static_assert(1, sizeof(U_d1_p));
+static_assert(1, sizeof(U_q1_p));
+
+#if ZERO_BITFIELD_UNION
+type U_b1_b0_b1 union { u8 m : 1; u8 : 0; u8 b : 1; }
+type U_w1_w0_w1 union { u16 m : 1; u16 : 0; u16 b : 1; }
+type U_d1_d0_d1 union { u32 m : 1; u32 : 0; u32 b : 1; }
+type U_q1_q0_q1 union { u64 m : 1; u64 : 0; u64 b : 1; }
+type U_b1_b0_b1_p union @(packed) { u8 m : 1; u8 : 0; u8 b : 1; }
+type U_w1_w0_w1_p union @(packed) { u16 m : 1; u16 : 0; u16 b : 1; }
+type U_d1_d0_d1_p union @(packed) { u32 m : 1; u32 : 0; u32 b : 1; }
+type U_q1_q0_q1_p union @(packed) { u64 m : 1; u64 : 0; u64 b : 1; }
+
+static_assert(2, sizeof(U_b1_b0_b1));
+static_assert(4, sizeof(U_w1_w0_w1));
+static_assert(8, sizeof(U_d1_d0_d1));
+static_assert(8, sizeof(U_q1_q0_q1));
+static_assert(2, sizeof(U_b1_b0_b1_p));
+static_assert(2, sizeof(U_w1_w0_w1_p));
+static_assert(2, sizeof(U_d1_d0_d1_p));
+static_assert(2, sizeof(U_q1_q0_q1_p));
+#endif
+
+type U_b1_b_b1 union { u8 a : 1; u8 m; u8 b : 1; }
+type U_w1_b_w1 union { u16 a : 1; u8 m; u16 b : 1; }
+type U_d1_b_d1 union { u32 a : 1; u8 m; u32 b : 1; }
+type U_q1_b_q1 union { u64 a : 1; u8 m; u64 b : 1; }
+type U_b1_b_b1_p union @(packed) { u8 a : 1; u8 m; u8 b : 1; }
+type U_w1_b_w1_p union @(packed) { u16 a : 1; u8 m; u16 b : 1; }
+type U_d1_b_d1_p union @(packed) { u32 a : 1; u8 m; u32 b : 1; }
+type U_q1_b_q1_p union @(packed) { u64 a : 1; u8 m; u64 b : 1; }
+
+static_assert(1, sizeof(U_b1_b_b1));
+static_assert(2, sizeof(U_w1_b_w1));
+static_assert(4, sizeof(U_d1_b_d1));
+static_assert(8, sizeof(U_q1_b_q1));
+static_assert(1, sizeof(U_b1_b_b1_p));
+static_assert(1, sizeof(U_w1_b_w1_p));
+static_assert(1, sizeof(U_d1_b_d1_p));
+static_assert(1, sizeof(U_q1_b_q1_p));
+
+type U_b1_b_b1_b_b1 union { u8 a : 1; u8 m; u8 b : 1; u8 n; u8 c : 1; }
+type U_w1_b_w1_b_w1 union { u16 a : 1; u8 m; u16 b : 1; u8 n; u16 c : 1; }
+type U_d1_b_d1_b_d1 union { u32 a : 1; u8 m; u32 b : 1; u8 n; u32 c : 1; }
+type U_q1_b_q1_b_q1 union { u64 a : 1; u8 m; u64 b : 1; u8 n; u64 c : 1; }
+type U_b1_b_b1_b_b1_p union @(packed) { u8 a : 1; u8 m; u8 b : 1; u8 n; u8 c : 1; }
+type U_w1_b_w1_b_w1_p union @(packed) { u16 a : 1; u8 m; u16 b : 1; u8 n; u16 c : 1; }
+type U_d1_b_d1_b_d1_p union @(packed) { u32 a : 1; u8 m; u32 b : 1; u8 n; u32 c : 1; }
+type U_q1_b_q1_b_q1_p union @(packed) { u64 a : 1; u8 m; u64 b : 1; u8 n; u64 c : 1; }
+
+static_assert(1, sizeof(U_b1_b_b1_b_b1));
+static_assert(2, sizeof(U_w1_b_w1_b_w1));
+static_assert(4, sizeof(U_d1_b_d1_b_d1));
+static_assert(8, sizeof(U_q1_b_q1_b_q1));
+static_assert(1, sizeof(U_b1_b_b1_b_b1_p));
+static_assert(1, sizeof(U_w1_b_w1_b_w1_p));
+static_assert(1, sizeof(U_d1_b_d1_b_d1_p));
+static_assert(1, sizeof(U_q1_b_q1_b_q1_p));
+
+type U_b_b union { u8 a; u8 m; }
+type U_b_w union { u8 a; u16 m; }
+type U_b_d union { u8 a; u32 m; }
+type U_b_q union { u8 a; u64 m; }
+type U_b_b_p union @(packed) { u8 a; u8 m; }
+type U_b_w_p union @(packed) { u8 a; u16 m; }
+type U_b_d_p union @(packed) { u8 a; u32 m; }
+type U_b_q_p union @(packed) { u8 a; u64 m; }
+
+static_assert(1, sizeof(U_b_b));
+static_assert(2, sizeof(U_b_w));
+static_assert(4, sizeof(U_b_d));
+static_assert(8, sizeof(U_b_q));
+static_assert(1, sizeof(U_b_b_p));
+static_assert(2, sizeof(U_b_w_p));
+static_assert(4, sizeof(U_b_d_p));
+static_assert(8, sizeof(U_b_q_p));
+
+type U_b_b_b union { u8 a; u8 m; u8 b; }
+type U_b_w_b union { u8 a; u16 m; u8 b; }
+type U_b_d_b union { u8 a; u32 m; u8 b; }
+type U_b_q_b union { u8 a; u64 m; u8 b; }
+type U_b_b_b_p union @(packed) { u8 a; u8 m; u8 b; }
+type U_b_w_b_p union @(packed) { u8 a; u16 m; u8 b; }
+type U_b_d_b_p union @(packed) { u8 a; u32 m; u8 b; }
+type U_b_q_b_p union @(packed) { u8 a; u64 m; u8 b; }
+
+static_assert(1, sizeof(U_b_b_b));
+static_assert(2, sizeof(U_b_w_b));
+static_assert(4, sizeof(U_b_d_b));
+static_assert(8, sizeof(U_b_q_b));
+static_assert(1, sizeof(U_b_b_b_p));
+static_assert(2, sizeof(U_b_w_b_p));
+static_assert(4, sizeof(U_b_d_b_p));
+static_assert(8, sizeof(U_b_q_b_p));
+
+type U_b_b1 union { u8 a; u8 m : 1; }
+type U_b_w1 union { u8 a; u16 m : 1; }
+type U_b_d1 union { u8 a; u32 m : 1; }
+type U_b_q1 union { u8 a; u64 m : 1; }
+type U_b_b1_p union @(packed) { u8 a; u8 m : 1; }
+type U_b_w1_p union @(packed) { u8 a; u16 m : 1; }
+type U_b_d1_p union @(packed) { u8 a; u32 m : 1; }
+type U_b_q1_p union @(packed) { u8 a; u64 m : 1; }
+
+static_assert(1, sizeof(U_b_b1));
+static_assert(2, sizeof(U_b_w1));
+static_assert(4, sizeof(U_b_d1));
+static_assert(8, sizeof(U_b_q1));
+static_assert(1, sizeof(U_b_b1_p));
+static_assert(1, sizeof(U_b_w1_p));
+static_assert(1, sizeof(U_b_d1_p));
+static_assert(1, sizeof(U_b_q1_p));
+
+type U_b1_b1 union { u8 a : 1; u8 m : 1; }
+type U_b1_w1 union { u8 a : 1; u16 m : 1; }
+type U_b1_d1 union { u8 a : 1; u32 m : 1; }
+type U_b1_q1 union { u8 a : 1; u64 m : 1; }
+type U_b1_b1_p union @(packed) { u8 a : 1; u8 m : 1; }
+type U_b1_w1_p union @(packed) { u8 a : 1; u16 m : 1; }
+type U_b1_d1_p union @(packed) { u8 a : 1; u32 m : 1; }
+type U_b1_q1_p union @(packed) { u8 a : 1; u64 m : 1; }
+
+static_assert(1, sizeof(U_b1_b1));
+static_assert(2, sizeof(U_b1_w1));
+static_assert(4, sizeof(U_b1_d1));
+static_assert(8, sizeof(U_b1_q1));
+static_assert(1, sizeof(U_b1_b1_p));
+static_assert(1, sizeof(U_b1_w1_p));
+static_assert(1, sizeof(U_b1_d1_p));
+static_assert(1, sizeof(U_b1_q1_p));
+
+type U_b_b1_b union { u8 a; u8 m : 1; u8 b; }
+type U_b_w1_b union { u8 a; u16 m : 1; u8 b; }
+type U_b_d1_b union { u8 a; u32 m : 1; u8 b; }
+type U_b_q1_b union { u8 a; u64 m : 1; u8 b; }
+type U_b_b1_b_p union @(packed) { u8 a; u8 m : 1; u8 b; }
+type U_b_w1_b_p union @(packed) { u8 a; u16 m : 1; u8 b; }
+type U_b_d1_b_p union @(packed) { u8 a; u32 m : 1; u8 b; }
+type U_b_q1_b_p union @(packed) { u8 a; u64 m : 1; u8 b; }
+
+static_assert(1, sizeof(U_b_b1_b));
+static_assert(2, sizeof(U_b_w1_b));
+static_assert(4, sizeof(U_b_d1_b));
+static_assert(8, sizeof(U_b_q1_b));
+static_assert(1, sizeof(U_b_b1_b_p));
+static_assert(1, sizeof(U_b_w1_b_p));
+static_assert(1, sizeof(U_b_d1_b_p));
+static_assert(1, sizeof(U_b_q1_b_p));
+
+type U_b1_b1_b1 union { u8 a : 1; u8 m : 1; u8 b : 1; }
+type U_b1_w1_b1 union { u8 a : 1; u16 m : 1; u8 b : 1; }
+type U_b1_d1_b1 union { u8 a : 1; u32 m : 1; u8 b : 1; }
+type U_b1_q1_b1 union { u8 a : 1; u64 m : 1; u8 b : 1; }
+type U_b1_b1_b1_p union @(packed) { u8 a : 1; u8 m : 1; u8 b : 1; }
+type U_b1_w1_b1_p union @(packed) { u8 a : 1; u16 m : 1; u8 b : 1; }
+type U_b1_d1_b1_p union @(packed) { u8 a : 1; u32 m : 1; u8 b : 1; }
+type U_b1_q1_b1_p union @(packed) { u8 a : 1; u64 m : 1; u8 b : 1; }
+
+static_assert(1, sizeof(U_b1_b1_b1));
+static_assert(2, sizeof(U_b1_w1_b1));
+static_assert(4, sizeof(U_b1_d1_b1));
+static_assert(8, sizeof(U_b1_q1_b1));
+static_assert(1, sizeof(U_b1_b1_b1_p));
+static_assert(1, sizeof(U_b1_w1_b1_p));
+static_assert(1, sizeof(U_b1_d1_b1_p));
+static_assert(1, sizeof(U_b1_q1_b1_p));
+
+type U_b5_b5_b5 union { u8 a : 5; u8 m : 5; u8 b : 5; }
+type U_b5_w5_b5 union { u8 a : 5; u16 m : 5; u8 b : 5; }
+type U_b5_d5_b5 union { u8 a : 5; u32 m : 5; u8 b : 5; }
+type U_b5_q5_b5 union { u8 a : 5; u64 m : 5; u8 b : 5; }
+type U_b5_b5_b5_p union @(packed) { u8 a : 5; u8 m : 5; u8 b : 5; }
+type U_b5_w5_b5_p union @(packed) { u8 a : 5; u16 m : 5; u8 b : 5; }
+type U_b5_d5_b5_p union @(packed) { u8 a : 5; u32 m : 5; u8 b : 5; }
+type U_b5_q5_b5_p union @(packed) { u8 a : 5; u64 m : 5; u8 b : 5; }
+
+static_assert(1, sizeof(U_b5_b5_b5));
+static_assert(2, sizeof(U_b5_w5_b5));
+static_assert(4, sizeof(U_b5_d5_b5));
+static_assert(8, sizeof(U_b5_q5_b5));
+static_assert(1, sizeof(U_b5_b5_b5_p));
+static_assert(1, sizeof(U_b5_w5_b5_p));
+static_assert(1, sizeof(U_b5_d5_b5_p));
+static_assert(1, sizeof(U_b5_q5_b5_p));
+
+type U_d24 union { u32 m : 24; }
+type U_d24_p union @(packed) { u32 m : 24; }
+type U_d24_d24 union { u32 a : 24; u32 m : 24; }
+type U_d24_d24_p union @(packed) { u32 a : 24; u32 m : 24; }
+type U_d24_d24_d24 union { u32 a : 24; u32 m : 24; u32 b : 24; }
+type U_d24_d24_d24_p union @(packed) { u32 a : 24; u32 m : 24; u32 b : 24; }
+type U_d24_d24_d24_d24 union { u32 a : 24; u32 m : 24; u32 b : 24; u32 c : 24; }
+type U_d24_d24_d24_d24_p union @(packed) { u32 a : 24; u32 m : 24; u32 b : 24; u32 c : 24; }
+type U_b_d24 union { u8 a; u32 m : 24; }
+type U_b_d24_p union @(packed) { u8 a; u32 m : 24; }
+type U_b_d24_b union { u8 a; u32 m : 24; u8 b; }
+type U_b_d24_b_p union @(packed) { u8 a; u32 m : 24; u8 b; }
+
+static_assert(4, sizeof(U_d24));
+static_assert(3, sizeof(U_d24_p));
+static_assert(4, sizeof(U_d24_d24));
+static_assert(3, sizeof(U_d24_d24_p));
+static_assert(4, sizeof(U_d24_d24_d24));
+static_assert(3, sizeof(U_d24_d24_d24_p));
+static_assert(4, sizeof(U_d24_d24_d24_d24));
+static_assert(3, sizeof(U_d24_d24_d24_d24_p));
+static_assert(4, sizeof(U_b_d24));
+static_assert(3, sizeof(U_b_d24_p));
+static_assert(4, sizeof(U_b_d24_b));
+static_assert(3, sizeof(U_b_d24_b_p));
+
+type U_d9 union { u32 m : 9; }
+type U_d9_p union @(packed) { u32 m : 9; }
+type U_b_d9 union { u8 a; u32 m : 9; }
+type U_b_d9_p union @(packed) { u8 a; u32 m : 9; }
+type U_b_d9_b union { u8 a; u32 m : 9; u8 b; }
+type U_b_d9_b_p union @(packed) { u8 a; u32 m : 9; u8 b; }
+
+static_assert(4, sizeof(U_d9));
+static_assert(2, sizeof(U_d9_p));
+static_assert(4, sizeof(U_b_d9));
+static_assert(2, sizeof(U_b_d9_p));
+static_assert(4, sizeof(U_b_d9_b));
+static_assert(2, sizeof(U_b_d9_b_p));
+
+type BlockKind enum u8 { Unspecified, AA = A8, }
+type BlockId u32;
+type Index struct { u32 start; u32 count; }
+type Block struct {
+    BlockKind kind : 8 ;   // BlockKind
+    u32 used : 1;
+    u32 checked : 1;    // can be used during various passes
+    u32 end_with_switch : 1;
+    u32 phi_source : 1;
+    u32 end_block : 1;  // ends with exit/ret, no successors
+    BlockId[2] dests;   // used if not 0 (2 u8)
+    Index instr;        // index into FuncInfo.instructions (2 u32)
+}
+static_assert(20, sizeof(Block));
+
+u8 dump;
+
+fn i32 dump_hex(u8 b) {
+    return printf(" %02X", b);
+}
+
+fn i32 dump_bin(u8 b) {
+    switch (b) {
+    case 0x00:
+    case 0xAA:
+    case 0xFF:
+        return dump_hex(b);
+    }
+    putchar(' ');
+    for (u32 i = 0; i < 8; i++)
+        putchar('0' + ((b >> i) & 1));
+    return 9;
+}
+
+u32 nvals;
+char **vals;
+
+fn bool filter_name(const char* name) {
+    if (!name || !nvals) return true;
+    if (!strncmp(name, "sizeof(", 7)) name += 7;
+    if (!strncmp(name, "offsetof(", 9)) name += 9;
+    const char* end = name;
+    while (*end && *end != ',' && *end != ')') end++;
+    for (u32 i = 0; i < nvals; i++) {
+        if (match_name(name, end, vals[i])) return true;
+    }
+    return false;
+}
+
+fn bool match_name(const char *name, const char *end, const char *pattern) {
+    for (;;) {
+        char c1;
+        char c2;
+        while ((c1 = (name < end) ? *name++ : '\0') == (c2 = *pattern++)) {
+            if (!c2) return true;
+        }
+        if (c2 == '?') {
+            if (c1) continue;
+        } else
+        if (c2 == '*') {
+            c2 = *pattern++;
+            if (!c2) return true;
+            for (; c1; c1 = (name < end) ? *name++ : '\0') {
+                if (c1 == c2 && match_name(name, end, pattern)) return true;
+            }
+        }
+        break;
+    }
+    return false;
+}
+
+fn void check(const char* s, usize a, u8* p1, u8* p2) {
+    local bool header;
+    usize b = (usize)(p2 - p1);
+
+    if (!filter_name(s)) return;
+
+    if (dump) {
+        if (*s == 's') {
+            printf("%28.*s:", (i32)(strlen(s) - 8), s + 7);
+            for (usize i = 0; i < b; i++) {
+                if (dump == 16) dump_hex(p1[i]);
+                else dump_bin(p1[i]);
+            }
+            printf("\n");
+        }
+        return;
+    }
+    if (s) {
+        if (a == b) return;
+        if (!header) {
+            header = true;
+            printf("+------------------------------+----+----+\n");
+            printf("|          expression          | C2 |  C |\n");
+            printf("+------------------------------+----+----+\n");
+        }
+        printf("| %28s | %2d | %2d |\n", s, a, b);
+    } else {
+        if (header) {
+            printf("+------------------------------+----+----+\n");
+        }
+    }
+}
+
+public fn i32 main(i32 argc, char **argv) {
+    i32 i;
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-d")) dump = 16;
+        else if (!strcmp(argv[i], "-b")) dump = 2;
+        else break;
+    }
+    nvals = (u32)(argc - i);
+    vals = argv + i;
+
+    S__b1[2] s__b1 = {{ }};
+    S__w1[2] s__w1 = {{ }};
+    S__d1[2] s__d1 = {{ }};
+    S__q1[2] s__q1 = {{ }};
+    S__b1_p[2] s__b1_p = {{ }};
+    S__w1_p[2] s__w1_p = {{ }};
+    S__d1_p[2] s__d1_p = {{ }};
+    S__q1_p[2] s__q1_p = {{ }};
+
+    S_b1[2] s_b1 = {{ 1 }};
+    S_w1[2] s_w1 = {{ 1 }};
+    S_d1[2] s_d1 = {{ 1 }};
+    S_q1[2] s_q1 = {{ 1 }};
+    S_b1_p[2] s_b1_p = {{ 1 }};
+    S_w1_p[2] s_w1_p = {{ 1 }};
+    S_d1_p[2] s_d1_p = {{ 1 }};
+    S_q1_p[2] s_q1_p = {{ 1 }};
+
+#if 1
+    S_b1_b0_b1[2] s_b1_b0_b1 = {{ 1, 1 }};
+    S_w1_w0_w1[2] s_w1_w0_w1 = {{ 1, 1 }};
+    S_d1_d0_d1[2] s_d1_d0_d1 = {{ 1, 1 }};
+    S_q1_q0_q1[2] s_q1_q0_q1 = {{ 1, 1 }};
+    S_b1_b0_b1_p[2] s_b1_b0_b1_p = {{ 1, 1 }};
+    S_w1_w0_w1_p[2] s_w1_w0_w1_p = {{ 1, 1 }};
+    S_d1_d0_d1_p[2] s_d1_d0_d1_p = {{ 1, 1 }};
+    S_q1_q0_q1_p[2] s_q1_q0_q1_p = {{ 1, 1 }};
+#endif
+
+    S_b1_b_b1[2] s_b1_b_b1 = {{ 1, 0, 1 }};
+    S_w1_b_w1[2] s_w1_b_w1 = {{ 1, 0, 1 }};
+    S_d1_b_d1[2] s_d1_b_d1 = {{ 1, 0, 1 }};
+    S_q1_b_q1[2] s_q1_b_q1 = {{ 1, 0, 1 }};
+    S_b1_b_b1_p[2] s_b1_b_b1_p = {{ 1, 0, 1 }};
+    S_w1_b_w1_p[2] s_w1_b_w1_p = {{ 1, 0, 1 }};
+    S_d1_b_d1_p[2] s_d1_b_d1_p = {{ 1, 0, 1 }};
+    S_q1_b_q1_p[2] s_q1_b_q1_p = {{ 1, 0, 1 }};
+
+    S_b1_b_b1_b_b1[2] s_b1_b_b1_b_b1 = {{ 1, 0, 1, 0, 1 }};
+    S_w1_b_w1_b_w1[2] s_w1_b_w1_b_w1 = {{ 1, 0, 1, 0, 1 }};
+    S_d1_b_d1_b_d1[2] s_d1_b_d1_b_d1 = {{ 1, 0, 1, 0, 1 }};
+    S_q1_b_q1_b_q1[2] s_q1_b_q1_b_q1 = {{ 1, 0, 1, 0, 1 }};
+    S_b1_b_b1_b_b1_p[2] s_b1_b_b1_b_b1_p = {{ 1, 0, 1, 0, 1 }};
+    S_w1_b_w1_b_w1_p[2] s_w1_b_w1_b_w1_p = {{ 1, 0, 1, 0, 1 }};
+    S_d1_b_d1_b_d1_p[2] s_d1_b_d1_b_d1_p = {{ 1, 0, 1, 0, 1 }};
+    S_q1_b_q1_b_q1_p[2] s_q1_b_q1_b_q1_p = {{ 1, 0, 1, 0, 1 }};
+
+    S_b_b[2] s_b_b = {{ 0, F8 }};
+    S_b_w[2] s_b_w = {{ 0, F16 }};
+    S_b_d[2] s_b_d = {{ 0, F32 }};
+    S_b_q[2] s_b_q = {{ 0, F64 }};
+    S_b_b_p[2] s_b_b_p = {{ 0, F8 }};
+    S_b_w_p[2] s_b_w_p = {{ 0, F16 }};
+    S_b_d_p[2] s_b_d_p = {{ 0, F32 }};
+    S_b_q_p[2] s_b_q_p = {{ 0, F64 }};
+
+    S_b_b_b[2] s_b_b_b = {{ 0, F8, A8 }};
+    S_b_w_b[2] s_b_w_b = {{ 0, F16, A8 }};
+    S_b_d_b[2] s_b_d_b = {{ 0, F32, A8 }};
+    S_b_q_b[2] s_b_q_b = {{ 0, F64, A8 }};
+    S_b_b_b_p[2] s_b_b_b_p = {{ 0, F8, A8 }};
+    S_b_w_b_p[2] s_b_w_b_p = {{ 0, F16, A8 }};
+    S_b_d_b_p[2] s_b_d_b_p = {{ 0, F32, A8 }};
+    S_b_q_b_p[2] s_b_q_b_p = {{ 0, F64, A8 }};
+
+    S_b_b1[2] s_b_b1 = {{ 0, 1 }};
+    S_b_w1[2] s_b_w1 = {{ 0, 1 }};
+    S_b_d1[2] s_b_d1 = {{ 0, 1 }};
+    S_b_q1[2] s_b_q1 = {{ 0, 1 }};
+    S_b_b1_p[2] s_b_b1_p = {{ 0, 1 }};
+    S_b_w1_p[2] s_b_w1_p = {{ 0, 1 }};
+    S_b_d1_p[2] s_b_d1_p = {{ 0, 1 }};
+    S_b_q1_p[2] s_b_q1_p = {{ 0, 1 }};
+
+    S_b1_b1[2] s_b1_b1 = {{ 0, 1 }};
+    S_b1_w1[2] s_b1_w1 = {{ 0, 1 }};
+    S_b1_d1[2] s_b1_d1 = {{ 0, 1 }};
+    S_b1_q1[2] s_b1_q1 = {{ 0, 1 }};
+    S_b1_b1_p[2] s_b1_b1_p = {{ 0, 1 }};
+    S_b1_w1_p[2] s_b1_w1_p = {{ 0, 1 }};
+    S_b1_d1_p[2] s_b1_d1_p = {{ 0, 1 }};
+    S_b1_q1_p[2] s_b1_q1_p = {{ 0, 1 }};
+
+    S_b_b1_b[2] s_b_b1_b = {{ 0, 1, A8 }};
+    S_b_w1_b[2] s_b_w1_b = {{ 0, 1, A8 }};
+    S_b_d1_b[2] s_b_d1_b = {{ 0, 1, A8 }};
+    S_b_q1_b[2] s_b_q1_b = {{ 0, 1, A8 }};
+    S_b_b1_b_p[2] s_b_b1_b_p = {{ 0, 1, A8 }};
+    S_b_w1_b_p[2] s_b_w1_b_p = {{ 0, 1, A8 }};
+    S_b_d1_b_p[2] s_b_d1_b_p = {{ 0, 1, A8 }};
+    S_b_q1_b_p[2] s_b_q1_b_p = {{ 0, 1, A8 }};
+
+    S_b1_b1_b1[2] s_b1_b1_b1 = {{ 1, 0, 1 }};
+    S_b1_w1_b1[2] s_b1_w1_b1 = {{ 1, 0, 1 }};
+    S_b1_d1_b1[2] s_b1_d1_b1 = {{ 1, 0, 1 }};
+    S_b1_q1_b1[2] s_b1_q1_b1 = {{ 1, 0, 1 }};
+    S_b1_b1_b1_p[2] s_b1_b1_b1_p = {{ 1, 0, 1 }};
+    S_b1_w1_b1_p[2] s_b1_w1_b1_p = {{ 1, 0, 1 }};
+    S_b1_d1_b1_p[2] s_b1_d1_b1_p = {{ 1, 0, 1 }};
+    S_b1_q1_b1_p[2] s_b1_q1_b1_p = {{ 1, 0, 1 }};
+
+    S_b5_b5_b5[2] s_b5_b5_b5 = {{ F5, 0, F5 }};
+    S_b5_w5_b5[2] s_b5_w5_b5 = {{ F5, 0, F5 }};
+    S_b5_d5_b5[2] s_b5_d5_b5 = {{ F5, 0, F5 }};
+    S_b5_q5_b5[2] s_b5_q5_b5 = {{ F5, 0, F5 }};
+    S_b5_b5_b5_p[2] s_b5_b5_b5_p = {{ F5, 0, F5 }};
+    S_b5_w5_b5_p[2] s_b5_w5_b5_p = {{ F5, 0, F5 }};
+    S_b5_d5_b5_p[2] s_b5_d5_b5_p = {{ F5, 0, F5 }};
+    S_b5_q5_b5_p[2] s_b5_q5_b5_p = {{ F5, 0, F5 }};
+
+    S_d24[2] s_d24 = {{ F24 }};
+    S_d24_p[2] s_d24_p = {{ F24 }};
+    S_d24_d24[2] s_d24_d24 = {{ F24, F24 }};
+    S_d24_d24_p[2] s_d24_d24_p = {{ F24, F24 }};
+    S_d24_d24_d24[2] s_d24_d24_d24 = {{ F24, F24, F24 }};
+    S_d24_d24_d24_p[2] s_d24_d24_d24_p = {{ F24, F24, F24 }};
+    S_d24_d24_d24_d24[2] s_d24_d24_d24_d24 = {{ F24, F24, F24, F24 }};
+    S_d24_d24_d24_d24_p[2] s_d24_d24_d24_d24_p = {{ F24, F24, F24, F24 }};
+    S_b_d24[2] s_b_d24 = {{ 0, F24 }};
+    S_b_d24_p[2] s_b_d24_p = {{ 0, F24 }};
+    S_b_d24_b[2] s_b_d24_b = {{ 0, F24, A8 }};
+    S_b_d24_b_p[2] s_b_d24_b_p = {{ 0, F24, A8 }};
+
+    S_d9[2] s_d9 = {{ F9 }};
+    S_d9_p[2] s_d9_p = {{ F9 }};
+    S_b_d9[2] s_b_d9 = {{ 0, F9 }};
+    S_b_d9_p[2] s_b_d9_p = {{ 0, F9 }};
+    S_b_d9_b[2] s_b_d9_b = {{ 0, F9, A8 }};
+    S_b_d9_b_p[2] s_b_d9_b_p = {{ 0, F9, A8 }};
+
+    check("sizeof(S__b1)", sizeof(S__b1), (u8*)&s__b1[0], (u8*)&s__b1[1]);
+    check("sizeof(S__w1)", sizeof(S__w1), (u8*)&s__w1[0], (u8*)&s__w1[1]);
+    check("sizeof(S__d1)", sizeof(S__d1), (u8*)&s__d1[0], (u8*)&s__d1[1]);
+    check("sizeof(S__q1)", sizeof(S__q1), (u8*)&s__q1[0], (u8*)&s__q1[1]);
+    check("sizeof(S__b1_p)", sizeof(S__b1_p), (u8*)&s__b1_p[0], (u8*)&s__b1_p[1]);
+    check("sizeof(S__w1_p)", sizeof(S__w1_p), (u8*)&s__w1_p[0], (u8*)&s__w1_p[1]);
+    check("sizeof(S__d1_p)", sizeof(S__d1_p), (u8*)&s__d1_p[0], (u8*)&s__d1_p[1]);
+    check("sizeof(S__q1_p)", sizeof(S__q1_p), (u8*)&s__q1_p[0], (u8*)&s__q1_p[1]);
+
+    check("sizeof(S_b1)", sizeof(S_b1), (u8*)&s_b1[0], (u8*)&s_b1[1]);
+    check("sizeof(S_w1)", sizeof(S_w1), (u8*)&s_w1[0], (u8*)&s_w1[1]);
+    check("sizeof(S_d1)", sizeof(S_d1), (u8*)&s_d1[0], (u8*)&s_d1[1]);
+    check("sizeof(S_q1)", sizeof(S_q1), (u8*)&s_q1[0], (u8*)&s_q1[1]);
+    check("sizeof(S_b1_p)", sizeof(S_b1_p), (u8*)&s_b1_p[0], (u8*)&s_b1_p[1]);
+    check("sizeof(S_w1_p)", sizeof(S_w1_p), (u8*)&s_w1_p[0], (u8*)&s_w1_p[1]);
+    check("sizeof(S_d1_p)", sizeof(S_d1_p), (u8*)&s_d1_p[0], (u8*)&s_d1_p[1]);
+    check("sizeof(S_q1_p)", sizeof(S_q1_p), (u8*)&s_q1_p[0], (u8*)&s_q1_p[1]);
+
+#if 1
+    check("sizeof(S_b1_b0_b1)", sizeof(S_b1_b0_b1), (u8*)&s_b1_b0_b1[0], (u8*)&s_b1_b0_b1[1]);
+    check("sizeof(S_w1_w0_w1)", sizeof(S_w1_w0_w1), (u8*)&s_w1_w0_w1[0], (u8*)&s_w1_w0_w1[1]);
+    check("sizeof(S_d1_d0_d1)", sizeof(S_d1_d0_d1), (u8*)&s_d1_d0_d1[0], (u8*)&s_d1_d0_d1[1]);
+    check("sizeof(S_q1_q0_q1)", sizeof(S_q1_q0_q1), (u8*)&s_q1_q0_q1[0], (u8*)&s_q1_q0_q1[1]);
+    check("sizeof(S_b1_b0_b1_p)", sizeof(S_b1_b0_b1_p), (u8*)&s_b1_b0_b1_p[0], (u8*)&s_b1_b0_b1_p[1]);
+    check("sizeof(S_w1_w0_w1_p)", sizeof(S_w1_w0_w1_p), (u8*)&s_w1_w0_w1_p[0], (u8*)&s_w1_w0_w1_p[1]);
+    check("sizeof(S_d1_d0_d1_p)", sizeof(S_d1_d0_d1_p), (u8*)&s_d1_d0_d1_p[0], (u8*)&s_d1_d0_d1_p[1]);
+    check("sizeof(S_q1_q0_q1_p)", sizeof(S_q1_q0_q1_p), (u8*)&s_q1_q0_q1_p[0], (u8*)&s_q1_q0_q1_p[1]);
+#endif
+
+    check("sizeof(S_b1_b_b1)", sizeof(S_b1_b_b1), (u8*)&s_b1_b_b1[0], (u8*)&s_b1_b_b1[1]);
+    check("sizeof(S_w1_b_w1)", sizeof(S_w1_b_w1), (u8*)&s_w1_b_w1[0], (u8*)&s_w1_b_w1[1]);
+    check("sizeof(S_d1_b_d1)", sizeof(S_d1_b_d1), (u8*)&s_d1_b_d1[0], (u8*)&s_d1_b_d1[1]);
+    check("sizeof(S_q1_b_q1)", sizeof(S_q1_b_q1), (u8*)&s_q1_b_q1[0], (u8*)&s_q1_b_q1[1]);
+    check("sizeof(S_b1_b_b1_p)", sizeof(S_b1_b_b1_p), (u8*)&s_b1_b_b1_p[0], (u8*)&s_b1_b_b1_p[1]);
+    check("sizeof(S_w1_b_w1_p)", sizeof(S_w1_b_w1_p), (u8*)&s_w1_b_w1_p[0], (u8*)&s_w1_b_w1_p[1]);
+    check("sizeof(S_d1_b_d1_p)", sizeof(S_d1_b_d1_p), (u8*)&s_d1_b_d1_p[0], (u8*)&s_d1_b_d1_p[1]);
+    check("sizeof(S_q1_b_q1_p)", sizeof(S_q1_b_q1_p), (u8*)&s_q1_b_q1_p[0], (u8*)&s_q1_b_q1_p[1]);
+
+    check("sizeof(S_b1_b_b1_b_b1)", sizeof(S_b1_b_b1_b_b1), (u8*)&s_b1_b_b1_b_b1[0], (u8*)&s_b1_b_b1_b_b1[1]);
+    check("sizeof(S_w1_b_w1_b_w1)", sizeof(S_w1_b_w1_b_w1), (u8*)&s_w1_b_w1_b_w1[0], (u8*)&s_w1_b_w1_b_w1[1]);
+    check("sizeof(S_d1_b_d1_b_d1)", sizeof(S_d1_b_d1_b_d1), (u8*)&s_d1_b_d1_b_d1[0], (u8*)&s_d1_b_d1_b_d1[1]);
+    check("sizeof(S_q1_b_q1_b_q1)", sizeof(S_q1_b_q1_b_q1), (u8*)&s_q1_b_q1_b_q1[0], (u8*)&s_q1_b_q1_b_q1[1]);
+    check("sizeof(S_b1_b_b1_b_b1_p)", sizeof(S_b1_b_b1_b_b1_p), (u8*)&s_b1_b_b1_b_b1_p[0], (u8*)&s_b1_b_b1_b_b1_p[1]);
+    check("sizeof(S_w1_b_w1_b_w1_p)", sizeof(S_w1_b_w1_b_w1_p), (u8*)&s_w1_b_w1_b_w1_p[0], (u8*)&s_w1_b_w1_b_w1_p[1]);
+    check("sizeof(S_d1_b_d1_b_d1_p)", sizeof(S_d1_b_d1_b_d1_p), (u8*)&s_d1_b_d1_b_d1_p[0], (u8*)&s_d1_b_d1_b_d1_p[1]);
+    check("sizeof(S_q1_b_q1_b_q1_p)", sizeof(S_q1_b_q1_b_q1_p), (u8*)&s_q1_b_q1_b_q1_p[0], (u8*)&s_q1_b_q1_b_q1_p[1]);
+
+    check("sizeof(S_b_b)", sizeof(S_b_b), (u8*)&s_b_b[0], (u8*)&s_b_b[1]);
+    check("sizeof(S_b_w)", sizeof(S_b_w), (u8*)&s_b_w[0], (u8*)&s_b_w[1]);
+    check("sizeof(S_b_d)", sizeof(S_b_d), (u8*)&s_b_d[0], (u8*)&s_b_d[1]);
+    check("sizeof(S_b_q)", sizeof(S_b_q), (u8*)&s_b_q[0], (u8*)&s_b_q[1]);
+    check("sizeof(S_b_b_p)", sizeof(S_b_b_p), (u8*)&s_b_b_p[0], (u8*)&s_b_b_p[1]);
+    check("sizeof(S_b_w_p)", sizeof(S_b_w_p), (u8*)&s_b_w_p[0], (u8*)&s_b_w_p[1]);
+    check("sizeof(S_b_d_p)", sizeof(S_b_d_p), (u8*)&s_b_d_p[0], (u8*)&s_b_d_p[1]);
+    check("sizeof(S_b_q_p)", sizeof(S_b_q_p), (u8*)&s_b_q_p[0], (u8*)&s_b_q_p[1]);
+
+    check("sizeof(S_b_b1)", sizeof(S_b_b1), (u8*)&s_b_b1[0], (u8*)&s_b_b1[1]);
+    check("sizeof(S_b_w1)", sizeof(S_b_w1), (u8*)&s_b_w1[0], (u8*)&s_b_w1[1]);
+    check("sizeof(S_b_d1)", sizeof(S_b_d1), (u8*)&s_b_d1[0], (u8*)&s_b_d1[1]);
+    check("sizeof(S_b_q1)", sizeof(S_b_q1), (u8*)&s_b_q1[0], (u8*)&s_b_q1[1]);
+    check("sizeof(S_b_b1_p)", sizeof(S_b_b1_p), (u8*)&s_b_b1_p[0], (u8*)&s_b_b1_p[1]);
+    check("sizeof(S_b_w1_p)", sizeof(S_b_w1_p), (u8*)&s_b_w1_p[0], (u8*)&s_b_w1_p[1]);
+    check("sizeof(S_b_d1_p)", sizeof(S_b_d1_p), (u8*)&s_b_d1_p[0], (u8*)&s_b_d1_p[1]);
+    check("sizeof(S_b_q1_p)", sizeof(S_b_q1_p), (u8*)&s_b_q1_p[0], (u8*)&s_b_q1_p[1]);
+
+    check("sizeof(S_b1_b1)", sizeof(S_b1_b1), (u8*)&s_b1_b1[0], (u8*)&s_b1_b1[1]);
+    check("sizeof(S_b1_w1)", sizeof(S_b1_w1), (u8*)&s_b1_w1[0], (u8*)&s_b1_w1[1]);
+    check("sizeof(S_b1_d1)", sizeof(S_b1_d1), (u8*)&s_b1_d1[0], (u8*)&s_b1_d1[1]);
+    check("sizeof(S_b1_q1)", sizeof(S_b1_q1), (u8*)&s_b1_q1[0], (u8*)&s_b1_q1[1]);
+    check("sizeof(S_b1_b1_p)", sizeof(S_b1_b1_p), (u8*)&s_b1_b1_p[0], (u8*)&s_b1_b1_p[1]);
+    check("sizeof(S_b1_w1_p)", sizeof(S_b1_w1_p), (u8*)&s_b1_w1_p[0], (u8*)&s_b1_w1_p[1]);
+    check("sizeof(S_b1_d1_p)", sizeof(S_b1_d1_p), (u8*)&s_b1_d1_p[0], (u8*)&s_b1_d1_p[1]);
+    check("sizeof(S_b1_q1_p)", sizeof(S_b1_q1_p), (u8*)&s_b1_q1_p[0], (u8*)&s_b1_q1_p[1]);
+
+    check("sizeof(S_b_b_b)", sizeof(S_b_b_b), (u8*)&s_b_b_b[0], (u8*)&s_b_b_b[1]);
+    check("sizeof(S_b_w_b)", sizeof(S_b_w_b), (u8*)&s_b_w_b[0], (u8*)&s_b_w_b[1]);
+    check("sizeof(S_b_d_b)", sizeof(S_b_d_b), (u8*)&s_b_d_b[0], (u8*)&s_b_d_b[1]);
+    check("sizeof(S_b_q_b)", sizeof(S_b_q_b), (u8*)&s_b_q_b[0], (u8*)&s_b_q_b[1]);
+    check("sizeof(S_b_b_b_p)", sizeof(S_b_b_b_p), (u8*)&s_b_b_b_p[0], (u8*)&s_b_b_b_p[1]);
+    check("sizeof(S_b_w_b_p)", sizeof(S_b_w_b_p), (u8*)&s_b_w_b_p[0], (u8*)&s_b_w_b_p[1]);
+    check("sizeof(S_b_d_b_p)", sizeof(S_b_d_b_p), (u8*)&s_b_d_b_p[0], (u8*)&s_b_d_b_p[1]);
+    check("sizeof(S_b_q_b_p)", sizeof(S_b_q_b_p), (u8*)&s_b_q_b_p[0], (u8*)&s_b_q_b_p[1]);
+
+    check("sizeof(S_b_b1_b)", sizeof(S_b_b1_b), (u8*)&s_b_b1_b[0], (u8*)&s_b_b1_b[1]);
+    check("sizeof(S_b_w1_b)", sizeof(S_b_w1_b), (u8*)&s_b_w1_b[0], (u8*)&s_b_w1_b[1]);
+    check("sizeof(S_b_d1_b)", sizeof(S_b_d1_b), (u8*)&s_b_d1_b[0], (u8*)&s_b_d1_b[1]);
+    check("sizeof(S_b_q1_b)", sizeof(S_b_q1_b), (u8*)&s_b_q1_b[0], (u8*)&s_b_q1_b[1]);
+    check("sizeof(S_b_b1_b_p)", sizeof(S_b_b1_b_p), (u8*)&s_b_b1_b_p[0], (u8*)&s_b_b1_b_p[1]);
+    check("sizeof(S_b_w1_b_p)", sizeof(S_b_w1_b_p), (u8*)&s_b_w1_b_p[0], (u8*)&s_b_w1_b_p[1]);
+    check("sizeof(S_b_d1_b_p)", sizeof(S_b_d1_b_p), (u8*)&s_b_d1_b_p[0], (u8*)&s_b_d1_b_p[1]);
+    check("sizeof(S_b_q1_b_p)", sizeof(S_b_q1_b_p), (u8*)&s_b_q1_b_p[0], (u8*)&s_b_q1_b_p[1]);
+
+    check("sizeof(S_b1_b1_b1)", sizeof(S_b1_b1_b1), (u8*)&s_b1_b1_b1[0], (u8*)&s_b1_b1_b1[1]);
+    check("sizeof(S_b1_w1_b1)", sizeof(S_b1_w1_b1), (u8*)&s_b1_w1_b1[0], (u8*)&s_b1_w1_b1[1]);
+    check("sizeof(S_b1_d1_b1)", sizeof(S_b1_d1_b1), (u8*)&s_b1_d1_b1[0], (u8*)&s_b1_d1_b1[1]);
+    check("sizeof(S_b1_q1_b1)", sizeof(S_b1_q1_b1), (u8*)&s_b1_q1_b1[0], (u8*)&s_b1_q1_b1[1]);
+    check("sizeof(S_b1_b1_b1_p)", sizeof(S_b1_b1_b1_p), (u8*)&s_b1_b1_b1_p[0], (u8*)&s_b1_b1_b1_p[1]);
+    check("sizeof(S_b1_w1_b1_p)", sizeof(S_b1_w1_b1_p), (u8*)&s_b1_w1_b1_p[0], (u8*)&s_b1_w1_b1_p[1]);
+    check("sizeof(S_b1_d1_b1_p)", sizeof(S_b1_d1_b1_p), (u8*)&s_b1_d1_b1_p[0], (u8*)&s_b1_d1_b1_p[1]);
+    check("sizeof(S_b1_q1_b1_p)", sizeof(S_b1_q1_b1_p), (u8*)&s_b1_q1_b1_p[0], (u8*)&s_b1_q1_b1_p[1]);
+
+    check("sizeof(S_b5_b5_b5)", sizeof(S_b5_b5_b5), (u8*)&s_b5_b5_b5[0], (u8*)&s_b5_b5_b5[1]);
+    check("sizeof(S_b5_w5_b5)", sizeof(S_b5_w5_b5), (u8*)&s_b5_w5_b5[0], (u8*)&s_b5_w5_b5[1]);
+    check("sizeof(S_b5_d5_b5)", sizeof(S_b5_d5_b5), (u8*)&s_b5_d5_b5[0], (u8*)&s_b5_d5_b5[1]);
+    check("sizeof(S_b5_q5_b5)", sizeof(S_b5_q5_b5), (u8*)&s_b5_q5_b5[0], (u8*)&s_b5_q5_b5[1]);
+    check("sizeof(S_b5_b5_b5_p)", sizeof(S_b5_b5_b5_p), (u8*)&s_b5_b5_b5_p[0], (u8*)&s_b5_b5_b5_p[1]);
+    check("sizeof(S_b5_w5_b5_p)", sizeof(S_b5_w5_b5_p), (u8*)&s_b5_w5_b5_p[0], (u8*)&s_b5_w5_b5_p[1]);
+    check("sizeof(S_b5_d5_b5_p)", sizeof(S_b5_d5_b5_p), (u8*)&s_b5_d5_b5_p[0], (u8*)&s_b5_d5_b5_p[1]);
+    check("sizeof(S_b5_q5_b5_p)", sizeof(S_b5_q5_b5_p), (u8*)&s_b5_q5_b5_p[0], (u8*)&s_b5_q5_b5_p[1]);
+
+    check("offsetof(S_b_b_b, b)", offsetof(S_b_b_b, b), (u8*)&s_b_b_b[0], (u8*)&s_b_b_b[0].b);
+    check("offsetof(S_b_w_b, b)", offsetof(S_b_w_b, b), (u8*)&s_b_w_b[0], (u8*)&s_b_w_b[0].b);
+    check("offsetof(S_b_d_b, b)", offsetof(S_b_d_b, b), (u8*)&s_b_d_b[0], (u8*)&s_b_d_b[0].b);
+    check("offsetof(S_b_q_b, b)", offsetof(S_b_q_b, b), (u8*)&s_b_q_b[0], (u8*)&s_b_q_b[0].b);
+    check("offsetof(S_b_b_b_p, b)", offsetof(S_b_b_b_p, b), (u8*)&s_b_b_b_p[0], (u8*)&s_b_b_b_p[0].b);
+    check("offsetof(S_b_w_b_p, b)", offsetof(S_b_w_b_p, b), (u8*)&s_b_w_b_p[0], (u8*)&s_b_w_b_p[0].b);
+    check("offsetof(S_b_d_b_p, b)", offsetof(S_b_d_b_p, b), (u8*)&s_b_d_b_p[0], (u8*)&s_b_d_b_p[0].b);
+    check("offsetof(S_b_q_b_p, b)", offsetof(S_b_q_b_p, b), (u8*)&s_b_q_b_p[0], (u8*)&s_b_q_b_p[0].b);
+
+    check("offsetof(S_b_b1_b, b)", offsetof(S_b_b1_b, b), (u8*)&s_b_b1_b[0], (u8*)&s_b_b1_b[0].b);
+    check("offsetof(S_b_w1_b, b)", offsetof(S_b_w1_b, b), (u8*)&s_b_w1_b[0], (u8*)&s_b_w1_b[0].b);
+    check("offsetof(S_b_d1_b, b)", offsetof(S_b_d1_b, b), (u8*)&s_b_d1_b[0], (u8*)&s_b_d1_b[0].b);
+    check("offsetof(S_b_q1_b, b)", offsetof(S_b_q1_b, b), (u8*)&s_b_q1_b[0], (u8*)&s_b_q1_b[0].b);
+    check("offsetof(S_b_b1_b_p, b)", offsetof(S_b_b1_b_p, b), (u8*)&s_b_b1_b_p[0], (u8*)&s_b_b1_b_p[0].b);
+    check("offsetof(S_b_w1_b_p, b)", offsetof(S_b_w1_b_p, b), (u8*)&s_b_w1_b_p[0], (u8*)&s_b_w1_b_p[0].b);
+    check("offsetof(S_b_d1_b_p, b)", offsetof(S_b_d1_b_p, b), (u8*)&s_b_d1_b_p[0], (u8*)&s_b_d1_b_p[0].b);
+    check("offsetof(S_b_q1_b_p, b)", offsetof(S_b_q1_b_p, b), (u8*)&s_b_q1_b_p[0], (u8*)&s_b_q1_b_p[0].b);
+
+    check("sizeof(S_d24)", sizeof(S_d24), (u8*)&s_d24[0], (u8*)&s_d24[1]);
+    check("sizeof(S_d24_p)", sizeof(S_d24_p), (u8*)&s_d24_p[0], (u8*)&s_d24_p[1]);
+    check("sizeof(S_d24_d24)", sizeof(S_d24_d24), (u8*)&s_d24_d24[0], (u8*)&s_d24_d24[1]);
+    check("sizeof(S_d24_d24_p)", sizeof(S_d24_d24_p), (u8*)&s_d24_d24_p[0], (u8*)&s_d24_d24_p[1]);
+    check("sizeof(S_d24_d24_d24)", sizeof(S_d24_d24_d24), (u8*)&s_d24_d24_d24[0], (u8*)&s_d24_d24_d24[1]);
+    check("sizeof(S_d24_d24_d24_p)", sizeof(S_d24_d24_d24_p), (u8*)&s_d24_d24_d24_p[0], (u8*)&s_d24_d24_d24_p[1]);
+    check("sizeof(S_d24_d24_d24_d24)", sizeof(S_d24_d24_d24_d24), (u8*)&s_d24_d24_d24_d24[0], (u8*)&s_d24_d24_d24_d24[1]);
+    check("sizeof(S_d24_d24_d24_d24_p)", sizeof(S_d24_d24_d24_d24_p), (u8*)&s_d24_d24_d24_d24_p[0], (u8*)&s_d24_d24_d24_d24_p[1]);
+    check("sizeof(S_b_d24)", sizeof(S_b_d24), (u8*)&s_b_d24[0], (u8*)&s_b_d24[1]);
+    check("sizeof(S_b_d24_p)", sizeof(S_b_d24_p), (u8*)&s_b_d24_p[0], (u8*)&s_b_d24_p[1]);
+    check("sizeof(S_b_d24_b)", sizeof(S_b_d24_b), (u8*)&s_b_d24_b[0], (u8*)&s_b_d24_b[1]);
+    check("sizeof(S_b_d24_b_p)", sizeof(S_b_d24_b_p), (u8*)&s_b_d24_b_p[0], (u8*)&s_b_d24_b_p[1]);
+    check("offsetof(S_b_d24_b, b)", offsetof(S_b_d24_b, b), (u8*)&s_b_d24_b[0], (u8*)&s_b_d24_b[0].b);
+    check("offsetof(S_b_d24_b_p, b)", offsetof(S_b_d24_b_p, b), (u8*)&s_b_d24_b_p[0], (u8*)&s_b_d24_b_p[0].b);
+
+    check("sizeof(S_d9)", sizeof(S_d9), (u8*)&s_d9[0], (u8*)&s_d9[1]);
+    check("sizeof(S_d9_p)", sizeof(S_d9_p), (u8*)&s_d9_p[0], (u8*)&s_d9_p[1]);
+    check("sizeof(S_b_d9)", sizeof(S_b_d9), (u8*)&s_b_d9[0], (u8*)&s_b_d9[1]);
+    check("sizeof(S_b_d9_p)", sizeof(S_b_d9_p), (u8*)&s_b_d9_p[0], (u8*)&s_b_d9_p[1]);
+    check("sizeof(S_b_d9_b)", sizeof(S_b_d9_b), (u8*)&s_b_d9_b[0], (u8*)&s_b_d9_b[1]);
+    check("sizeof(S_b_d9_b_p)", sizeof(S_b_d9_b_p), (u8*)&s_b_d9_b_p[0], (u8*)&s_b_d9_b_p[1]);
+    check("offsetof(S_b_d9_b, b)", offsetof(S_b_d9_b, b), (u8*)&s_b_d9_b[0], (u8*)&s_b_d9_b[0].b);
+    check("offsetof(S_b_d9_b_p, b)", offsetof(S_b_d9_b_p, b), (u8*)&s_b_d9_b_p[0], (u8*)&s_b_d9_b_p[0].b);
+
+    U_b1[2] u_b1 = {{ .m = 1 }};
+    U_w1[2] u_w1 = {{ .m = 1 }};
+    U_d1[2] u_d1 = {{ .m = 1 }};
+    U_q1[2] u_q1 = {{ .m = 1 }};
+    U_b1_p[2] u_b1_p = {{ .m = 1 }};
+    U_w1_p[2] u_w1_p = {{ .m = 1 }};
+    U_d1_p[2] u_d1_p = {{ .m = 1 }};
+    U_q1_p[2] u_q1_p = {{ .m = 1 }};
+
+#if ZERO_BITFIELD_UNION
+    U_b1_b0_b1[2] u_b1_b0_b1 = {{ .m = 1 }};
+    U_w1_w0_w1[2] u_w1_w0_w1 = {{ .m = 1 }};
+    U_d1_d0_d1[2] u_d1_d0_d1 = {{ .m = 1 }};
+    U_q1_q0_q1[2] u_q1_q0_q1 = {{ .m = 1 }};
+    U_b1_b0_b1_p[2] u_b1_b0_b1_p = {{ .m = 1 }};
+    U_w1_w0_w1_p[2] u_w1_w0_w1_p = {{ .m = 1 }};
+    U_d1_d0_d1_p[2] u_d1_d0_d1_p = {{ .m = 1 }};
+    U_q1_q0_q1_p[2] u_q1_q0_q1_p = {{ .m = 1 }};
+#endif
+
+    U_b1_b_b1[2] u_b1_b_b1 = {{ .m = 1 }};
+    U_w1_b_w1[2] u_w1_b_w1 = {{ .m = 1 }};
+    U_d1_b_d1[2] u_d1_b_d1 = {{ .m = 1 }};
+    U_q1_b_q1[2] u_q1_b_q1 = {{ .m = 1 }};
+    U_b1_b_b1_p[2] u_b1_b_b1_p = {{ .m = 1 }};
+    U_w1_b_w1_p[2] u_w1_b_w1_p = {{ .m = 1 }};
+    U_d1_b_d1_p[2] u_d1_b_d1_p = {{ .m = 1 }};
+    U_q1_b_q1_p[2] u_q1_b_q1_p = {{ .m = 1 }};
+
+    U_b1_b_b1_b_b1[2] u_b1_b_b1_b_b1 = {{ .m = 1 }};
+    U_w1_b_w1_b_w1[2] u_w1_b_w1_b_w1 = {{ .m = 1 }};
+    U_d1_b_d1_b_d1[2] u_d1_b_d1_b_d1 = {{ .m = 1 }};
+    U_q1_b_q1_b_q1[2] u_q1_b_q1_b_q1 = {{ .m = 1 }};
+    U_b1_b_b1_b_b1_p[2] u_b1_b_b1_b_b1_p = {{ .m = 1 }};
+    U_w1_b_w1_b_w1_p[2] u_w1_b_w1_b_w1_p = {{ .m = 1 }};
+    U_d1_b_d1_b_d1_p[2] u_d1_b_d1_b_d1_p = {{ .m = 1 }};
+    U_q1_b_q1_b_q1_p[2] u_q1_b_q1_b_q1_p = {{ .m = 1 }};
+
+    U_b_b[2] u_b_b = {{ .m = F8 }};
+    U_b_w[2] u_b_w = {{ .m = F16 }};
+    U_b_d[2] u_b_d = {{ .m = F32 }};
+    U_b_q[2] u_b_q = {{ .m = F64 }};
+    U_b_b_p[2] u_b_b_p = {{ .m = F8 }};
+    U_b_w_p[2] u_b_w_p = {{ .m = F16 }};
+    U_b_d_p[2] u_b_d_p = {{ .m = F32 }};
+    U_b_q_p[2] u_b_q_p = {{ .m = F64 }};
+
+    U_b_b_b[2] u_b_b_b = {{ .m = F8 }};
+    U_b_w_b[2] u_b_w_b = {{ .m = F16 }};
+    U_b_d_b[2] u_b_d_b = {{ .m = F32 }};
+    U_b_q_b[2] u_b_q_b = {{ .m = F64 }};
+    U_b_b_b_p[2] u_b_b_b_p = {{ .m = F8 }};
+    U_b_w_b_p[2] u_b_w_b_p = {{ .m = F16 }};
+    U_b_d_b_p[2] u_b_d_b_p = {{ .m = F32 }};
+    U_b_q_b_p[2] u_b_q_b_p = {{ .m = F64 }};
+
+    U_b_b1[2] u_b_b1 = {{ .m = 1 }};
+    U_b_w1[2] u_b_w1 = {{ .m = 1 }};
+    U_b_d1[2] u_b_d1 = {{ .m = 1 }};
+    U_b_q1[2] u_b_q1 = {{ .m = 1 }};
+    U_b_b1_p[2] u_b_b1_p = {{ .m = 1 }};
+    U_b_w1_p[2] u_b_w1_p = {{ .m = 1 }};
+    U_b_d1_p[2] u_b_d1_p = {{ .m = 1 }};
+    U_b_q1_p[2] u_b_q1_p = {{ .m = 1 }};
+
+    U_b1_b1[2] u_b1_b1 = {{ .m = 1 }};
+    U_b1_w1[2] u_b1_w1 = {{ .m = 1 }};
+    U_b1_d1[2] u_b1_d1 = {{ .m = 1 }};
+    U_b1_q1[2] u_b1_q1 = {{ .m = 1 }};
+    U_b1_b1_p[2] u_b1_b1_p = {{ .m = 1 }};
+    U_b1_w1_p[2] u_b1_w1_p = {{ .m = 1 }};
+    U_b1_d1_p[2] u_b1_d1_p = {{ .m = 1 }};
+    U_b1_q1_p[2] u_b1_q1_p = {{ .m = 1 }};
+
+    U_b_b1_b[2] u_b_b1_b = {{ .m = 1 }};
+    U_b_w1_b[2] u_b_w1_b = {{ .m = 1 }};
+    U_b_d1_b[2] u_b_d1_b = {{ .m = 1 }};
+    U_b_q1_b[2] u_b_q1_b = {{ .m = 1 }};
+    U_b_b1_b_p[2] u_b_b1_b_p = {{ .m = 1 }};
+    U_b_w1_b_p[2] u_b_w1_b_p = {{ .m = 1 }};
+    U_b_d1_b_p[2] u_b_d1_b_p = {{ .m = 1 }};
+    U_b_q1_b_p[2] u_b_q1_b_p = {{ .m = 1 }};
+
+    U_b1_b1_b1[2] u_b1_b1_b1 = {{ .m = 1 }};
+    U_b1_w1_b1[2] u_b1_w1_b1 = {{ .m = 1 }};
+    U_b1_d1_b1[2] u_b1_d1_b1 = {{ .m = 1 }};
+    U_b1_q1_b1[2] u_b1_q1_b1 = {{ .m = 1 }};
+    U_b1_b1_b1_p[2] u_b1_b1_b1_p = {{ .m = 1 }};
+    U_b1_w1_b1_p[2] u_b1_w1_b1_p = {{ .m = 1 }};
+    U_b1_d1_b1_p[2] u_b1_d1_b1_p = {{ .m = 1 }};
+    U_b1_q1_b1_p[2] u_b1_q1_b1_p = {{ .m = 1 }};
+
+    U_b5_b5_b5[2] u_b5_b5_b5 = {{ .m = F5 }};
+    U_b5_w5_b5[2] u_b5_w5_b5 = {{ .m = F5 }};
+    U_b5_d5_b5[2] u_b5_d5_b5 = {{ .m = F5 }};
+    U_b5_q5_b5[2] u_b5_q5_b5 = {{ .m = F5 }};
+    U_b5_b5_b5_p[2] u_b5_b5_b5_p = {{ .m = F5 }};
+    U_b5_w5_b5_p[2] u_b5_w5_b5_p = {{ .m = F5 }};
+    U_b5_d5_b5_p[2] u_b5_d5_b5_p = {{ .m = F5 }};
+    U_b5_q5_b5_p[2] u_b5_q5_b5_p = {{ .m = F5 }};
+
+    U_d24[2] u_d24 = {{ .m = F24 }};
+    U_d24_p[2] u_d24_p = {{ .m = F24 }};
+    U_d24_d24[2] u_d24_d24 = {{ .m = F24 }};
+    U_d24_d24_p[2] u_d24_d24_p = {{ .m = F24 }};
+    U_d24_d24_d24[2] u_d24_d24_d24 = {{ .m = F24 }};
+    U_d24_d24_d24_p[2] u_d24_d24_d24_p = {{ .m = F24 }};
+    U_d24_d24_d24_d24[2] u_d24_d24_d24_d24 = {{ .m = F24 }};
+    U_d24_d24_d24_d24_p[2] u_d24_d24_d24_d24_p = {{ .m = F24 }};
+    U_b_d24[2] u_b_d24 = {{ .m = F24 }};
+    U_b_d24_p[2] u_b_d24_p = {{ .m = F24 }};
+    U_b_d24_b[2] u_b_d24_b = {{ .m = F24 }};
+    U_b_d24_b_p[2] u_b_d24_b_p = {{ .m = F24 }};
+
+    U_d9[2] u_d9 = {{ .m = F9 }};
+    U_d9_p[2] u_d9_p = {{ .m = F9 }};
+    U_b_d9[2] u_b_d9 = {{ .m = F9 }};
+    U_b_d9_p[2] u_b_d9_p = {{ .m = F9 }};
+    U_b_d9_b[2] u_b_d9_b = {{ .m = F9 }};
+    U_b_d9_b_p[2] u_b_d9_b_p = {{ .m = F9 }};
+
+    check("sizeof(U_b1)", sizeof(U_b1), (u8*)&u_b1[0], (u8*)&u_b1[1]);
+    check("sizeof(U_w1)", sizeof(U_w1), (u8*)&u_w1[0], (u8*)&u_w1[1]);
+    check("sizeof(U_d1)", sizeof(U_d1), (u8*)&u_d1[0], (u8*)&u_d1[1]);
+    check("sizeof(U_q1)", sizeof(U_q1), (u8*)&u_q1[0], (u8*)&u_q1[1]);
+    check("sizeof(U_b1_p)", sizeof(U_b1_p), (u8*)&u_b1_p[0], (u8*)&u_b1_p[1]);
+    check("sizeof(U_w1_p)", sizeof(U_w1_p), (u8*)&u_w1_p[0], (u8*)&u_w1_p[1]);
+    check("sizeof(U_d1_p)", sizeof(U_d1_p), (u8*)&u_d1_p[0], (u8*)&u_d1_p[1]);
+    check("sizeof(U_q1_p)", sizeof(U_q1_p), (u8*)&u_q1_p[0], (u8*)&u_q1_p[1]);
+
+#if ZERO_BITFIELD_UNION
+    check("sizeof(U_b1_b0_b1)", sizeof(U_b1_b0_b1), (u8*)&u_b1_b0_b1[0], (u8*)&u_b1_b0_b1[1]);
+    check("sizeof(U_w1_w0_w1)", sizeof(U_w1_w0_w1), (u8*)&u_w1_w0_w1[0], (u8*)&u_w1_w0_w1[1]);
+    check("sizeof(U_d1_d0_d1)", sizeof(U_d1_d0_d1), (u8*)&u_d1_d0_d1[0], (u8*)&u_d1_d0_d1[1]);
+    check("sizeof(U_q1_q0_q1)", sizeof(U_q1_q0_q1), (u8*)&u_q1_q0_q1[0], (u8*)&u_q1_q0_q1[1]);
+    check("sizeof(U_b1_b0_b1_p)", sizeof(U_b1_b0_b1_p), (u8*)&u_b1_b0_b1_p[0], (u8*)&u_b1_b0_b1_p[1]);
+    check("sizeof(U_w1_w0_w1_p)", sizeof(U_w1_w0_w1_p), (u8*)&u_w1_w0_w1_p[0], (u8*)&u_w1_w0_w1_p[1]);
+    check("sizeof(U_d1_d0_d1_p)", sizeof(U_d1_d0_d1_p), (u8*)&u_d1_d0_d1_p[0], (u8*)&u_d1_d0_d1_p[1]);
+    check("sizeof(U_q1_q0_q1_p)", sizeof(U_q1_q0_q1_p), (u8*)&u_q1_q0_q1_p[0], (u8*)&u_q1_q0_q1_p[1]);
+#endif
+
+    check("sizeof(U_b1_b_b1)", sizeof(U_b1_b_b1), (u8*)&u_b1_b_b1[0], (u8*)&u_b1_b_b1[1]);
+    check("sizeof(U_w1_b_w1)", sizeof(U_w1_b_w1), (u8*)&u_w1_b_w1[0], (u8*)&u_w1_b_w1[1]);
+    check("sizeof(U_d1_b_d1)", sizeof(U_d1_b_d1), (u8*)&u_d1_b_d1[0], (u8*)&u_d1_b_d1[1]);
+    check("sizeof(U_q1_b_q1)", sizeof(U_q1_b_q1), (u8*)&u_q1_b_q1[0], (u8*)&u_q1_b_q1[1]);
+    check("sizeof(U_b1_b_b1_p)", sizeof(U_b1_b_b1_p), (u8*)&u_b1_b_b1_p[0], (u8*)&u_b1_b_b1_p[1]);
+    check("sizeof(U_w1_b_w1_p)", sizeof(U_w1_b_w1_p), (u8*)&u_w1_b_w1_p[0], (u8*)&u_w1_b_w1_p[1]);
+    check("sizeof(U_d1_b_d1_p)", sizeof(U_d1_b_d1_p), (u8*)&u_d1_b_d1_p[0], (u8*)&u_d1_b_d1_p[1]);
+    check("sizeof(U_q1_b_q1_p)", sizeof(U_q1_b_q1_p), (u8*)&u_q1_b_q1_p[0], (u8*)&u_q1_b_q1_p[1]);
+
+    check("sizeof(U_b1_b_b1_b_b1)", sizeof(U_b1_b_b1_b_b1), (u8*)&u_b1_b_b1_b_b1[0], (u8*)&u_b1_b_b1_b_b1[1]);
+    check("sizeof(U_w1_b_w1_b_w1)", sizeof(U_w1_b_w1_b_w1), (u8*)&u_w1_b_w1_b_w1[0], (u8*)&u_w1_b_w1_b_w1[1]);
+    check("sizeof(U_d1_b_d1_b_d1)", sizeof(U_d1_b_d1_b_d1), (u8*)&u_d1_b_d1_b_d1[0], (u8*)&u_d1_b_d1_b_d1[1]);
+    check("sizeof(U_q1_b_q1_b_q1)", sizeof(U_q1_b_q1_b_q1), (u8*)&u_q1_b_q1_b_q1[0], (u8*)&u_q1_b_q1_b_q1[1]);
+    check("sizeof(U_b1_b_b1_b_b1_p)", sizeof(U_b1_b_b1_b_b1_p), (u8*)&u_b1_b_b1_b_b1_p[0], (u8*)&u_b1_b_b1_b_b1_p[1]);
+    check("sizeof(U_w1_b_w1_b_w1_p)", sizeof(U_w1_b_w1_b_w1_p), (u8*)&u_w1_b_w1_b_w1_p[0], (u8*)&u_w1_b_w1_b_w1_p[1]);
+    check("sizeof(U_d1_b_d1_b_d1_p)", sizeof(U_d1_b_d1_b_d1_p), (u8*)&u_d1_b_d1_b_d1_p[0], (u8*)&u_d1_b_d1_b_d1_p[1]);
+    check("sizeof(U_q1_b_q1_b_q1_p)", sizeof(U_q1_b_q1_b_q1_p), (u8*)&u_q1_b_q1_b_q1_p[0], (u8*)&u_q1_b_q1_b_q1_p[1]);
+
+    check("sizeof(U_b_b)", sizeof(U_b_b), (u8*)&u_b_b[0], (u8*)&u_b_b[1]);
+    check("sizeof(U_b_w)", sizeof(U_b_w), (u8*)&u_b_w[0], (u8*)&u_b_w[1]);
+    check("sizeof(U_b_d)", sizeof(U_b_d), (u8*)&u_b_d[0], (u8*)&u_b_d[1]);
+    check("sizeof(U_b_q)", sizeof(U_b_q), (u8*)&u_b_q[0], (u8*)&u_b_q[1]);
+    check("sizeof(U_b_b_p)", sizeof(U_b_b_p), (u8*)&u_b_b_p[0], (u8*)&u_b_b_p[1]);
+    check("sizeof(U_b_w_p)", sizeof(U_b_w_p), (u8*)&u_b_w_p[0], (u8*)&u_b_w_p[1]);
+    check("sizeof(U_b_d_p)", sizeof(U_b_d_p), (u8*)&u_b_d_p[0], (u8*)&u_b_d_p[1]);
+    check("sizeof(U_b_q_p)", sizeof(U_b_q_p), (u8*)&u_b_q_p[0], (u8*)&u_b_q_p[1]);
+
+    check("sizeof(U_b_b1)", sizeof(U_b_b1), (u8*)&u_b_b1[0], (u8*)&u_b_b1[1]);
+    check("sizeof(U_b_w1)", sizeof(U_b_w1), (u8*)&u_b_w1[0], (u8*)&u_b_w1[1]);
+    check("sizeof(U_b_d1)", sizeof(U_b_d1), (u8*)&u_b_d1[0], (u8*)&u_b_d1[1]);
+    check("sizeof(U_b_q1)", sizeof(U_b_q1), (u8*)&u_b_q1[0], (u8*)&u_b_q1[1]);
+    check("sizeof(U_b_b1_p)", sizeof(U_b_b1_p), (u8*)&u_b_b1_p[0], (u8*)&u_b_b1_p[1]);
+    check("sizeof(U_b_w1_p)", sizeof(U_b_w1_p), (u8*)&u_b_w1_p[0], (u8*)&u_b_w1_p[1]);
+    check("sizeof(U_b_d1_p)", sizeof(U_b_d1_p), (u8*)&u_b_d1_p[0], (u8*)&u_b_d1_p[1]);
+    check("sizeof(U_b_q1_p)", sizeof(U_b_q1_p), (u8*)&u_b_q1_p[0], (u8*)&u_b_q1_p[1]);
+
+    check("sizeof(U_b1_b1)", sizeof(U_b1_b1), (u8*)&u_b1_b1[0], (u8*)&u_b1_b1[1]);
+    check("sizeof(U_b1_w1)", sizeof(U_b1_w1), (u8*)&u_b1_w1[0], (u8*)&u_b1_w1[1]);
+    check("sizeof(U_b1_d1)", sizeof(U_b1_d1), (u8*)&u_b1_d1[0], (u8*)&u_b1_d1[1]);
+    check("sizeof(U_b1_q1)", sizeof(U_b1_q1), (u8*)&u_b1_q1[0], (u8*)&u_b1_q1[1]);
+    check("sizeof(U_b1_b1_p)", sizeof(U_b1_b1_p), (u8*)&u_b1_b1_p[0], (u8*)&u_b1_b1_p[1]);
+    check("sizeof(U_b1_w1_p)", sizeof(U_b1_w1_p), (u8*)&u_b1_w1_p[0], (u8*)&u_b1_w1_p[1]);
+    check("sizeof(U_b1_d1_p)", sizeof(U_b1_d1_p), (u8*)&u_b1_d1_p[0], (u8*)&u_b1_d1_p[1]);
+    check("sizeof(U_b1_q1_p)", sizeof(U_b1_q1_p), (u8*)&u_b1_q1_p[0], (u8*)&u_b1_q1_p[1]);
+
+    check("sizeof(U_b_b_b)", sizeof(U_b_b_b), (u8*)&u_b_b_b[0], (u8*)&u_b_b_b[1]);
+    check("sizeof(U_b_w_b)", sizeof(U_b_w_b), (u8*)&u_b_w_b[0], (u8*)&u_b_w_b[1]);
+    check("sizeof(U_b_d_b)", sizeof(U_b_d_b), (u8*)&u_b_d_b[0], (u8*)&u_b_d_b[1]);
+    check("sizeof(U_b_q_b)", sizeof(U_b_q_b), (u8*)&u_b_q_b[0], (u8*)&u_b_q_b[1]);
+    check("sizeof(U_b_b_b_p)", sizeof(U_b_b_b_p), (u8*)&u_b_b_b_p[0], (u8*)&u_b_b_b_p[1]);
+    check("sizeof(U_b_w_b_p)", sizeof(U_b_w_b_p), (u8*)&u_b_w_b_p[0], (u8*)&u_b_w_b_p[1]);
+    check("sizeof(U_b_d_b_p)", sizeof(U_b_d_b_p), (u8*)&u_b_d_b_p[0], (u8*)&u_b_d_b_p[1]);
+    check("sizeof(U_b_q_b_p)", sizeof(U_b_q_b_p), (u8*)&u_b_q_b_p[0], (u8*)&u_b_q_b_p[1]);
+
+    check("sizeof(U_b_b1_b)", sizeof(U_b_b1_b), (u8*)&u_b_b1_b[0], (u8*)&u_b_b1_b[1]);
+    check("sizeof(U_b_w1_b)", sizeof(U_b_w1_b), (u8*)&u_b_w1_b[0], (u8*)&u_b_w1_b[1]);
+    check("sizeof(U_b_d1_b)", sizeof(U_b_d1_b), (u8*)&u_b_d1_b[0], (u8*)&u_b_d1_b[1]);
+    check("sizeof(U_b_q1_b)", sizeof(U_b_q1_b), (u8*)&u_b_q1_b[0], (u8*)&u_b_q1_b[1]);
+    check("sizeof(U_b_b1_b_p)", sizeof(U_b_b1_b_p), (u8*)&u_b_b1_b_p[0], (u8*)&u_b_b1_b_p[1]);
+    check("sizeof(U_b_w1_b_p)", sizeof(U_b_w1_b_p), (u8*)&u_b_w1_b_p[0], (u8*)&u_b_w1_b_p[1]);
+    check("sizeof(U_b_d1_b_p)", sizeof(U_b_d1_b_p), (u8*)&u_b_d1_b_p[0], (u8*)&u_b_d1_b_p[1]);
+    check("sizeof(U_b_q1_b_p)", sizeof(U_b_q1_b_p), (u8*)&u_b_q1_b_p[0], (u8*)&u_b_q1_b_p[1]);
+
+    check("sizeof(U_b1_b1_b1)", sizeof(U_b1_b1_b1), (u8*)&u_b1_b1_b1[0], (u8*)&u_b1_b1_b1[1]);
+    check("sizeof(U_b1_w1_b1)", sizeof(U_b1_w1_b1), (u8*)&u_b1_w1_b1[0], (u8*)&u_b1_w1_b1[1]);
+    check("sizeof(U_b1_d1_b1)", sizeof(U_b1_d1_b1), (u8*)&u_b1_d1_b1[0], (u8*)&u_b1_d1_b1[1]);
+    check("sizeof(U_b1_q1_b1)", sizeof(U_b1_q1_b1), (u8*)&u_b1_q1_b1[0], (u8*)&u_b1_q1_b1[1]);
+    check("sizeof(U_b1_b1_b1_p)", sizeof(U_b1_b1_b1_p), (u8*)&u_b1_b1_b1_p[0], (u8*)&u_b1_b1_b1_p[1]);
+    check("sizeof(U_b1_w1_b1_p)", sizeof(U_b1_w1_b1_p), (u8*)&u_b1_w1_b1_p[0], (u8*)&u_b1_w1_b1_p[1]);
+    check("sizeof(U_b1_d1_b1_p)", sizeof(U_b1_d1_b1_p), (u8*)&u_b1_d1_b1_p[0], (u8*)&u_b1_d1_b1_p[1]);
+    check("sizeof(U_b1_q1_b1_p)", sizeof(U_b1_q1_b1_p), (u8*)&u_b1_q1_b1_p[0], (u8*)&u_b1_q1_b1_p[1]);
+
+    check("sizeof(U_b5_b5_b5)", sizeof(U_b5_b5_b5), (u8*)&u_b5_b5_b5[0], (u8*)&u_b5_b5_b5[1]);
+    check("sizeof(U_b5_w5_b5)", sizeof(U_b5_w5_b5), (u8*)&u_b5_w5_b5[0], (u8*)&u_b5_w5_b5[1]);
+    check("sizeof(U_b5_d5_b5)", sizeof(U_b5_d5_b5), (u8*)&u_b5_d5_b5[0], (u8*)&u_b5_d5_b5[1]);
+    check("sizeof(U_b5_q5_b5)", sizeof(U_b5_q5_b5), (u8*)&u_b5_q5_b5[0], (u8*)&u_b5_q5_b5[1]);
+    check("sizeof(U_b5_b5_b5_p)", sizeof(U_b5_b5_b5_p), (u8*)&u_b5_b5_b5_p[0], (u8*)&u_b5_b5_b5_p[1]);
+    check("sizeof(U_b5_w5_b5_p)", sizeof(U_b5_w5_b5_p), (u8*)&u_b5_w5_b5_p[0], (u8*)&u_b5_w5_b5_p[1]);
+    check("sizeof(U_b5_d5_b5_p)", sizeof(U_b5_d5_b5_p), (u8*)&u_b5_d5_b5_p[0], (u8*)&u_b5_d5_b5_p[1]);
+    check("sizeof(U_b5_q5_b5_p)", sizeof(U_b5_q5_b5_p), (u8*)&u_b5_q5_b5_p[0], (u8*)&u_b5_q5_b5_p[1]);
+
+    check("sizeof(U_d24)", sizeof(U_d24), (u8*)&u_d24[0], (u8*)&u_d24[1]);
+    check("sizeof(U_d24_p)", sizeof(U_d24_p), (u8*)&u_d24_p[0], (u8*)&u_d24_p[1]);
+    check("sizeof(U_d24_d24)", sizeof(U_d24_d24), (u8*)&u_d24_d24[0], (u8*)&u_d24_d24[1]);
+    check("sizeof(U_d24_d24_p)", sizeof(U_d24_d24_p), (u8*)&u_d24_d24_p[0], (u8*)&u_d24_d24_p[1]);
+    check("sizeof(U_d24_d24_d24)", sizeof(U_d24_d24_d24), (u8*)&u_d24_d24_d24[0], (u8*)&u_d24_d24_d24[1]);
+    check("sizeof(U_d24_d24_d24_p)", sizeof(U_d24_d24_d24_p), (u8*)&u_d24_d24_d24_p[0], (u8*)&u_d24_d24_d24_p[1]);
+    check("sizeof(U_d24_d24_d24_d24)", sizeof(U_d24_d24_d24_d24), (u8*)&u_d24_d24_d24_d24[0], (u8*)&u_d24_d24_d24_d24[1]);
+    check("sizeof(U_d24_d24_d24_d24_p)", sizeof(U_d24_d24_d24_d24_p), (u8*)&u_d24_d24_d24_d24_p[0], (u8*)&u_d24_d24_d24_d24_p[1]);
+    check("sizeof(U_b_d24)", sizeof(U_b_d24), (u8*)&u_b_d24[0], (u8*)&u_b_d24[1]);
+    check("sizeof(U_b_d24_p)", sizeof(U_b_d24_p), (u8*)&u_b_d24_p[0], (u8*)&u_b_d24_p[1]);
+    check("sizeof(U_b_d24_b)", sizeof(U_b_d24_b), (u8*)&u_b_d24_b[0], (u8*)&u_b_d24_b[1]);
+    check("sizeof(U_b_d24_b_p)", sizeof(U_b_d24_b_p), (u8*)&u_b_d24_b_p[0], (u8*)&u_b_d24_b_p[1]);
+
+    check("sizeof(U_d9)", sizeof(U_d9), (u8*)&u_d9[0], (u8*)&u_d9[1]);
+    check("sizeof(U_d9_p)", sizeof(U_d9_p), (u8*)&u_d9_p[0], (u8*)&u_d9_p[1]);
+    check("sizeof(U_b_d9)", sizeof(U_b_d9), (u8*)&u_b_d9[0], (u8*)&u_b_d9[1]);
+    check("sizeof(U_b_d9_p)", sizeof(U_b_d9_p), (u8*)&u_b_d9_p[0], (u8*)&u_b_d9_p[1]);
+    check("sizeof(U_b_d9_b)", sizeof(U_b_d9_b), (u8*)&u_b_d9_b[0], (u8*)&u_b_d9_b[1]);
+    check("sizeof(U_b_d9_b_p)", sizeof(U_b_d9_b_p), (u8*)&u_b_d9_b_p[0], (u8*)&u_b_d9_b_p[1]);
+
+    Block[2] block = {{ AA, 1, 0, 1, 0, 1, { 0xDEADBEEF, 0xBABEFACE }, { 0xDEADBEEF, 0xBABEFACE }}};
+
+    check("sizeof(Block)", sizeof(Block), (u8*)&block[0], (u8*)&block[1]);
+
+    check(nil, 0, nil, nil);
+
+    return 0;
+}

--- a/test/types/struct/bitfield_zero_width.c2
+++ b/test/types/struct/bitfield_zero_width.c2
@@ -3,6 +3,7 @@ module test;
 
 type Foo struct {
     u32 field : 1;
+    u32       : 0;        // zero width bit-field must ne unnamed
     u32 pad   : 0;        // @error{zero width for bit-field 'pad'}
 }
 


### PR DESCRIPTION
* accept zero width unnamed bitfields in struct to force alignment
* use PCC algorithm for compatibility with gcc, clang and tcc
* add test/types/struct/bitfield_validator.c2 to test many combinations and check consistency with c struct layout and sizes