### PR TITLE
File-utils: add path APIs, add File object, remove Reader/Writer

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -37,7 +37,6 @@ import incr_array_list as ia_list;
 import ctype;
 import stdarg local;
 import stdlib;
-import string;
 
 const u32 MaxDepth = 8;
 const u32 LHS = 0x01;
@@ -592,20 +591,18 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
 
         // open file, copy contents to StringPool and close
         const char* filename = ma.astPool.idx2str(embed.text);
-        file_utils.Reader reader;
-        if (!reader.open(filename)) {
-            ma.error(embed.loc, "error opening embedded file '%s': %s", filename, string.strerror(reader.error));
+        file_utils.File reader.init("", filename);
+        if (!reader.load()) {
+            ma.error(embed.loc, "error opening embedded file '%s': %s", filename, reader.getError());
             return;
         }
 
-        u32 src_len = reader.size;
-        u32 len = reader.size;
-        //TODO check input for weird chars if string
-        u32 value = ma.astPool.add(reader.data(), reader.size, false);
-        if (!is_char) {
-            src_len--;
-            len--;
-        }
+        //TODO: attribute should have source length
+        u32 src_len = 8; // source length is attribute @(embed="xxx")
+        u32 len = reader.data_size();
+        //TODO: check input for weird chars if string
+        u32 value = ma.astPool.add(reader.data(), len, false);
+        if (!is_char) len--;
         Expr* init = ma.builder.actOnStringLiteral(embed.loc, src_len, value, len);
 
         // Note: VarDecl already needed to allocate extra space during creation! (parser checks embed attr for this)

--- a/ast_utils/constants.c2
+++ b/ast_utils/constants.c2
@@ -27,16 +27,8 @@ public const u32 MaxMultiString = 64*1024;
 public const u32 MaxMultiDeclBits = 4;
 public const u32 MaxMultiDecl = (1 << MaxMultiDeclBits) - 1;
 
-public const u32 Max_path = 512;
-
 public const char* output_dir = "output";
-
 public const char* recipe_name = "recipe.txt";
-
 public const char* buildfile_name = "build.yaml";
-
 public const char* manifest_name = "manifest.yaml";
-
 public const char* refs_filename = "refs";
-
-

--- a/common/file/file_utils.c2
+++ b/common/file/file_utils.c2
@@ -16,13 +16,110 @@
 module file_utils;
 
 import c_errno local;
+import stdlib local;
+import string local;
 import sys_stat local;
 
+public const u32 Max_path = 512;
+
+public fn const char* get_basename(const char* s) {
+    const char* base = s;
+    while (*s) {
+        if (*s++ == '/') base = s;
+    }
+    return base;
+}
+
+public fn const char* get_extension(const char* s) {
+    const char* ext = nil;
+    for (; *s; s++) {
+        if (*s == '/') ext = nil;
+        if (*s == '.') ext = s;
+    }
+    return ext ? ext : s;
+}
+
+// Copy a string with truncation
+// return the length of the string if shorter than size
+// otherwise truncate the string and return size
+// compare the return value with size to detect truncation
+fn usize pstrcpy(char *dest, usize size, const char* src) {
+    usize i;
+    for (i = 0; i < size; i++) {
+        if ((dest[i] = src[i]) == '\0') return i;
+    }
+    if (size) dest[size - 1] = '\0';
+    return size;
+}
+
+// Copy a directory name with truncation and append a / if not empty
+fn usize copy_dirname(char *buf, usize size, const char* dir) {
+    usize pos = pstrcpy(buf, size, dir);
+    if (pos && pos < size && dir[pos - 1] != '/') {
+        if (pos + 1 < size) {
+            buf[pos] = '/';
+            buf[pos + 1] = '\0';
+        }
+        pos += 1;
+    }
+    return pos;
+}
+
+// construct a path in a buffer from a directory name and a filename
+// if the path fits in the destination array, a pointer to it is returned.
+// otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
+public fn const char* make_path(char *buf, usize size, const char* dir, const char* filename) {
+    usize pos = 0;
+    if (*filename != '/') pos = copy_dirname(buf, size, dir);
+    if (pos < size) {
+        pos += pstrcpy(buf + pos, size - pos, filename);
+        if (pos < size) return buf;
+    }
+    errno = ENAMETOOLONG;
+    return nil;
+}
+
+// construct a path in a buffer from a directory name, a filename and an extension
+// if the path fits in the destination array, a pointer to it is returned.
+// otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
+public fn const char* make_path_ext(char *buf, usize size, const char* dir, const char* filename, const char* ext) {
+    usize pos = 0;
+    if (*filename != '/') pos = copy_dirname(buf, size, dir);
+    if (pos < size) {
+        pos += pstrcpy(buf + pos, size - pos, filename);
+        if (pos < size) {
+            pos += pstrcpy(buf + pos, size - pos, ext);
+            if (pos < size) return buf;
+        }
+    }
+    errno = ENAMETOOLONG;
+    return nil;
+}
+
+// construct a path in a buffer from a directory name, a subdirectory name and an extension
+// if the path fits in the destination array, a pointer to it is returned.
+// otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
+public fn const char* make_path3(char *buf, usize size, const char* dir, const char* subdir, const char* filename) {
+    usize pos = 0;
+    if (*filename != '/') {
+        if (*subdir != '/') pos = copy_dirname(buf, size, dir);
+        if (pos < size) pos += copy_dirname(buf + pos, size - pos, subdir);
+    }
+    if (pos < size) {
+        pos += pstrcpy(buf + pos, size - pos, filename);
+        if (pos < size) return buf;
+    }
+    errno = ENAMETOOLONG;
+    return nil;
+}
+
 // returns 0 on success, errno on failure
-public fn i32 create_directory(const char* path) {
-    char[512] tmp;
+// create a directory path, OK if exists already
+public fn i32 create_path(const char* path) {
+    char[file_utils.Max_path] tmp;
     char *p = tmp;
-    if (*path == '/') *p++ = *path++;
+    if (!*path) return 0;
+    *p++ = *path++;
     for (;;) {
         char c = *path++;
         // ignore duplicate and trailing slashes
@@ -36,15 +133,86 @@ public fn i32 create_directory(const char* path) {
                 break;
         }
         if (p > &tmp[elemsof(tmp) - 2])
-            return ENAMETOOLONG;
+            return errno = ENAMETOOLONG;
         *p++ = c;
     }
     return 0;
 }
 
-public fn bool exists(const char* filename) {
+public fn bool path_exists(const char* path) {
     Stat statbuf;
-    // TODO also check regular file
-    return (stat(filename, &statbuf) == 0);
+    return !stat(path, &statbuf);
 }
 
+public fn bool is_file(const char* filename) @(unused) {
+    Stat statbuf;
+    return !stat(filename, &statbuf) && (statbuf.st_mode & S_IFMT) == S_IFREG;
+}
+
+public fn bool is_dir(const char* dirname) @(unused) {
+    Stat statbuf;
+    return !stat(dirname, &statbuf) && (statbuf.st_mode & S_IFMT) == S_IFDIR;
+}
+
+public type File struct @(unused) {
+    char[Max_path] path;
+    i32 handle;  // 0:none, otherwise unix handle +1
+    i32 error;
+    u32 contents_size;
+    void* contents;
+}
+
+public fn bool File.init(File* file, const char* dir, const char* filename) {
+    file.handle = 0;
+    file.error = 0;
+    file.contents_size = 0;
+    file.contents = nil;
+    if (!make_path(file.path, elemsof(file.path), dir, filename)) {
+        file.error = ENAMETOOLONG;
+        return false;
+    }
+    return true;
+}
+
+public fn bool File.init_ext(File* file, const char* dir, const char* filename, const char* ext) @(unused) {
+    if (!file.init(dir, filename)) return false;
+    u32 len = (u32)strlen(file.path);
+    len += pstrcpy(file.path + len, elemsof(file.path) - len, ext);
+    if (len >= elemsof(file.path)) {
+        file.error = ENAMETOOLONG;
+        return false;
+    }
+    return true;
+}
+
+public fn void File.close(File* file) @(unused) {
+    if (file.contents) {
+        stdlib.free(file.contents);
+        file.contents = nil;
+    }
+}
+
+public fn bool File.exists(File *file) @(unused) {
+    return path_exists(file.path);
+}
+
+const i32 Err_not_a_file = 2001;
+const i32 Err_read_error = 2002;
+const i32 Err_too_large = 2003;
+const i32 Err_write_error = 2004;
+
+public fn const char* File.getError(File* file) @(unused) {
+    switch (file.error) {
+    case Err_not_a_file:
+        return "not a regular file";
+    case Err_read_error:
+        return "read error";
+    case Err_write_error:
+        return "write error";
+    case Err_too_large:
+        return "file too large";
+    default:
+        break;
+    }
+    return strerror(file.error);
+}

--- a/common/file/reader.c2
+++ b/common/file/reader.c2
@@ -20,19 +20,6 @@ import c_errno local;
 import sys_stat local;
 import unistd local;
 import stdlib;
-import string local;
-
-u8 empty;
-
-const i32 Err_not_a_file = 2001;
-const i32 Err_read_error = 2002;
-const i32 Err_too_large = 2003;
-
-public type Reader struct {
-    u8* region;
-    u32 size;
-    i32 error;
-}
 
 fn isize read2(i32 hd, void* data, usize len) {
     u8* p = data;
@@ -51,17 +38,20 @@ fn isize read2(i32 hd, void* data, usize len) {
     return total_read;
 }
 
-public fn bool Reader.open(Reader* file, const char* filename) {
-    file.region = nil;
-    file.size = 0;
-    file.error = 0;
-
-    i32 fd = open(filename, O_RDONLY | O_BINARY);
-    if (fd == -1) {
+public fn bool File.load(File* file) {
+    if (file.error) return false;
+    file.contents_size = 0;
+    if (file.contents) {
+        stdlib.free(file.contents);
+        file.contents = nil;
+    }
+    i32 fd = open(file.path, O_RDONLY | O_BINARY);
+    if (fd < 0) {
         file.error = errno;
         return false;
     }
 
+    // TODO: handle files whose size cannot be determined
     Stat statbuf;
     if (fstat(fd, &statbuf)) {
         file.error = errno;
@@ -82,74 +72,52 @@ public fn bool Reader.open(Reader* file, const char* filename) {
         return false;
     }
 
-    u8* region = stdlib.malloc(size + 1);
-    i64 numread = read2(fd, region, size);
+    u8* region = stdlib.malloc((usize)size + 1);
+    if (!region) {
+        file.error = ENOMEM;
+        close(fd);
+        return false;
+    }
+    isize numread = read2(fd, region, size);
     if (numread < 0) {
         file.error = errno;
         stdlib.free(region);
         close(fd);
         return false;
     }
-    if (numread != size) {
+    if ((usize)numread != size) {
         file.error = Err_read_error;
         stdlib.free(region);
         close(fd);
         return false;
     }
     region[size] = '\0';
-    file.region = region;
-    file.size = size;
+    file.contents = region;
+    file.contents_size = size;
     close(fd);
     return true;
 }
 
-public fn void Reader.close(Reader* file) {
-    if (file.size) {
-        stdlib.free(file.region);
-        file.region = nil;
-        file.size = 0;
-    }
+public fn bool File.isOpen(const File* file) @(unused) {
+    return file.contents != nil;
 }
 
-public fn bool Reader.isOpen(const Reader* file) @(unused) {
-    return file.region != nil;
+public fn const void* File.data(File* file) @(unused) {
+    return file.contents;
 }
 
-public fn const u8* Reader.udata(Reader* file) @(unused) {
-    return file.region;
+public fn u32 File.data_size(File* file) @(unused) {
+    return file.contents_size;
 }
 
-public fn const char* Reader.data(Reader* file) @(unused) {
-    return cast<const char*>(file.region);
+public fn bool File.isEmpty(const File* file) @(unused) {
+    return file.contents_size == 0;
 }
 
-public fn bool Reader.isEmpty(const Reader* file) @(unused) {
-    return file.size == 0;
-}
-
-public fn const char* Reader.getError(const Reader* file) @(unused) {
-    const char *msg;
-    switch (file.error) {
-    case Err_not_a_file:
-        msg = "not a regular file";
-        break;
-    case Err_read_error:
-        msg = "read error";
-        break;
-    case Err_too_large:
-        msg = "file too large";
-        break;
-    default:
-        msg = strerror(file.error);
-        break;
-    }
-    return msg;
-}
-
-public fn void* Reader.detach(Reader* file, u32 *psize) {
-    void* data = file.region;
-    *psize = file.size;
-    file.region = nil;
-    file.size = 0;
+public fn void* File.detach(File* file, u32 *psize) @(unused) {
+    void* data = file.contents;
+    *psize = file.contents_size;
+    file.contents = nil;
+    file.contents_size = 0;
     return data;
 }

--- a/common/file/writer.c2
+++ b/common/file/writer.c2
@@ -17,14 +17,7 @@ module file_utils;
 
 import libc_fcntl local;
 import c_errno local;
-import string local;
 import unistd local;
-
-const i32 Err_write_error = 2003;
-
-public type Writer struct {
-    i32 error;
-}
 
 fn isize write2(i32 hd, const void* data, usize len) {
     const u8* p = data;
@@ -43,23 +36,25 @@ fn isize write2(i32 hd, const void* data, usize len) {
     return total_written;
 }
 
-public fn bool Writer.write(Writer* writer, const char* filename, const void* data, u32 len) {
-    writer.error = 0;
+public fn bool File.write(File* file, const void* data, usize len) {
+    if (file.error) return false;
 
-    i32 fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0660);
-    if (fd == -1) {
-        writer.error = errno;
+    i32 fd = open(file.path, O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0660);
+    if (fd < 0) {
+        file.error = errno;
         return false;
     }
 
-    i64 written = write2(fd, data, len);
+    isize written = write2(fd, data, len);
     if (written < 0) {
-        writer.error = errno;
+        file.error = errno;
         close(fd);
         return false;
     }
-    if (written != len) {
-        writer.error = Err_write_error;
+
+    // TODO: store number of bytes written to file?
+    if ((usize)written != len) {
+        file.error = Err_write_error;
         close(fd);
         return false;
     }
@@ -67,17 +62,3 @@ public fn bool Writer.write(Writer* writer, const char* filename, const void* da
     close(fd);
     return true;
 }
-
-public fn const char* Writer.getError(const Writer* file) @(unused) {
-    const char *msg;
-    switch (file.error) {
-    case Err_write_error:
-        msg = "write error";
-        break;
-    default:
-        msg = strerror(file.error);
-        break;
-    }
-    return msg;
-}
-

--- a/common/manifest_writer.c2
+++ b/common/manifest_writer.c2
@@ -18,12 +18,10 @@ module manifest_writer;
 import ast;
 import component;
 import console;
-import constants;
 import file_utils;
 import string_buffer;
 import string_list;
 
-import stdio;
 import stdlib local;
 
 fn const char* getKindStr(const component.Component* c) {
@@ -79,11 +77,9 @@ public fn void write(const char* dir, component.Component* c, const char* filena
     out.add("modules:\n");
     c.visitModules(on_module, out);
 
-    char[constants.Max_path] fullname;
-    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", dir, filename);
-    file_utils.Writer writer;
-    if (!writer.write(fullname, out.data(), out.size())) {
-        console.error("cannot write to %s: %s", fullname, writer.getError());
+    file_utils.File file.init(dir, filename);
+    if (!file.write(out.data(), out.size())) {
+        console.error("cannot write to %s: %s", file.path, file.getError());
         exit(EXIT_FAILURE);
     }
     out.free();

--- a/common/process_utils.c2
+++ b/common/process_utils.c2
@@ -15,6 +15,8 @@
 
 module process_utils;
 
+import file_utils;
+
 import ctype local;
 import string local;
 import stdarg local;
@@ -96,8 +98,8 @@ public fn i32 run_args(const char* path, const char* cmd, const char* args, cons
         close(error_pipe[0]);
 
         // redirect output to logfile
-        char[512] filename;
-        snprintf(filename, elemsof(filename), "%s%s", path, logfile);
+        char[file_utils.Max_path] filename;
+        file_utils.make_path(filename, elemsof(filename), path, logfile);
         close(STDOUT_FILENO);
         i32 fdout = open(filename, O_TRUNC | O_CREAT | O_WRONLY, 0644);
         if (fdout == -1) {
@@ -122,7 +124,7 @@ public fn i32 run_args(const char* path, const char* cmd, const char* args, cons
             printf("changing to dir: %s\n", path);
         }
 
-        char[512] self;
+        char[file_utils.Max_path] self;
         if (!find_bin(self, elemsof(self), cmd)) {
             child_error(error_pipe[1], "command not found: %s", cmd);
         }
@@ -148,14 +150,13 @@ public fn i32 run_args(const char* path, const char* cmd, const char* args, cons
         // close the writing end of the error pipe
         close(error_pipe[1]);
         char[256] error;
-        memset(error, 0, sizeof(error));
         isize numread = read(error_pipe[0], error, sizeof(error)-1);
         if (numread < 0) {
             fprintf(stderr, "Error reading pipe\n");
             close(error_pipe[0]);
             return -1;
         }
-        error[numread] = 0;
+        error[numread] = '\0';
         close(error_pipe[0]);
 
         if (numread != 0) {
@@ -296,7 +297,7 @@ public fn i32 run2(const char* path, const char* cmd, const char* args, char* ou
             }
         }
 
-        char[512] self;
+        char[file_utils.Max_path] self;
         if (!find_bin(self, elemsof(self), cmd)) {
             child_error(error_pipe[1], "command not found: %s", cmd);
         }
@@ -320,7 +321,6 @@ public fn i32 run2(const char* path, const char* cmd, const char* args, char* ou
         close(error_pipe[1]);
         close(output_pipe[1]);
         char[256] error;
-        memset(error, 0, sizeof(error));
         isize numread = read(error_pipe[0], error, sizeof(error)-1);
         if (numread < 0) {
             fprintf(stderr, "Error reading pipe\n");
@@ -328,7 +328,7 @@ public fn i32 run2(const char* path, const char* cmd, const char* args, char* ou
             close(output_pipe[0]);
             return -1;
         }
-        error[numread] = 0;
+        error[numread] = '\0';
         close(error_pipe[0]);
 
         if (numread != 0) {

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -162,8 +162,8 @@ public fn void SourceMgr.clear(SourceMgr* sm, i32 handle) {
 
 fn void* SourceMgr.loadFile(SourceMgr* sm, u32 name, SrcLoc loc, u32* psize) {
     const char* filename = sm.pool.idx2str(name);
-    file_utils.Reader file;
-    if (file.open(filename)) return file.detach(psize);
+    file_utils.File file.init("", filename);
+    if (file.load()) return file.detach(psize);
 
     // TODO only color if enabled (cannot use console since we need source loc first)
     if (loc) {

--- a/common/string_utils.c2
+++ b/common/string_utils.c2
@@ -51,20 +51,3 @@ public fn bool endsWith(const char* text, const char* tail) @(unused) {
     usize tlen = strlen(tail);
     return (tlen <= len && !memcmp(text + len - tlen, tail, tlen));
 }
-
-public fn const char* getBasename(const char* s) {
-    const char* base = s;
-    while (*s) {
-        if (*s++ == '/') base = s;
-    }
-    return base;
-}
-
-public fn const char* getExtension(const char* s) {
-    const char* ext = nil;
-    for (; *s; s++) {
-        if (*s == '/') ext = nil;
-        if (*s == '.') ext = s;
-    }
-    return ext ? ext : s;
-}

--- a/common/utils.c2
+++ b/common/utils.c2
@@ -16,6 +16,7 @@
 module utils;
 
 import constants;
+import file_utils;
 
 import c_errno local;
 import stdio local;
@@ -34,8 +35,8 @@ public fn u64 now() @(unused) {
 }
 
 public type PathInfo struct {
-    char[constants.Max_path] orig2root; // subdir/subdir/
-    char[constants.Max_path] root2orig; // ../../
+    char[file_utils.Max_path] orig2root; // subdir/subdir/
+    char[file_utils.Max_path] root2orig; // ../../
 }
 
 public fn bool PathInfo.hasSubdir(const PathInfo* pi) {
@@ -48,14 +49,14 @@ public fn bool findProjectDir(PathInfo* info) {
         info.root2orig[0] = 0;
         info.orig2root[0] = 0;
     }
-    char[constants.Max_path] base_path;
-    char[constants.Max_path] rel_path;
+    char[file_utils.Max_path] base_path;
+    char[file_utils.Max_path] rel_path;
     base_path[0] = 0;
     rel_path[0] = 0;
 
-    char[constants.Max_path] buffer;
+    char[file_utils.Max_path] buffer;
     while (1) {
-        char* path = unistd.getcwd(buffer, constants.Max_path);
+        char* path = unistd.getcwd(buffer, elemsof(buffer));
         if (path == nil) {
             perror("getcwd");
             return false;
@@ -63,8 +64,7 @@ public fn bool findProjectDir(PathInfo* info) {
         if (base_path[0] == 0) strcpy(base_path, path);
 
         Stat buf;
-        i32 error = stat(constants.recipe_name, &buf);
-        if (error) {
+        if (stat(constants.recipe_name, &buf)) {
             if (path[0] == '/' && path[1] == '\0') return false;
             if (errno != ENOENT) {
                 perror("stat");
@@ -82,8 +82,7 @@ public fn bool findProjectDir(PathInfo* info) {
                 return true;
             }
         }
-        error = unistd.chdir("..");
-        if (error) {
+        if (unistd.chdir("..")) {
             perror("chdir");
             return false;
         }

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -45,6 +45,7 @@ import unused_checker;
 import utils;
 import warning_flags;
 
+import c_errno local;
 import ctype;
 import string;
 import stdlib;
@@ -350,10 +351,9 @@ fn void Compiler.build(Compiler* c,
     string.strcpy(info.target_name, c.auxPool.idx2str(target.getNameIdx()));
 
     // create output directory
-    stdio.sprintf(info.output_dir, "%s/%s", output_base, c.auxPool.idx2str(target.getNameIdx()));
-    i32 err = file_utils.create_directory(info.output_dir);
-    if (err) {
-        console.error("cannot create directory %s", info.output_dir);
+    if (!file_utils.make_path(info.output_dir, elemsof(info.output_dir), output_base, c.auxPool.idx2str(target.getNameIdx()))
+    ||  file_utils.create_path(info.output_dir)) {
+        console.error("cannot create directory %s: %s", info.output_dir, string.strerror(errno));
         stdlib.exit(-1);
     }
 

--- a/compiler/compiler_libs.c2
+++ b/compiler/compiler_libs.c2
@@ -21,6 +21,7 @@ import component local;
 import component_sorter;
 import console;
 import constants;
+import file_utils;
 import manifest;
 import module_list;
 import module_sorter;
@@ -34,7 +35,6 @@ import libc_dirent local;
 import stdio;
 import stdlib;
 import string;
-import sys_stat local;
 
 fn void Compiler.createComponent(Compiler* c, u32 name, bool is_direct, bool is_static) {
     Kind kind = is_static ? Kind.ExternalStatic : Kind.ExternalDynamic;
@@ -89,14 +89,14 @@ fn void Compiler.open_lib(Compiler* c, Component* comp) {
     const char* libstr = comp.getName();
 
     console.debug("opening lib %s", libstr);
-    char[512] libdir;
-    if (!c.find_lib(libstr, libdir)) {
+    char[file_utils.Max_path] libdir;
+    if (!c.find_lib(libstr, libdir, elemsof(libdir))) {
         console.error("cannot find library '%s'", libstr);
         stdlib.exit(-1);
     }
 
-    char[512] fullname;
-    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", libdir, constants.manifest_name);
+    char[file_utils.Max_path] fullname;
+    if (!file_utils.make_path(fullname, elemsof(fullname), libdir, constants.manifest_name)) return;
     u32 filename_idx = c.auxPool.addStr(fullname, false);
     i32 file_id = c.sm.open(filename_idx, 0, false);
     if (file_id == -1) return;
@@ -150,16 +150,14 @@ fn bool Compiler.has_component(Compiler* c, u32 name) {
     return false;
 }
 
-fn bool Compiler.find_lib(const Compiler* c, const char* libname, char* fullpath) {
+fn bool Compiler.find_lib(const Compiler* c, const char* libname, char* libdir, usize size) {
     for (u32 i=0; i<c.libdirs.length(); i++) {
         const char* dirname = c.libdirs.get(i);
-        stdio.sprintf(fullpath, "%s/%s/%s", dirname, libname, constants.manifest_name);
-
-        Stat statbuf;
-        i32 err = stat(fullpath, &statbuf);
-        if (!err) {
-            stdio.sprintf(fullpath, "%s/%s", dirname, libname);
-            return true;
+        if (file_utils.make_path(libdir, size, dirname, libname)) {
+            char[file_utils.Max_path] path;
+            if (file_utils.make_path(path, elemsof(path), libdir, constants.manifest_name)
+            &&  file_utils.is_file(path))
+                return true;
         }
     }
     return false;
@@ -169,15 +167,16 @@ fn void Compiler.parseExternalModule(void* arg, ast.Module* m) {
     Compiler* c = arg;
     if (!m.isUsed()) return;
 
-    char[512] filename;
-    i32 len = stdio.sprintf(filename, "%s/%s.c2i", c.current.getPath(), m.getName());
-    u32 name = c.auxPool.add(filename, cast<usize>(len), false);
+    char[file_utils.Max_path] filename;
+    if (!file_utils.make_path_ext(filename, elemsof(filename), c.current.getPath(), m.getName(), ".c2i"))
+        return;
 
+    u32 name = c.auxPool.addStr(filename, false);
     i32 file_id = c.sm.open(name, 0, false);
     if (file_id == -1) return;   // note: error already printed
 
     m.setLoaded();
-    console.debug("parsing %s", c.sm.getFileName(file_id));
+    console.debug("parsing %s", filename);
     // on parse error, c.parser state has already been updated
     c.parser.parse(file_id, true, false);
 
@@ -243,18 +242,15 @@ fn void Compiler.showLibs(Compiler* c, string_buffer.Buf* out, const char* dirna
         return;
     }
 
-    char[512] fullname;
     while (Dirent* entry = readdir(dir)) {
+        char[file_utils.Max_path] fullname;
         const char* name = entry.d_name;
         if (name[0] != '.' && entry.d_type == DT_DIR) {
-            i32 len = stdio.snprintf(fullname, elemsof(fullname), "%s/%s/%s", dirname, name, constants.manifest_name);
-            if (len >= elemsof(fullname)) continue;
+            if (!file_utils.make_path3(fullname, elemsof(fullname), dirname, name, constants.manifest_name)
+            ||  !file_utils.is_file(fullname))
+                continue;
 
-            Stat statbuf;
-            i32 err = stat(fullname, &statbuf);
-            if (err) continue;
-
-            u32 filename_idx = c.auxPool.add(fullname, cast<usize>(len), false);
+            u32 filename_idx = c.auxPool.addStr(fullname, false);
 
             out.indent(2);
             out.print("%-12s", name);

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -70,16 +70,16 @@ fn void Options.free(Options *opts) {
 }
 
 fn void write_file_or_die(const char* filename, string_buffer.Buf* buf) {
-    file_utils.Writer writer;
-    if (!writer.write(filename, buf.udata(), buf.size())) {
-        console.error("c2c: cannot write to %s: %s", filename, writer.getError());
+    file_utils.File file.init("", filename);
+    if (!file.write(buf.udata(), buf.size())) {
+        console.error("c2c: cannot write to %s: %s", file.path, file.getError());
         exit(EXIT_FAILURE);
     }
 }
 
 fn void create_project(const char* name) {
 
-    if (file_utils.exists("main.c2") || file_utils.exists("recipe.txt")) {
+    if (file_utils.path_exists("main.c2") || file_utils.path_exists("recipe.txt")) {
         console.error("c2c: main.c2 and/or recipe.txt already exist");
         exit(EXIT_FAILURE);
     }
@@ -446,8 +446,8 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
 
     if (c.opts.files.length()) {
         // use basename of first filename as target name
-        const char* basename = string_utils.getBasename(c.opts.files.get(0));
-        const char* ext = string_utils.getExtension(basename);
+        const char* basename = file_utils.get_basename(c.opts.files.get(0));
+        const char* ext = file_utils.get_extension(basename);
         u32 target_idx = c.auxPool.add(basename, cast<u32>(ext - basename), true);
         build_target.BackEndKind backend = build_target.BackEndKind.C;
         if (c.opts.use_ir_backend) backend = build_target.BackEndKind.IR;

--- a/compiler/plugin_mgr.c2
+++ b/compiler/plugin_mgr.c2
@@ -23,7 +23,6 @@ import string_pool;
 import string_utils;
 
 import c_errno local;
-import constants;
 import dlfcn local;
 import libc_dirent local;
 import stdio;
@@ -121,14 +120,11 @@ public fn void Mgr.show(const Mgr* m) {
             console.warn("cannot read '%s': %s", path, strerror(errno));
             continue;
         }
-        Dirent* entry = readdir(dir);
-        while (entry != nil) {
+        while (Dirent* entry = readdir(dir)) {
             if (is_plugin(entry)) {
                 console.log("  %s/%s", path, entry.d_name);
             }
-            entry = readdir(dir);
         }
-
         closedir(dir);
     }
 }
@@ -148,12 +144,11 @@ fn bool Mgr.loadPlugin(Mgr* m, u32 name, u32 options, bool is_global) {
     const char* name_str = m.auxPool.idx2str(name);
 
     char[128] filename;
-    stdio.sprintf(filename, "lib%s%s", name_str, lib_ext);
+    stdio.snprintf(filename, elemsof(filename), "lib%s%s", name_str, lib_ext);
 
-    char[constants.Max_path] fullname; // TODO use string_buffer?
-
-    if (!m.find_file(fullname, filename)) {
-        stdio.sprintf(m.error_msg, "cannot find plugin %s", name_str);
+    char[file_utils.Max_path] fullname;
+    if (!m.find_file(fullname, elemsof(fullname), filename)) {
+        stdio.snprintf(m.error_msg, elemsof(m.error_msg), "cannot find plugin %s (%s)", name_str, filename);
         return false;
     }
 
@@ -163,13 +158,13 @@ fn bool Mgr.loadPlugin(Mgr* m, u32 name, u32 options, bool is_global) {
     p.is_active = true;
     p.handle = dlopen(fullname, RTLD_NOW | RTLD_LOCAL);
     if (p.handle == nil) {
-        stdio.sprintf(m.error_msg, "cannot load plugin: %s", dlerror());
+        stdio.snprintf(m.error_msg, elemsof(m.error_msg), "cannot load plugin %s: %s", fullname, dlerror());
         return false;
     }
 
     void* handle_symbol = dlsym(p.handle, "plugin_main_handle");
     if (!handle_symbol) {
-        stdio.sprintf(m.error_msg, "invalid plugin %s: %s", fullname, dlerror());
+        stdio.snprintf(m.error_msg, elemsof(m.error_msg), "invalid plugin %s: %s", fullname, dlerror());
         dlclose(p.handle);
         return false;
     }
@@ -178,7 +173,7 @@ fn bool Mgr.loadPlugin(Mgr* m, u32 name, u32 options, bool is_global) {
     p.arg = p.functions.load(m.auxPool.idx2str(options), m.console_timing, m.console_debug);
     if (!p.arg) {
         dlclose(p.handle);
-        stdio.sprintf(m.error_msg, "plugin failed to load");
+        stdio.snprintf(m.error_msg, elemsof(m.error_msg), "plugin %s failed to load", fullname);
         return false;
     }
 
@@ -196,11 +191,11 @@ public fn bool Mgr.loadLocal(Mgr* m, u32 name, u32 options) {
 }
 
 
-fn bool Mgr.find_file(Mgr* m, char* fullname, const char* filename) {
+fn bool Mgr.find_file(Mgr* m, char* fullname, usize size, const char* filename) {
     for (u32 i=0; i<m.paths.length(); i++) {
-        const char* path = m.paths.get(i);
-        stdio.sprintf(fullname, "%s/%s", path, filename);
-        if (file_utils.exists(fullname)) return true;
+        if (file_utils.make_path(fullname, size, m.paths.get(i), filename)
+        &&  file_utils.is_file(fullname))
+            return true;
     }
     return false;
 }

--- a/generator/c/c2i_generator.c2
+++ b/generator/c/c2i_generator.c2
@@ -16,13 +16,10 @@
 module c2i_generator;
 
 import ast local;
-import constants;
 import console;
 import file_utils;
 import string_buffer;
 import string_list;
-
-import stdio;
 
 type Generator struct {
     string_buffer.Buf* out;
@@ -57,11 +54,9 @@ public fn void generate(const char* output_dir,
 }
 
 fn void Generator.write(Generator* gen, const char* output_dir) {
-    char[constants.Max_path] fullname;
-    stdio.snprintf(fullname, elemsof(fullname), "%s/%s.c2i", output_dir, gen.mod.getName());
-    file_utils.Writer writer;
-    if (!writer.write(fullname, gen.out.udata(), gen.out.size())) {
-        console.error("cannot write to %s: %s", fullname, writer.getError());
+    file_utils.File file.init_ext(output_dir, gen.mod.getName(), ".c2i");
+    if (!file.write(gen.out.udata(), gen.out.size())) {
+        console.error("cannot write to %s: %s", file.path, file.getError());
     }
 }
 

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -36,6 +36,7 @@ import string_pool;
 import string_utils;
 import target_info;
 
+import c_errno local;
 import string;
 import stdlib;
 import stdio;
@@ -1041,11 +1042,9 @@ fn void Generator.generateInterfaceFiles(Generator* gen, Module* m) {
     hdr.add("#ifdef __cplusplus\n}\n#endif\n\n");
     hdr.add("#endif\n");
 
-    char[constants.Max_path] fullname;
-    stdio.snprintf(fullname, elemsof(fullname), "%s/%s.h", gen.results_dir, m.getName());
-    file_utils.Writer writer;
-    if (!writer.write(fullname, hdr.data(), hdr.size())) {
-        console.error("cannot write to %s: %s", fullname, writer.getError());
+    file_utils.File file.init_ext(gen.results_dir, m.getName(), ".h");
+    if (!file.write(hdr.data(), hdr.size())) {
+        console.error("cannot write to %s: %s", file.path, file.getError());
     }
     gen.cur_external = false;
 }
@@ -1193,11 +1192,9 @@ fn void Generator.free(Generator* gen) {
 }
 
 fn void Generator.write(Generator* gen, const char* output_dir, const char* filename, string_buffer.Buf* buf) {
-    char[constants.Max_path] fullname;
-    stdio.snprintf(fullname, elemsof(fullname), "%s/%s", output_dir, filename);
-    file_utils.Writer writer;
-    if (!writer.write(fullname, buf.udata(), buf.size())) {
-        console.error("cannot write to %s: %s", fullname, writer.getError());
+    file_utils.File file.init(output_dir, filename);
+    if (!file.write(buf.udata(), buf.size())) {
+        console.error("cannot write to %s: %s", file.path, file.getError());
     }
 }
 
@@ -1218,11 +1215,10 @@ public fn void generate(string_pool.Pool* astPool,
                         bool fast_build, bool asan, bool msan, bool ubsan,
                         bool test_mode, bool trace_calls)
 {
-    char[constants.Max_path] dir;
-    stdio.sprintf(dir, "%s/%s", output_dir, Dir);
-    i32 err = file_utils.create_directory(dir);
-    if (err) {
-        console.error("cannot create directory %s: %s", dir, string.strerror(err));
+    char[file_utils.Max_path] dir;
+    if (!file_utils.make_path(dir, elemsof(dir), output_dir, Dir)
+    ||  file_utils.create_path(dir)) {
+        console.error("cannot create directory %s: %s", dir, string.strerror(errno));
         return;
     }
 
@@ -1298,17 +1294,17 @@ public fn void generate(string_pool.Pool* astPool,
 
 public fn void build(const char* output_dir)
 {
+#if SYSTEM_FREEBSD || SYSTEM_OPENBSD
+    const char* make = "gmake";
+#else
     const char* make = "make";
-#if SYSTEM_FREEBSD
-    make = "gmake";
-#endif
-#if SYSTEM_OPENBSD
-    make = "gmake";
 #endif
 
-    // TODO use stringbuf for this
-    char[constants.Max_path] dir;
-    stdio.sprintf(dir, "%s/%s/", output_dir, Dir);
+    char[file_utils.Max_path] dir;
+    if (!file_utils.make_path_ext(dir, elemsof(dir), output_dir, Dir, "/")) {
+        console.error("cannot launch C compilation: %s", string.strerror(errno));
+        return;
+    }
 
     i32 retval = process_utils.run_args(dir, make, "-j", LogFile);
     if (retval != 0) {

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -20,7 +20,6 @@ import build_file;
 import build_target;
 import component;
 import console;
-import constants;
 import file_utils;
 import module_list;
 import string_buffer;
@@ -94,7 +93,7 @@ fn void Generator.createMakefile(Generator* gen,
         out.add("LDFLAGS+=-fsanitize=undefined\n");
     }
 
-    char[128] target_name;
+    char[file_utils.Max_path] target_name;
 
     if (gen.fast_build) {
         // dont add *.c, but add (handy for switching between fast/normal build
@@ -291,11 +290,9 @@ fn void Generator.generateC2TypesHeader(Generator* gen) {
     out.clear();
     out.add(C2_types_header);
 
-    char[constants.Max_path] fullname;
-    stdio.snprintf(fullname, elemsof(fullname), "%s/c2types.h", gen.results_dir);
-    file_utils.Writer writer;
-    if (!writer.write(fullname, out.data(), out.size())) {
-        console.error("cannot write to %s: %s", fullname, writer.getError());
+    file_utils.File file.init(gen.results_dir, "c2types.h");
+    if (!file.write(out.data(), out.size())) {
+        console.error("cannot write to %s: %s", file.path, file.getError());
     }
     out.clear();
 }

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -32,8 +32,8 @@ import string_pool;
 import target_info;
 import value_maplist;
 
+import c_errno local;
 import string;
-import stdio;
 
 type JumpScope struct {
     u32 break_block;    // 0 means invalid (assert)
@@ -569,11 +569,10 @@ public fn void generate(const char* target,
                         bool enable_asserts,
                         bool print,
                         bool print_all) {
-    char[constants.Max_path] ir_dir;
-    stdio.sprintf(ir_dir, "%s/ir", output_dir);
-    i32 err = file_utils.create_directory(ir_dir);
-    if (err) {
-        console.error("cannot create directory %s: %s", ir_dir, string.strerror(err));
+    char[file_utils.Max_path] ir_dir;
+    if (!file_utils.make_path(ir_dir, elemsof(ir_dir), output_dir, "ir")
+    ||  file_utils.create_path(ir_dir)) {
+        console.error("cannot create directory %s: %s", ir_dir, string.strerror(errno));
         return;
     }
 

--- a/plugins/deps_generator.c2
+++ b/plugins/deps_generator.c2
@@ -414,10 +414,8 @@ public fn void generate(const char* title, const char* output_dir, component.Lis
     gen.indent--;
     out.add("</dsm>\n");
 
-    char[128] outfile;
-    sprintf(outfile, "%s/%s", output_dir, "deps.xml");
-    file_utils.Writer file;
-    file.write(outfile, out.data(), out.size());
+    file_utils.File file.init(output_dir, "deps.xml");
+    file.write(out.data(), out.size());
 
     if (gen.visitor) gen.visitor.free();
 

--- a/plugins/plugin_info.c2
+++ b/plugins/plugin_info.c2
@@ -21,6 +21,7 @@ import ast_context;
 import build_target;
 import component;
 import diagnostics;
+import file_utils;
 import source_mgr;
 import string_pool;
 import string_buffer;
@@ -47,7 +48,7 @@ public type Info struct {
     void* fn_arg;
 
     char[32] target_name;
-    char[256] output_dir;
+    char[file_utils.Max_path] output_dir;
 }
 
 // only used by plugins

--- a/plugins/refs_generator.c2
+++ b/plugins/refs_generator.c2
@@ -19,11 +19,11 @@ import ast local;
 import component;
 import console;
 import c2refs as refs;
+import file_utils;
 import source_mgr;
 import ast_visitor;
 
 import string;
-import stdio;
 
 type Generator struct {
     source_mgr.SourceMgr* sm;
@@ -136,8 +136,8 @@ public fn void generate(source_mgr.SourceMgr* sm, const char* output_dir, compon
         comps.get(i).visitModules(Generator.on_module, &gen);
     }
 
-    char[128] outfile;
-    stdio.sprintf(outfile, "%s/%s", output_dir, filename);
+    char[file_utils.Max_path] outfile;
+    file_utils.make_path(outfile, elemsof(outfile), output_dir, filename);
     gen.refs.write(outfile);
     gen.refs.free();
 

--- a/plugins/shell_cmd_plugin.c2
+++ b/plugins/shell_cmd_plugin.c2
@@ -74,10 +74,10 @@ fn void init(void* arg, plugin_info.Info* info) {
     ast.setGlobals(info.ast_globals);
     ast.builtins = info.ast_builtins;
 
-    console.debug("shell_cmd: opening %s", p.config_file);
-    file_utils.Reader file;
-    if (!file.open(p.config_file)) {
-        console.error("shell_cmd: cannot open file %s: %s", p.config_file, file.getError());
+    console.debug("shell_cmd: loading %s", p.config_file);
+    file_utils.File file.init("", p.config_file);
+    if (!file.load()) {
+        console.error("shell_cmd: cannot load file %s: %s", p.config_file, file.getError());
         exit(EXIT_FAILURE);
     }
     yaml.Parser* parser = yaml.Parser.create();

--- a/recipe.txt
+++ b/recipe.txt
@@ -10,6 +10,7 @@ set common
     common/component.c2
     common/console.c2
     common/diagnostics.c2
+    common/file/file_utils.c2
     common/file/reader.c2
     common/file/writer.c2
     common/library_list.c2
@@ -135,6 +136,7 @@ set yaml
 end
 
 set refs
+    common/file/file_utils.c2
     common/linked_list.c2
     common/quicksort.c2
     common/utils.c2
@@ -181,7 +183,6 @@ executable c2c
     common/bit_array.c2
     common/bit_utils.c2
     common/component_sorter.c2
-    common/file/file_utils.c2
     common/index_list.c2
     common/dsm_sorter.c2
     common/manifest_writer.c2
@@ -357,6 +358,7 @@ executable tester
     ast_utils/constants.c2
     ast_utils/string_buffer.c2
 
+    common/file/file_utils.c2
     common/file/reader.c2
     common/file/writer.c2
     common/string_utils.c2
@@ -380,6 +382,7 @@ executable c2cat
     ast_utils/string_buffer.c2
     ast_utils/string_pool.c2
 
+    common/file/file_utils.c2
     common/file/reader.c2
     common/string_list.c2
     common/utf8.c2
@@ -409,6 +412,7 @@ executable c2loc
     ast_utils/string_pool.c2
 
     common/build_target.c2
+    common/file/file_utils.c2
     common/file/reader.c2
     common/library_list.c2
     common/source_mgr.c2

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -286,8 +286,8 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
 
 public fn i32 c2cat(const char* filename)
 {
-    file_utils.Reader file;
-    if (!file.open(filename)) {
+    file_utils.File file.init("", filename);
+    if (!file.load()) {
         fprintf(stderr, "error opening %s: %s\n", filename, file.getError());
         return -1;
     }
@@ -298,6 +298,7 @@ public fn i32 c2cat(const char* filename)
     ctx.offset = 0;
     ctx.input = file.data();
     ctx.in_attributes = 0;
+    u32 file_size = file.data_size();
 
     string_list.List features;
     features.init(ctx.pool);
@@ -320,13 +321,13 @@ public fn i32 c2cat(const char* filename)
         ctx.print_token(&tok);
     }
 
-    if (ctx.offset <= file.size) {
-        u32 len = file.size - ctx.offset;
+    if (ctx.offset <= file_size) {
+        u32 len = file_size - ctx.offset;
         if (len) ctx.out.add2(ctx.input + ctx.offset, len);
     } else {
         ctx.out.add1('\n');
         ctx.out.color(col_error);
-        ctx.out.print("error: offset=%d file.size=%d", ctx.offset, file.size);
+        ctx.out.print("error: offset=%d file_size=%d", ctx.offset, file_size);
         ctx.out.color(col_normal);
         ctx.out.add1('\n');
     }

--- a/tools/c2rename.c2
+++ b/tools/c2rename.c2
@@ -17,6 +17,7 @@ module refs_main;
 
 import c2refs local;
 import constants;
+import file_utils;
 import replacer;
 import refs_finder;
 import utils;
@@ -95,10 +96,10 @@ public fn i32 main(i32 argc, const char** argv)
     }
 
     const char* refsfile = constants.refs_filename;
-    char[constants.Max_path] refsname;
+    char[file_utils.Max_path] refsname;
     if (opts.target) {
-        snprintf(refsname, 256, "%s/%s/%s", constants.output_dir, opts.target, constants.refs_filename);
-        refsname[255] = 0;
+        file_utils.make_path3(refsname, elemsof(refsname),
+                              constants.output_dir, opts.target, constants.refs_filename);
         refsfile = refsname;
     } else {
         refs_finder.Finder* finder = refs_finder.create(constants.output_dir, constants.refs_filename);

--- a/tools/c2tags.c2
+++ b/tools/c2tags.c2
@@ -17,6 +17,7 @@ module refs_main;
 
 import c2refs local;
 import constants;
+import file_utils;
 import refs_finder;
 import string_pool;
 import utils;
@@ -187,15 +188,13 @@ fn void use_fn(void* arg, const Dest* res) {
         count++;
 
         // TODO extract to info
-        char[constants.Max_path] fullname;
-        const char* full;
+        char[file_utils.Max_path] fullname;
+        const char* filename = res.filename;
         if (info.hasSubdir()) {
-            sprintf(fullname, "%s%s", info.root2orig, res.filename);
-            full = fullname;
-        } else {
-            full = res.filename;
+            file_utils.make_path(fullname, elemsof(fullname), info.root2orig, filename);
+            filename = fullname;
         }
-        printf("found %s %d %d\n", full, res.line, res.col);
+        printf("found %s %d %d\n", filename, res.line, res.col);
     }
 }
 
@@ -203,16 +202,13 @@ fn void use_fn_multi(void* arg, const Dest* res) {
     const utils.PathInfo* info = arg;
 
     if (res.filename) {
-        char[constants.Max_path] fullname;
-        const char* full;
+        char[file_utils.Max_path] fullname;
+        const char* filename = res.filename;
         if (opts.filename && info.hasSubdir()) {
-            sprintf(fullname, "%s%s", info.root2orig, res.filename);
-            full = fullname;
-        } else {
-            full = res.filename;
+            file_utils.make_path(fullname, elemsof(fullname), info.root2orig, filename);
+            filename = fullname;
         }
-
-        results.add(full, res.line, res.col);
+        results.add(filename, res.line, res.col);
     }
 }
 
@@ -261,9 +257,9 @@ public fn i32 main(i32 argc, const char** argv)
     }
     //printf("P1 [%s]\n", info.root2orig);
     //printf("P2 [%s]\n", info.orig2root);
-    char[constants.Max_path] fullname;
+    char[file_utils.Max_path] fullname;
     if (opts.filename && info.hasSubdir()) {
-        sprintf(fullname, "%s/%s", info.orig2root, opts.filename);
+        file_utils.make_path(fullname, elemsof(fullname), info.orig2root, opts.filename);
         opts.filename = fullname;
     }
 #if MeasureTime

--- a/tools/common/refs_finder.c2
+++ b/tools/common/refs_finder.c2
@@ -15,6 +15,7 @@
 
 module refs_finder;
 
+import file_utils;
 import string_pool;
 
 import c_errno local;
@@ -22,7 +23,6 @@ import libc_dirent local;
 import stdio local;
 import stdlib local;
 import string;
-import sys_stat local;
 
 public type Finder struct @(opaque) {
     const char* dirname;
@@ -51,15 +51,15 @@ public fn void Finder.free(Finder* f) {
 }
 
 public fn u32 Finder.search(Finder* f, const char* target) {
-    char[512] fullname;
+    char[file_utils.Max_path] fullname;
 
     if (target) {
-        stdio.snprintf(fullname, 512, "%s/%s/%s", f.dirname, target, f.filename);
-        Stat statbuf;
-        i32 err = stat(fullname, &statbuf);
-        if (err) return 0;
-        f.add(fullname);
-        return 1;
+        if (file_utils.make_path3(fullname, elemsof(fullname), f.dirname, target, f.filename)
+        &&  file_utils.path_exists(fullname)) {
+            f.add(fullname);
+            return 1;
+        }
+        return 0;
     }
     DIR* dir = opendir(f.dirname);
     if (dir == nil) {
@@ -67,19 +67,14 @@ public fn u32 Finder.search(Finder* f, const char* target) {
         exit(EXIT_FAILURE);
     }
 
-    Dirent* entry = readdir(dir);
-    while (entry != nil) {
+    while (Dirent* entry = readdir(dir)) {
         const char* name = entry.d_name;
         if (name[0] != '.' && entry.d_type == DT_DIR) {
-            stdio.snprintf(fullname, 512, "%s/%s/%s", f.dirname, name, f.filename);
-
-            Stat statbuf;
-            i32 err = stat(fullname, &statbuf);
-            if (err) goto next;
-            f.add(fullname);
+            if (file_utils.make_path3(fullname, elemsof(fullname), f.dirname, name, f.filename)
+            &&  file_utils.path_exists(fullname)) {
+                f.add(fullname);
+            }
         }
-next:
-        entry = readdir(dir);
     }
     closedir(dir);
     return f.count;

--- a/tools/common/replacer.c2
+++ b/tools/common/replacer.c2
@@ -46,7 +46,7 @@ public type Replacer struct @(opaque) {
     u32 f_capacity;
     Fragment* fragments;
 
-    file_utils.Reader file;
+    file_utils.File file;
     u8* dest;
     u32 dest_capacity;
 }
@@ -97,8 +97,8 @@ fn void Replacer.addFragment(Replacer* r, u32 start, u32 end) {
 
 fn void Replacer.flushFragments(Replacer* r, const char* filename) {
     u32 new_len = cast<u32>(string.strlen(r.new_name));
-    u32 new_size = r.file.size;
-    new_size += (r.f_count - 1)* (new_len - r.old_len);
+    u32 new_size = r.file.data_size();
+    new_size += (r.f_count - 1) * (new_len - r.old_len);
     if (new_size + 1 > r.dest_capacity) {
         if (r.dest) stdlib.free(r.dest);
         r.dest_capacity = new_size+1; // add 1 for 0-terminator
@@ -107,7 +107,7 @@ fn void Replacer.flushFragments(Replacer* r, const char* filename) {
     }
 
     //printf("Fragments:\n");
-    const u8* src = r.file.udata();
+    const u8* src = r.file.data();
     u32 dest_idx = 0;
     for (u32 i=0; i<r.f_count; i++) {
         Fragment* f = &r.fragments[i];
@@ -123,8 +123,8 @@ fn void Replacer.flushFragments(Replacer* r, const char* filename) {
     r.dest[dest_idx] = 0;
 
     // write
-    file_utils.Writer outfile;
-    if (!outfile.write(filename, r.dest, new_size)) {
+    file_utils.File outfile.init("", filename);
+    if (!outfile.write(r.dest, new_size)) {
         fprintf(stderr, "cannot write to %s: %s\n", filename, outfile.getError());
     }
 
@@ -160,7 +160,7 @@ fn u32 findLine(const char* start, u32 line) {
 }
 
 fn u32 Replacer.findOffset(Replacer* r, u32 line, u32 column) {
-    //printf("find offset %d %d  file.size %d\n", line, column, r.file.size);
+    //printf("find offset %d %d  file.size %d\n", line, column, r.file.data_size());
     // TODO cache last entry
 
     u32 cur_line = 1;
@@ -196,19 +196,20 @@ public fn i32 Replacer.replace(Replacer* r, u16 old_len) {
         if (filename != cur_file) {
             num_files++;
             if (r.file.isOpen()) {
-                r.addFragment(prev_offset, r.file.size);
+                r.addFragment(prev_offset, r.file.data_size());
                 r.flushFragments(cur_file);
                 r.file.close();
                 prev_offset = 0;
             }
             cur_file = filename;
-            if (!r.file.open(filename)) {
+            r.file.init("", filename);
+            if (!r.file.load()) {
                 fprintf(stderr, "error opening %s: %s\n", filename, r.file.getError());
                 return -1;
             }
         }
         u32 offset = r.findOffset(l.line, l.column);
-        if (offset >= r.file.size) {
+        if (offset >= r.file.data_size()) {
             printf("invalid position %s %d %d\n", l.filename, l.line, l.column);
             return -1;
         }
@@ -219,7 +220,7 @@ public fn i32 Replacer.replace(Replacer* r, u16 old_len) {
         prev_offset = offset += r.old_len;
     }
     if (r.file.isOpen()) {
-        r.addFragment(prev_offset, r.file.size);
+        r.addFragment(prev_offset, r.file.data_size());
         r.flushFragments(cur_file);
         r.file.close();
     }

--- a/tools/tester/expect_file.c2
+++ b/tools/tester/expect_file.c2
@@ -15,7 +15,6 @@
 
 module expect_file;
 
-import sys_stat local;
 import stdlib local;
 import string local;
 import stdio local;
@@ -48,7 +47,7 @@ public type ExpectMode enum u8 {
 }
 
 public type ExpectFile struct @(opaque) {
-    char[128] filename;
+    char[file_utils.Max_path] filename;
     ExpectMode mode;
     string_buffer.Buf* output;  // will be set in check()
 
@@ -145,24 +144,17 @@ fn void ExpectFile.setExpected(ExpectFile* f) {
 }
 
 public fn bool ExpectFile.check(ExpectFile* f, string_buffer.Buf* output, const char* basedir) {
-    // TODO use constant
-    char[128] fullname;
-    sprintf(fullname, "%s%s", basedir, f.filename);
     f.output = output;
     bool result = true;
 
-    // check if file exists
-    Stat statbuf;
-    i32 err = stat(fullname, &statbuf);
-    if (err) {
-        color_print2(f.output, colError, "  missing expected file '%s' (%s)", f.filename, fullname);
+    file_utils.File file.init(basedir, f.filename);
+    if (!file.exists()) {
+        color_print2(f.output, colError, "  missing expected file '%s' (%s)", f.filename, file.path);
         return false;
     }
 
-    file_utils.Reader file;
-    bool ok = file.open(fullname);
-    if (!ok) {
-        fprintf(stderr, "error opening %s: %s\n", fullname, file.getError());
+    if (!file.load()) {
+        fprintf(stderr, "error loading %s: %s\n", file.path, file.getError());
         exit(EXIT_FAILURE);
     }
 

--- a/tools/tester/issues.c2
+++ b/tools/tester/issues.c2
@@ -15,6 +15,8 @@
 
 module issues;
 
+import file_utils;
+
 import stdlib local;
 import string local;
 import stdio local; // for dump()
@@ -32,9 +34,9 @@ public type Iter struct {
 }
 
 public fn const char* relativeFilename(const char *name) {
-    char[512] buffer;
+    char[file_utils.Max_path] buffer;
     char* path = unistd.getcwd(buffer, sizeof(buffer));
-    if (path && path[1]) {
+    if (path && *path && path[1]) {
         usize len = strlen(path);
         if (!strncmp(name, path, len) && name[len] == '/' && name[len + 1] != '\0')
             return name + len + 1;

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -23,7 +23,6 @@ import string local;
 import unistd local;
 
 import color;
-import constants;
 import expect_file local;
 import file_utils;
 import issues local;
@@ -60,7 +59,7 @@ type Type enum u8 { ERROR, WARNING, NOTE }
 
 public type Db struct {
     string_buffer.Buf* output;  // no ownership
-    file_utils.Reader* file;    // no ownership
+    const char* source;    // no ownership
     const char* filename;
     TestKind kind;
     const char* tmp_dir;
@@ -86,7 +85,7 @@ public type Db struct {
     u32 line_nr;
     string_buffer.Buf* errorMsg;    // ownership
     string_buffer.Buf* recipe;      // ownership
-    char[constants.Max_path] current_file;
+    char[file_utils.Max_path] current_file;
     char[64] target;
 
     char[32] word_buffer;
@@ -95,7 +94,7 @@ public type Db struct {
 
 public fn void Db.init(Db* db,
                          string_buffer.Buf* output,
-                         file_utils.Reader* file,
+                         const char* source,
                          const char* filename,
                          TestKind kind,
                          const char* tmp_dir,
@@ -105,7 +104,7 @@ public fn void Db.init(Db* db,
 {
     memset(db, 0, sizeof(Db));
     db.output = output;
-    db.file = file;
+    db.source = source;
     db.filename = filename;
     db.kind = kind;
     db.tmp_dir = tmp_dir;
@@ -121,7 +120,7 @@ public fn void Db.init(Db* db,
     db.recipe = string_buffer.create(4096, false, 2);
 
     if (kind == TestKind.C2) { // only for single file test
-        sprintf(db.current_file, "%s/%s", cwd, filename);
+        file_utils.make_path(db.current_file, elemsof(db.current_file), cwd, filename);
     }
 }
 
@@ -208,11 +207,9 @@ fn void Db.matchError(Db* db, const char* filename, i32 linenr, const char* msg)
 }
 
 fn void Db.writeFile(Db* db, const char* filename, const char* data, u32 len) {
-    char[128] fullname;
-    sprintf(fullname, "%s/%s", db.tmp_dir, filename);
-    file_utils.Writer writer;
-    if (!writer.write(fullname, data, len)) {
-        print_error("error writing %s: %s", fullname, writer.getError());
+    file_utils.File file.init(db.tmp_dir, filename);
+    if (!file.write(data, len)) {
+        print_error("error writing %s: %s", file.path, file.getError());
         exit(EXIT_FAILURE);
     }
 }
@@ -630,7 +627,7 @@ public fn void Db.parseLine(Db* db, const char* start, const char* end) {
 }
 
 public fn bool Db.parse(Db* db) {
-    const char* cp = db.file.data();
+    const char* cp = db.source;
     db.cur = cp;
     db.line_nr = 1;
 
@@ -848,8 +845,8 @@ fn void Db.checkErrors(Db* db, const char* buffer, u32 size) {
 }
 
 fn void Db.checkExpectedFiles(Db* db) {
-    char[constants.Max_path] basedir;
-    sprintf(basedir, "%s/output/test/", db.tmp_dir);
+    char[file_utils.Max_path] basedir;
+    file_utils.make_path(basedir, elemsof(basedir), db.tmp_dir, "output/test/");
     for (u32 i=0; i<db.expectedCount; ++i) {
         ExpectFile* e = db.expectedFiles[i];
         if (!e.check(db.output, basedir)) db.hasErrors = true;

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -160,24 +160,23 @@ fn void handle_dir(TestQueue* queue, const char* path) {
         color_print(colError, "cannot open dir '%s': %s", path, strerror(errno));
         return;
     }
-    Dirent* dir2 = readdir(dir);
-    char[test_db.MAX_LINE] temp;
-    while (dir2 != nil) {
-        // FIXME: need string.makepath
-        snprintf(temp, sizeof(temp), "%s/%s", path, dir2.d_name);
-        switch (dir2.d_type) {
-        case DT_REG:
-            handle_file(queue, temp);
-            break;
-        case DT_DIR:
-            if (strcmp(dir2.d_name, ".") != 0 && strcmp(dir2.d_name, "..") != 0) {
-                handle_dir(queue, temp);
+
+    while (Dirent* entry = readdir(dir)) {
+        char[file_utils.Max_path] temp;
+        if (file_utils.make_path(temp, elemsof(temp), path, entry.d_name)) {
+            switch (entry.d_type) {
+            case DT_REG:
+                handle_file(queue, temp);
+                break;
+            case DT_DIR:
+                if (strcmp(entry.d_name, ".") != 0 && strcmp(entry.d_name, "..") != 0) {
+                    handle_dir(queue, temp);
+                }
+                break;
+            default:
+                break;
             }
-            break;
-        default:
-            break;
         }
-        dir2 = readdir(dir);
     }
     closedir(dir);
 }
@@ -255,15 +254,14 @@ fn void Tester.run_test(Tester* t, Test* test) {
     string_buffer.Buf* buf = string_buffer.create(4096, true, 2);
     buf.print("%s ", test.filename);
 
-    file_utils.Reader file;
-    bool ok = file.open(test.filename);
-    if (!ok) {
+    file_utils.File file.init("", test.filename);
+    if (!file.load()) {
         print_error("error opening %s: %s", test.filename, file.getError());
         exit(EXIT_FAILURE);
     }
 
     test_db.Db db;
-    db.init(buf, &file, test.filename, test.kind, t.tmp_dir, c2c_cmd, t.cwd, runSkipped);
+    db.init(buf, file.data(), test.filename, test.kind, t.tmp_dir, c2c_cmd, t.cwd, runSkipped);
     bool print = verboseLevel > 1;
     bool skip = db.parse();
     if (skip) {
@@ -347,18 +345,10 @@ public fn i32 main(i32 argc, char** argv) {
         }
         target = arg;
 
-        Stat statbuf;
-        if (stat(target, &statbuf)) {
-            print_error("error stat-ing %s: %s", target, strerror(errno));
-            return -1;
-        }
-        // strip off trailing '/'
-        usize len = strlen(target);
-        if (len > 1 && target[len - 1] == '/') target[--len] = '\0';
-
-        if ((statbuf.st_mode & S_IFMT) == S_IFREG) {
+        if (file_utils.is_file(target)) {
             handle_file(queue, target);
-        } else if ((statbuf.st_mode & S_IFMT) == S_IFDIR) {
+        } else
+        if (file_utils.is_dir(target)) {
             handle_dir(queue, target);
         } else {
             print_error("argument must be a regular file a directory: %s", target);


### PR DESCRIPTION
* rename `constants.Max_path` as `file_utils.Max_path`
* rename `string.getBasename()` to `file_utils.get_basename()`
* rename `string.getExtension()` to `file_utils.get_extension()`
* add `make_path()`, `make_path_ext()`, `make_path3()`
* construct paths with `make_path()` instead of `sprintf()`
* rename `file_utils.create_directory()` as `file_utils.create_path()`
* use `Max_path` for size of buffers use for filenames and directories
* add `file_utils.is_file()` and `file_utils.is_dir()`
* use `file_utils.path_exists()` instead of `stat`
* use `while (Dirent* entry = readdir(dir))` pattern to enumerate dirs
* add `file_utils.File` struct to encapsulate path operations for file access
* remove `file_utils.Reader` and `file_utils.Writer`
* use `File.load()` in place of `Reader.open()`.