### PR TITLE
Generator: trim attribute output in C generator

### DIFF
--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -160,8 +160,7 @@ public fn void Buf.indent(Buf* buf, u32 indent) {
 }
 
 public fn bool Buf.endsWith(const Buf* buf, char c) {
-    if (buf.size_ && buf.data_[buf.size_-1] == c) return true;
-    return false;
+    return (buf.size_ && buf.data_[buf.size_-1] == c);
 }
 
 fn void Buf.resize(Buf* buf, u32 capacity) {
@@ -243,6 +242,10 @@ public fn void Buf.encodeHex(Buf* buf, const u8* data, u32 len) @(unused) {
     }
     *cp = 0;
     buf.size_ += len * 3 - 1;
+}
+
+public fn void Buf.trim(Buf* buf, u32 len) @(unused) {
+    buf.size_ = (buf.size_ >= len) ? buf.size_ - len : 0;
 }
 
 public fn void Buf.resetToLastNewline(Buf* buf) @(unused) {

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -758,43 +758,34 @@ fn void Generator.gen_func_proto(Generator* gen, FunctionDecl* fd, string_buffer
     VarDecl** params = fd.getParams();
     u32 num_params = fd.getNumParams();
 
-    bool has_attr = false;
     const char* section = d.getSection();
     if (section) {
-        has_attr = true;
         gen.emitSectionAttr(out, section);
         out.space();
     }
     if (fd.hasAttrInline()) {
-        if (has_attr) out.space();
         // Note: inline functions are always static
         //out.add("__inline__ ");
         out.add("static inline ");
-        has_attr = true;
     }
     if (fd.hasAttrWeak()) {
-        //if (has_attr) out.space();
         out.add("__attribute__((weak)) ");
-        has_attr = true;
     }
     if (fd.hasAttrConstructor()) {
-        //if (has_attr) out.space();
         out.add("__attribute__((constructor)) ");
-        has_attr = true;
     }
     if (fd.hasAttrDestructor()) {
-        //if (has_attr) out.space();
         out.add("__attribute__((destructor)) ");
-        has_attr = true;
     }
 
     u8 printf_arg = fd.getAttrPrintf();
     if (printf_arg) {
-        //if (has_attr) out.space();
         out.print("__attribute__((__format__(printf, %d, %d))) ", printf_arg, num_params +1);
-        has_attr = true;
     }
-    if (has_attr) out.newline();
+    if (out.endsWith(' ')) {
+        out.trim(1);
+        out.newline();
+    }
 
     if (d == gen.mainFunc) {
         out.add("int32_t main");


### PR DESCRIPTION
* add `string-buffer.Buf.trim(len)`
* remove trailing space on attribute line in C output