### PR TITLE
Analyser: fix 32/64 bit issues

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -66,6 +66,7 @@ const u8[elemsof(TypeKind)][elemsof(TypeKind)] Conversions = {
 //  5 = float -> integer
 //  6 = loss of FP-precision
 //  7 = ok, no conversion needed (eg. char -> u8, isize -> i64, i32 -> bool)
+// No need to adjust for 32-bit as ISize and USize are converted before the lookup
 const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] BuiltinConversions = {
     //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32  Flt64  ISize  USize  Bool  Void
     //  1      2      3      4      5      6      7      8      9      10     11     12     13     14    15
@@ -74,19 +75,19 @@ const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] BuiltinConversions = {
     // Int8 ->
     {   3,     0,     1,     1,     1,     3,     3,     3,     3,     1,     1,     1,     3,     7,    2  },
     // Int16 ->
-    {   4,     4,     0,     1,     1,     3,     3,     3,     3,     1,     1,     1,     3,     7,    2  },
+    {   4,     4,     0,     1,     1,     4,     3,     3,     3,     1,     1,     1,     3,     7,    2  },
     // Int32 ->
-    {   4,     4,     4,     0,     1,     3,     3,     3,     3,     1,     1,     1,     3,     7,    2  },
+    {   4,     4,     4,     7,     1,     4,     4,     3,     3,     1,     1,     1,     3,     7,    2  },
     // Int64 ->
-    {   4,     4,     4,     4,     0,     3,     3,     3,     3,     1,     1,     7,     3,     7,    2  },
+    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     7,     3,     7,    2  },
     // UInt8 ->
-    {   1,     3,     3,     3,     3,     0,     1,     1,     1,     1,     1,     3,     1,     7,    2  },
+    {   1,     3,     1,     1,     1,     0,     1,     1,     1,     1,     1,     3,     1,     7,    2  },
     // UInt16 ->
-    {   4,     4,     3,     3,     3,     4,     0,     1,     1,     1,     1,     3,     1,     7,    2  },
+    {   4,     4,     3,     1,     1,     4,     0,     1,     1,     1,     1,     3,     1,     7,    2  },
     // UInt32 ->
-    {   4,     4,     4,     3,     3,     4,     4,     0,     1,     1,     1,     3,     1,     7,    2  },
+    {   4,     4,     4,     3,     1,     4,     4,     7,     1,     1,     1,     3,     1,     7,    2  },
     // UInt64 ->
-    {   4,     4,     4,     4,     3,     4,     4,     4,     0,     1,     1,     3,     7,     7,    2  },
+    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     7,     7,    2  },
     // Flt32 ->
     {   5,     5,     5,     5,     5,     5,     5,     5,     5,     0,     1,     5,     5,     2,    2  },
     // Flt64 ->
@@ -227,7 +228,7 @@ fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon
         return true;
     }
 
