### PR TITLE
C-generator: use native C types in C backend for c_xxx types

### DIFF
--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -300,6 +300,8 @@ fn void Compiler.build(Compiler* c,
     if (opts.msan) c.addFeature("__MSAN__", "1");
     if (opts.ubsan) c.addFeature("__UBSAN__", "1");
 
+    c.addFeature("USE_NATIVE_CTYPES", "1");
+
     target.addLib(c.auxPool.add("c2", 2, true), false);
 
     c.parser = c2_parser.create(sm,

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -455,7 +455,39 @@ fn void Generator.emitFunctionType(Generator* gen, string_buffer.Buf* out, Decl*
     out.add(";\n\n");
 }
 
+fn bool match_type(const char* s, const char* list, const char** sp) {
+    while (*list) {
+        usize len;
+        for (len = 0; list[len] && list[len] != ','; len++)
+            continue;
+        usize i;
+        for (i = 0; i < len && s[i] == list[i]; i++)
+            continue;
+        if (i == len && (s[i] == '\0' || s[i] == ' ')) {
+            *sp = s + i;
+            return true;
+        }
+        list += len;
+        list += (*list == ',');
+    }
+    return false;
+}
+
+fn bool is_c_type(const char* s) {
+    for (;;) {
+        while (*s == ' ') s++;
+        if (!*s) return true;
+        if (!match_type(s, "const,volatile,unsigned,signed,short,long,"
+                        "_Bool,char,int,float,double,size_t,ssize_t", &s))
+            break;
+    }
+    return false;
+}
+
 fn void Generator.emitAliasType(Generator* gen, string_buffer.Buf* out, Decl* d) {
+    const char* cname = d.getCName();
+    if (cname && is_c_type(cname))
+        return;
     // For now, just generate canonicalType as RHS
     QualType qt = d.getType();
     qt = qt.getCanonicalType(); // just generate final type
@@ -464,7 +496,7 @@ fn void Generator.emitAliasType(Generator* gen, string_buffer.Buf* out, Decl* d)
     gen.emitTypePost(out, qt);
     out.space();
     gen.emitCName(out, d);
-    out.add(";\n\n");
+    out.add(";\n");
 }
 
 fn bool emitAsDefine(const VarDecl* vd) {
@@ -1357,7 +1389,6 @@ const char[] Include_guard1 =
 const char[] C_types =
     ```c
     // --- internally added ---
-    typedef unsigned char bool;
     typedef signed char int8_t;
     typedef unsigned char uint8_t;
     typedef signed short int16_t;

--- a/libs/c2/c2.c2i
+++ b/libs/c2/c2.c2i
@@ -1,5 +1,28 @@
 module c2;
 
+#if USE_NATIVE_CTYPES
+type c_char char @(cname="char");
+type c_uchar u8 @(cname="unsigned char");
+type c_short i16 @(cname="short");
+type c_ushort u16 @(cname="unsigned short");
+type c_int i32 @(cname="int");
+type c_uint u32 @(cname="unsigned int");
+type c_longlong i64 @(cname="long long");
+type c_ulonglong u64 @(cname="unsigned long long");
+type c_float f32 @(cname="float");
+type c_double f64 @(cname="double");
+#if ARCH_32BIT
+type c_long i32 @(cname="long");
+type c_ulong u32 @(cname="unsigned long");
+type c_size u32 @(cname="size_t");
+type c_ssize i32 @(cname="ssize_t");
+#else
+type c_long i64 @(cname="long");
+type c_ulong u64 @(cname="unsigned long");
+type c_size u64 @(cname="size_t");
+type c_ssize i64 @(cname="ssize_t");
+#endif
+#else  // compiling the compiler from bootstrap code
 type c_char char;
 type c_uchar u8;
 type c_short i16;
@@ -20,6 +43,7 @@ type c_long i64;
 type c_ulong u64;
 type c_size u64;
 type c_ssize i64;
+#endif
 #endif
 
 const i8 min_i8 = -128;


### PR DESCRIPTION
* prevent output of type aliases that have a cname attribute that is a native C type
* update libs/c2/c2.c2i so native C types get output as themselves