### PR TITLE
Compiler: include sign bit in BuiltinType widths

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -333,20 +333,17 @@ fn bool Checker.checkPointer2Func(Checker* c, const Type* lcanon, const Type* rc
 
 fn bool Checker.checkIntConversion(Checker* c, const BuiltinType* bi) {
     Expr* e = *c.expr_ptr;
-    const u8 wl = (u8)bi.getWidth();
+    u32 wl = bi.getWidth();
     ExprWidth w = getExprWidth(e);
     //stdio.printf("INT CONVERSION signed|width: %d %d -> %d %d\n", w.is_signed, w.width, bi.isSigned(), w.width);
 
-    // dont allowd signed -> unsigned
-    // allow unsigned X -> signed X for same widths
-    if (w.is_signed == bi.isSigned()) {
-        return (w.width <= wl);
-    } else {
-        // allow unsigned -> signed only if it gets bigger (eg. u16 fits in i32)
+    if (w.is_signed != bi.isSigned()) {
+        // dont allow signed -> unsigned: fully defined but requires explicit cast in c2
         if (w.is_signed) return false;
-        return w.width <= wl;
+        // allow unsigned -> signed only if value is preserved (eg. u16 fits in i32)
+        return w.width < wl;
     }
-    return false;
+    return w.width <= wl;
 }
 
 // Note: try to fix array type that has been decayed to a pointer
@@ -428,6 +425,7 @@ fn bool Checker.checkFunc2Pointer(Checker* c, const Type* lcanon, const Type* rc
 
 fn bool Checker.checkEnum2Int(Checker* c, const Type* lcanon, const Type* rcanon) {
     // Note: enum constant values can never be negative
+    // TODO check if negative enum values are rejected
     const BuiltinType* bi = (BuiltinType*)lcanon;
     u32 width = bi.getWidth();
     if (width == 64) return true;  // 64-bit

--- a/analyser/conversion_checker_expr.c2
+++ b/analyser/conversion_checker_expr.c2
@@ -32,6 +32,12 @@ fn ExprWidth ExprWidth.mergeSmaller(ExprWidth w1, ExprWidth w2) {
 
 fn ExprWidth ExprWidth.mergeWider(ExprWidth w1, ExprWidth w2) {
     ExprWidth result;
+    if (w1.is_signed != w2.is_signed) {
+        // increase unsigned width to account for sign bit
+        // this allows 'i8 b = some_i8 + 100;' and rejects 'i8 b = some_i8 + 200;'
+        if (w1.is_signed && w2.width < 32) w2.width += 1;
+        if (w2.is_signed && w1.width < 32) w1.width += 1;
+    }
     result.width = (w1.width > w2.width) ? w1.width : w2.width;
     result.is_signed = w1.is_signed | w2.is_signed;
     return result;
@@ -156,9 +162,11 @@ fn ExprWidth getBinOpWidth(const BinaryOperator* b) {
         break;
     case ShiftLeft:
         ExprWidth result = getExprWidth(b.getLHS());
-        if (result.width < 31) { result.width = 31; result.is_signed = true; }
+        // TODO handle constant RHS and int promotion
+        if (result.width < 32) { result.width = 32; result.is_signed = true; }
         return result;
     case ShiftRight:
+        // TODO handle constant RHS
         return getExprWidth(b.getLHS());
     case LessThan:
     case GreaterThan:

--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -707,7 +707,7 @@ fn bool Analyser.checkShiftArgs(Analyser* ma, Expr* lhs, Expr* rhs) {
     }
     BuiltinType* bi = canon.getBuiltinTypeOrNil();
     u32 width = bi.getWidth();
-    width += bi.isSigned(); // allow i32 a = 1 << 31
+    // Do not reduce width of signed types to allow `i32 a = 1 << 31;`
 
     if (lhs.isCtv()) {
         Value val = ctv_analyser.get_value(lhs);

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -523,6 +523,7 @@ fn bool Analyser.analyseBitOffsetIndex(Analyser* ma, Expr** e_ptr, QualType base
         return false;
     }
 
+    // accept shifting 1 << 31
     if (val.as_u64() >= base_bi.getWidth()) {
         ma.errorRange(e.getLoc(), e.getRange(), "bitoffset index value '%s' too large for type '%s'", val.str(), baseType.diagName());
         return false;

--- a/analyser_utils/ctv_analyser.c2
+++ b/analyser_utils/ctv_analyser.c2
@@ -24,24 +24,14 @@ type Limit struct {
     u64 max_val;
 }
 
-fn void Limit.init2(Limit* l, u32 width, bool is_signed) {
+fn void Limit.init(Limit* l, u32 width, bool is_signed) {
     if (is_signed) {
         i64 max_val = (i64)0x7FFFFFFFFFFFFFFF >> (64 - width);
         l.min_val = -max_val - 1;
         l.max_val = (u64)max_val;
     } else {
         l.min_val = 0;
-        l.max_val = (u64)0xFFFFFFFFFFFFFFFF >> (64 - width);
-    }
-}
-
-fn void Limit.init1(Limit* l, u32 width) {
-    if (width <= 1) {  // Bool and Void;
-        l.max_val = width;
-        l.min_val = 1 - width;
-    } else {
-        bool is_signed = width & 1;
-        l.init2(width + is_signed, is_signed);
+        l.max_val = (u64)~(u64)0 >> (64 - width);
     }
 }
 
@@ -293,7 +283,7 @@ public fn bool checkBitfield(diagnostics.Diags* diags, u8 bitfield_width, bool b
         diags.errorRange(e.getLoc(), e.getRange(), "%s", value.error_msg);
         return false;
     }
-    Limit limit.init2(bitfield_width, bitfield_signed);
+    Limit limit.init(bitfield_width, bitfield_signed);
 
     if (!value.checkRange(limit.min_val, limit.max_val)) {
         diags.errorRange(e.getLoc(), e.getRange(), "constant value %s out-of-bounds for bitfield, range [%d, %d]",
@@ -314,7 +304,7 @@ public fn bool checkRange(diagnostics.Diags* diags, QualType qt, Value* value, S
     // TODO: check float32 range
     if (bi.getKind() == BuiltinKind.Float32 || bi.getKind() == BuiltinKind.Float64) return true;
 
-    Limit limit.init1(bi.getWidth());
+    Limit limit.init(bi.getWidth(), bi.isSigned());
 
     if (!value.checkRange(limit.min_val, limit.max_val)) {
         SrcRange range = { 0, 0 };

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -159,26 +159,6 @@ static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_sizes));
 // Default builtin type widths (adjusted for 32-bit in globals)
 const u32[] BuiltinType_default_widths = {
     [BuiltinKind.Char] = 8,
-    [BuiltinKind.Int8] = 7,
-    [BuiltinKind.Int16] = 15,
-    [BuiltinKind.Int32] = 31,
-    [BuiltinKind.Int64] = 63,
-    [BuiltinKind.UInt8] = 8,
-    [BuiltinKind.UInt16] = 16,
-    [BuiltinKind.UInt32] = 32,
-    [BuiltinKind.UInt64] = 64,
-    [BuiltinKind.Float32] = 0,
-    [BuiltinKind.Float64] = 0,
-    [BuiltinKind.ISize] = 63, // adjusted in global
-    [BuiltinKind.USize] = 64, // adjusted in global
-    [BuiltinKind.Bool] = 1,
-    [BuiltinKind.Void] = 0,
-}
-static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_widths));
-
-// Default builtin bitfield widths (adjusted for 32-bit in globals)
-const u32[] BuiltinType_bitfield_sizes = {
-    [BuiltinKind.Char] = 8,
     [BuiltinKind.Int8] = 8,
     [BuiltinKind.Int16] = 16,
     [BuiltinKind.Int32] = 32,
@@ -194,7 +174,7 @@ const u32[] BuiltinType_bitfield_sizes = {
     [BuiltinKind.Bool] = 1,
     [BuiltinKind.Void] = 0,
 }
-static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_bitfield_sizes));
+static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_widths));
 
 public fn const char* BuiltinKind.str(BuiltinKind kind) {
     return builtinType_names[kind];
@@ -289,10 +269,6 @@ public fn u32 BuiltinType.getAlignment(const BuiltinType* b) {
 
 public fn u32 BuiltinType.getWidth(const BuiltinType* b) {
     return globals.builtinType_width[b.getKind()];
-}
-
-fn u32 BuiltinType.getBitfieldSize(const BuiltinType* b) {
-    return globals.builtinType_bitfield_sizes[b.getKind()];
 }
 
 fn void BuiltinType.print(const BuiltinType* b, string_buffer.Buf* out) {

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -94,7 +94,7 @@ public fn u32 QualType.getBitFieldWidth(const QualType* qt) {
     const Type* t = canon.getTypeOrNil();
     if (t.isBuiltinType()) {
         BuiltinType* bi = (BuiltinType*)t;
-        return bi.getBitfieldSize();
+        return bi.getWidth();
     }
     if (t.isEnumType()) {
         // TODO return bits needed for max value to allow use in bitfields

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -106,7 +106,6 @@ public type Globals struct @(opaque) {
 
     u32[elemsof(BuiltinKind)] builtinType_sizes;
     u32[elemsof(BuiltinKind)] builtinType_width;
-    u32[elemsof(BuiltinKind)] builtinType_bitfield_sizes;
     BuiltinKind[elemsof(BuiltinKind)] builtinType_baseTypes;
 
     u32[elemsof(attr.AttrKind)] attr_name_indexes;
@@ -161,12 +160,8 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
     globals.builtinType_sizes[BuiltinKind.USize] = wordsize;
 
     string.memcpy(globals.builtinType_width, BuiltinType_default_widths, sizeof(BuiltinType_default_widths));
-    globals.builtinType_width[BuiltinKind.ISize] = wordsize * 8 - 1;
+    globals.builtinType_width[BuiltinKind.ISize] = wordsize * 8;
     globals.builtinType_width[BuiltinKind.USize] = wordsize * 8;
-
-    string.memcpy(globals.builtinType_bitfield_sizes, BuiltinType_bitfield_sizes, sizeof(BuiltinType_bitfield_sizes));
-    globals.builtinType_bitfield_sizes[BuiltinKind.ISize] = wordsize * 8;
-    globals.builtinType_bitfield_sizes[BuiltinKind.USize] = wordsize * 8;
 
     for (u32 i=0; i<elemsof(BuiltinKind); i++) {
         globals.builtinType_baseTypes[i] = (BuiltinKind)i;

--- a/ast/value.c2
+++ b/ast/value.c2
@@ -182,24 +182,27 @@ public fn u64 Value.as_u64(Value* v) {
 }
 
 public fn u8 Value.getWidth(const Value* v) {
-    if (v.kind != ValueKind.Integer)
+    if (v.kind != ValueKind.Integer) {
+        // TODO: handle f32 vs f64? all constant floating point
+        //       computations are currently performed as double
         return 64;
-    //TODO find faster way
-    u64 value = v.negative ? v.uvalue - 1 : v.uvalue;
-    if (value <= 65535) {
-        if (value <= 255) {
-            if (value <= 127) return 7;
-            else return 8;
+    }
+    // TODO: check if this poses problems, possibly use 1 instead
+    if (v.uvalue == 0) return 0;
+    // Return actual bitwidth of integer value including sign bit
+    u64 value = v.uvalue - v.negative;
+    u32 width = v.negative;
+    //TODO use 64 - value.leading_zeros() + v.negative;
+    if (value) {
+        width += 1;
+        for (u32 shift = 32; shift; shift >>= 1) {
+            if (value >= ((u64)1 << shift)) {
+                value >>= shift;
+                width += shift;
+            }
         }
-        if (value <= 32767) return 15;
-        else return 16;
     }
-    if (value <= 4294967295) {
-        if (value <= 2147483647) return 31;
-        else return 32;
-    }
-    if (value <= 9223372036854775807) return 63;
-    return 64;
+    return (u8)width;
 }
 
 public fn bool Value.checkRange(const Value* v, i64 min, u64 max) {
@@ -663,45 +666,20 @@ public fn void Value.mask(Value* v, u32 width) {
     }
 }
 
-fn void Value.truncate(Value *orig, bool is_signed, u32 width) {
+fn void Value.truncate(Value *orig, u32 width, bool is_signed) {
     assert(orig.isDecimal());
-    // TODO signed, for now only take uvalue
     u64 uvalue = orig.as_u64();
-    u64 mask = 1;
-    u64 sbit = 0;
-    switch (width) {
-    case 1:
-        uvalue = (uvalue != 0) ? 1 : 0;
-        break;
-    case 7:
-        sbit = 0x80;
-        fallthrough;
-    case 8:
-        mask = 0xFF;
-        break;
-    case 15:
-        sbit = 0x8000;
-        fallthrough;
-    case 16:
-        mask = 0xFFFF;
-        break;
-    case 31:
-        sbit = 0x80000000;
-        fallthrough;
-    case 32:
-        mask = 0xFFFFFFFF;
-        break;
-    case 63:
-        sbit = 0x8000000000000000;
-        fallthrough;
-    case 64:
-        mask = 0xFFFFFFFFFFFFFFFF;
-        break;
-    }
-    if (uvalue & sbit)
-        orig.setSigned((i64)((uvalue & (sbit - 1)) - sbit));
-    else
+    if (is_signed) {
+        u64 sbit = (u64)1 << (width - 1);
+        u64 mask = sbit - 1;
+        if (uvalue & sbit)
+            orig.setSigned((i64)((uvalue & mask) - sbit));
+        else
+            orig.setUnsigned(uvalue & mask);
+    } else {
+        u64 mask = (u64)~(u64)0 >> (64 - width);
         orig.setUnsigned(uvalue & mask);
+    }
 }
 
 public fn void Value.incr(Value* v) {
@@ -752,6 +730,8 @@ public fn void Value.decr(Value* v) {
 fn Value Value.castAs(const Value* v, QualType qt) {
     Value result = *v;
 
+    if (result.kind == Error)
+        return result;
     qt = qt.getCanonicalType();
     if (qt.isEnum())
         qt = qt.getEnum().getImplType();
@@ -759,24 +739,25 @@ fn Value Value.castAs(const Value* v, QualType qt) {
         return result;
     assert(qt.isBuiltin());
     BuiltinType* bi = qt.getBuiltin();
+    u32 width = bi.getWidth();
     switch (result.kind) {  // @@@
     case Integer:
         if (qt.isFloat()) {
             result.setFloat(result.toFloat());
-            if (bi.getWidth() == 32) {
-                result.setFloat(cast<f32>(result.toFloat()));
+            if (width == 32) {
+                result.fvalue = (f32)result.fvalue;
             }
         } else
         if (qt.isBool()) {
             result.setUnsigned(!result.isZero());
         } else {
-            result.truncate(bi.isSigned(), bi.getWidth());
+            result.truncate(width, bi.isSigned());
         }
         break;
     case Float:
         if (qt.isFloat()) {
-            if (bi.getWidth() == 32) {
-                result.setFloat(cast<f32>(result.fvalue));
+            if (width == 32) {
+                result.fvalue = (f32)result.fvalue;
             }
         } else
         if (qt.isBool()) {
@@ -784,11 +765,11 @@ fn Value Value.castAs(const Value* v, QualType qt) {
         } else {
             // TODO: check for overflow
             if (bi.isSigned()) {
-                result.setSigned(cast<i64>(result.fvalue));
+                result.setSigned((i64)result.fvalue);
             } else {
-                result.setUnsigned(cast<u64>(result.fvalue));
+                result.setUnsigned((u64)result.fvalue);
             }
-            result.truncate(bi.isSigned(), bi.getWidth());
+            result.truncate(width, bi.isSigned());
         }
         break;
     default:


### PR DESCRIPTION
* use standard width 8/16/32/64 for i8/i16/i32/i64
* remove `BuiltinType_bitfield_sizes` and equivalent array in `global`
* remove `BuiltinType.getBitfieldSize()`
* swap `Value.truncate` arguments for consistency
* simplify `Value.getWidth()`, `Value.truncate()` and `Value.castAs()`.
* use single init function `Limit.init()`.
* simplify `Checker.checkIntConversion()`