-    u8 res = BuiltinConversions[rbuiltin.getKind()][lbuiltin.getKind()];
+    u8 res = BuiltinConversions[rbuiltin.getBaseKind()][lbuiltin.getBaseKind()];
     switch (res) {
     case 0:     // should not happen
         c.diags.error(c.loc, "BUILTIN SHOULD NOT HAPPEN (%d - %d)\n", lcanon.getKind(), rcanon.getKind());
@@ -613,6 +614,7 @@ fn bool Checker.checkPointer2BuiltinCast(Checker* c, const Type* lcanon, const T
 }
 
 // Just takes smallest type, dont promote both sides to i32
+// No need to adjust for 32-bit as ISize and USize are converted before the lookup
 const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] ConditionalOperatorResult = {
     //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool  Void
     //  0      1      2      3      4      5      6      7      8      9     10     11     12     13     14
@@ -653,7 +655,7 @@ public fn QualType get_common_arithmetic_type(QualType t1, QualType t2) {
 
     BuiltinType* bi1 = t1.getBuiltin();
     BuiltinType* bi2 = t2.getBuiltin();
-    BuiltinKind kind = (BuiltinKind)ConditionalOperatorResult[bi2.getKind()][bi1.getKind()];
+    BuiltinKind kind = (BuiltinKind)ConditionalOperatorResult[bi2.getBaseKind()][bi1.getBaseKind()];
     return ast.builtins[kind];
 }
 
@@ -668,6 +670,7 @@ public fn QualType get_common_arithmetic_type(QualType t1, QualType t2) {
      6 error,
 */
 // See ISO/IEC 9899:201x 6.3.1
+// No need to adjust for 32-bit as ISize and USize are converted before the lookup
 const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] UsualArithmeticConversions = {
     //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool  Void
     //  0      1      2      3      4      5      6      7      8      9     10     11     12     13     14

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -136,6 +136,7 @@ const bool[] BuiltinType_integer = {
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_integer));
 
+// Default builtin type sizes (adjusted for 32-bit in globals)
 const u32[] BuiltinType_default_sizes = {
     [BuiltinKind.Char] = 1,
     [BuiltinKind.Int8] = 1,
@@ -148,13 +149,14 @@ const u32[] BuiltinType_default_sizes = {
     [BuiltinKind.UInt64] = 8,
     [BuiltinKind.Float32] = 4,
     [BuiltinKind.Float64] = 8,
-    [BuiltinKind.ISize] = 8,       // ISize <- need to change for ARCH
-    [BuiltinKind.USize] = 8,       // USize <- need to change for ARCH
+    [BuiltinKind.ISize] = 8,       // adjusted in global
+    [BuiltinKind.USize] = 8,       // adjusted in global
     [BuiltinKind.Bool] = 1,
     [BuiltinKind.Void] = 0,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_sizes));
 
+// Default builtin type widths (adjusted for 32-bit in globals)
 const u32[] BuiltinType_default_widths = {
     [BuiltinKind.Char] = 8,
     [BuiltinKind.Int8] = 7,
@@ -167,13 +169,14 @@ const u32[] BuiltinType_default_widths = {
     [BuiltinKind.UInt64] = 64,
     [BuiltinKind.Float32] = 0,
     [BuiltinKind.Float64] = 0,
-    [BuiltinKind.ISize] = 63, // ISize <- need to change for ARCH
-    [BuiltinKind.USize] = 64, // USize <- need to change for ARCH
+    [BuiltinKind.ISize] = 63, // adjusted in global
+    [BuiltinKind.USize] = 64, // adjusted in global
     [BuiltinKind.Bool] = 1,
     [BuiltinKind.Void] = 0,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_widths));
 
+// Default builtin bitfield widths (adjusted for 32-bit in globals)
 const u32[] BuiltinType_bitfield_sizes = {
     [BuiltinKind.Char] = 8,
     [BuiltinKind.Int8] = 8,
@@ -186,8 +189,8 @@ const u32[] BuiltinType_bitfield_sizes = {
     [BuiltinKind.UInt64] = 64,
     [BuiltinKind.Float32] = 0,
     [BuiltinKind.Float64] = 0,
-    [BuiltinKind.ISize] = 64,       // ISize <- need to change for ARCH
-    [BuiltinKind.USize] = 64,       // USize <- need to change for ARCH
+    [BuiltinKind.ISize] = 64,       // adjusted in global
+    [BuiltinKind.USize] = 64,       // adjusted in global
     [BuiltinKind.Bool] = 1,
     [BuiltinKind.Void] = 0,
 }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -1325,11 +1325,9 @@ const char[] C_types =
     typedef unsigned short uint16_t;
     typedef signed int int32_t;
     typedef unsigned int uint32_t;
-    // FIXME: these should be target dependent
-    typedef signed long int64_t;
-    typedef unsigned long uint64_t;
-    typedef long ssize_t;
-    typedef unsigned long size_t;
+    ```;
+const char[] C_defines =
+    ```c
     #define true 1
     #define false 0
 
@@ -1378,6 +1376,33 @@ fn void Generator.emit_external_header(Generator* gen, bool enable_asserts, cons
     out.add(Include_guard1);
     out.add(Warning_control);
     out.add(C_types);
+    if (ast.getWordSize() == 4) {
+        // ILP32 (32-bit int, long and pointers)
+        out.add(```c
+                typedef signed long long int64_t;
+                typedef unsigned long long uint64_t;
+                typedef signed long ssize_t;
+                typedef unsigned long size_t;
+                ```);
+    } else {
+        // LP64 (64-bit long and pointers)
+        out.add(```c
+                typedef signed long int64_t;
+                typedef unsigned long uint64_t;
+                typedef signed long ssize_t;
+                typedef unsigned long size_t;
+                ```);
+#if 0
+        // TODO support LLP64 (64-bit long long and pointers, but 32-bit long)
+        out.add(```c
+                typedef signed long long int64_t;
+                typedef unsigned long long uint64_t;
+                typedef signed long long ssize_t;
+                typedef unsigned long long size_t;
+                ```);
+#endif
+    }
+    out.add(C_defines);
 #if 1
     // __builtin_offsetof is supported by gcc and clang and is necessary
     // for -fsanitary=undefined to prevent null pointer arithmetics warnings.

--- a/test/types/conversion/integer_types.c2
+++ b/test/types/conversion/integer_types.c2
@@ -49,7 +49,7 @@ fn void test_i16(i16 a) {
     i16 s = a;
     i32 i = a;
     i64 l = a;
-    u8  m2 = a; // @error{implicit conversion changes signedness: 'i16' to 'u8'}
+    u8  m2 = a; // @error{implicit conversion loses integer precision: 'i16' to 'u8'}
     u16 s2 = a; // @error{implicit conversion changes signedness: 'i16' to 'u16'}
     u32 i2 = a; // @error{implicit conversion changes signedness: 'i16' to 'u32'}
     u64 l2 = a; // @error{implicit conversion changes signedness: 'i16' to 'u64'}
@@ -63,8 +63,8 @@ fn void test_i32(i32 a) {
     i16 s = a; // @error{implicit conversion loses integer precision: 'i32' to 'i16'}
     i32 i = a;
     i64 l = a;
-    u8  m2 = a; // @error{implicit conversion changes signedness: 'i32' to 'u8'}
-    u16 s2 = a; // @error{implicit conversion changes signedness: 'i32' to 'u16'}
+    u8  m2 = a; // @error{implicit conversion loses integer precision: 'i32' to 'u8'}
+    u16 s2 = a; // @error{implicit conversion loses integer precision: 'i32' to 'u16'}
     u32 i2 = a; // @error{implicit conversion changes signedness: 'i32' to 'u32'}
     u64 l2 = a; // @error{implicit conversion changes signedness: 'i32' to 'u64'}
     isize is = a;
@@ -77,9 +77,9 @@ fn void test_i64(i64 a) {
     i16 s = a;  // @error{implicit conversion loses integer precision: 'i64' to 'i16'}
     i32 i = a;  // @error{implicit conversion loses integer precision: 'i64' to 'i32'}
     i64 l = a;
-    u8  m2 = a; // @error{implicit conversion changes signedness: 'i64' to 'u8'}
-    u16 s2 = a; // @error{implicit conversion changes signedness: 'i64' to 'u16'}
-    u32 i2 = a; // @error{implicit conversion changes signedness: 'i64' to 'u32'}
+    u8  m2 = a; // @error{implicit conversion loses integer precision: 'i64' to 'u8'}
+    u16 s2 = a; // @error{implicit conversion loses integer precision: 'i64' to 'u16'}
+    u32 i2 = a; // @error{implicit conversion loses integer precision: 'i64' to 'u32'}
     u64 l2 = a; // @error{implicit conversion changes signedness: 'i64' to 'u64'}
     isize is = a;
     usize us = a; // @error{implicit conversion changes signedness: 'i64' to 'usize'}


### PR DESCRIPTION
* use `getBaseType` for conversion checks to convert ISize/USize to 32/64 bit
* fix conversion errors: signed types to smaller unsigned type is loss of integer precision rather than signedness change.
* fix C type generation for isize/usize