### PR TITLE
source-mgr: simplify APIs

### DIFF
--- a/ast_utils/string_pool.c2
+++ b/ast_utils/string_pool.c2
@@ -190,7 +190,7 @@ fn void Pool.resize_entries(Pool* p, u32 capacity) {
     p.entries = entries;
 }
 
-public fn void Pool.report(const Pool* p) @(unused) {
+public fn void Pool.report(const Pool* p, const char* name) @(unused) {
     u32 max = 0;
     u32 min = 999;
     u32 hash_size = p.hash_mask + 1;
@@ -213,7 +213,7 @@ public fn void Pool.report(const Pool* p) @(unused) {
             }
         }
     }
-    stdio.printf("pool: count %d, adds %d, data %d/%d\n",
+    stdio.printf("%s: count %d, adds %d, data %d/%d\n", name,
                  p.hash_count, p.num_adds, p.data_size, p.data_capacity);
 
     stdio.printf("  hash: entries: %d/%d/%d/%d, min %d, max %d, avg %.2f, memory %d\n",

--- a/common/build_file.c2
+++ b/common/build_file.c2
@@ -240,13 +240,10 @@ public fn Info* parse(source_mgr.SourceMgr* sm, string_pool.Pool* pool, const ch
     info.lib_dirs.init(pool);
     info.plugin_dirs.init(pool);
 
-    u32 filename_idx = pool.addStr(filename, false);
-    i32 file_id = sm.open(filename_idx, 0, false);
+    i32 file_id = sm.loadFile(filename, 0);
     if (file_id == -1) return nil;
 
     bool ok = info.parse(sm.get_content(file_id));
-
-    sm.close(file_id);
 
     if (!ok) return nil;
 

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -45,25 +45,16 @@ type File struct {
     u32 offset;
     u32 data_size;
     bool is_generated;
-    bool is_source;
     bool is_const;
-    char* data_;
+    char* data;
     CheckPoint *checkpoints;
 }
 
 fn void File.clear(File* f) {
-    if (!f.is_const) stdlib.free(f.data_);
-    f.data_ = nil;
+    if (!f.is_const) stdlib.free(f.data);
+    f.data = nil;
     stdlib.free(f.checkpoints);
     f.checkpoints = nil;
-}
-
-fn u32 File.size(const File* f) {
-    return f.data_size;
-}
-
-fn const char* File.data(File* f) {
-    return f.data_;
 }
 
 fn CheckPoint update_checkpoint(CheckPoint cp, const char* src, u32 len) {
@@ -90,7 +81,7 @@ fn void File.addCheckPoints(File* f) {
     u32 ncheck = f.data_size / CheckPointSize;
     CheckPoint* cp = stdlib.malloc((ncheck + 1) * sizeof(CheckPoint));
     CheckPoint pos = { 0, 0 }
-    const char* src = f.data_;
+    const char* src = f.data;
     f.checkpoints = cp;
     while (ncheck-- > 0) {
         *cp++ = pos;
@@ -104,12 +95,12 @@ fn CheckPoint File.findCheckPoint(File *f, u32 offset) {
     if (!f.checkpoints) f.addCheckPoints();
     CheckPoint pos = f.checkpoints[offset / CheckPointSize];
     u32 chunk = offset % CheckPointSize;
-    const char* src = f.data_ + offset - chunk;
+    const char* src = f.data + offset - chunk;
     return update_checkpoint(pos, src, chunk);
 }
 
 public type SourceMgr struct @(opaque) {
-    const string_pool.Pool* pool;
+    string_pool.Pool* pool;
 
     File* files;
     u32 num_files;
@@ -121,7 +112,7 @@ public type SourceMgr struct @(opaque) {
     u16* index;
 }
 
-public fn SourceMgr* create(const string_pool.Pool* pool) {
+public fn SourceMgr* create(string_pool.Pool* pool) {
     SourceMgr* sm = stdlib.calloc(1, sizeof(SourceMgr));
     sm.pool = pool;
     sm.max_files = InitialMaxFiles;
@@ -148,8 +139,7 @@ public fn void SourceMgr.clear(SourceMgr* sm, i32 handle) {
     if (handle >= 0) start_handle = (u32)(handle + 1);
 
     for (u32 i = start_handle; i < sm.num_files; i++) {
-        File* f = &sm.files[i];
-        f.clear();
+        sm.files[i].clear();
     }
     sm.num_files = start_handle;
     sm.index_count = 1;
@@ -160,22 +150,6 @@ public fn void SourceMgr.clear(SourceMgr* sm, i32 handle) {
     sm.max_offset = sm.index_count * FileIndexSize;
 }
 
-fn void* SourceMgr.loadFile(SourceMgr* sm, u32 name, SrcLoc loc, u32* psize) {
-    const char* filename = sm.pool.idx2str(name);
-    file_utils.File file.init("", filename);
-    if (file.load()) return file.detach(psize);
-
-    // TODO only color if enabled (cannot use console since we need source loc first)
-    if (loc) {
-        stdio.fprintf(stdio.stderr, "%s: %serror:%s cannot open %s: %s\n",
-                      sm.loc2str(loc), color.Red, color.Normal, filename, file.getError());
-    } else {
-        stdio.fprintf(stdio.stderr, "%serror%s: cannot open %s: %s\n",
-                      color.Red, color.Normal, filename, file.getError());
-    }
-    return nil;
-}
-
 fn void SourceMgr.resize(SourceMgr* sm) {
     sm.max_files *= 2;
     File* files2 = stdlib.malloc(sizeof(File) * sm.max_files);
@@ -184,38 +158,43 @@ fn void SourceMgr.resize(SourceMgr* sm) {
     sm.files = files2;
 }
 
-public fn i32 SourceMgr.addGenerated(SourceMgr* sm, u32 name, void* data, u32 size) @(unused) {
+public fn i32 SourceMgr.addGenerated(SourceMgr* sm, const char* name, void* data, u32 size) @(unused) {
 #if PrintGenerated
-    stdio.printf("------ GENERATED (%s) ------\n%s\n", sm.pool.idx2str(name), data);
+    stdio.printf("------ GENERATED (%s) ------\n%s\n", name, data);
 #endif
-    return sm.addFile(name, data, size, false, true, false);
+    return sm.addFile(name, data, size, true, false);
 }
 
-public fn i32 SourceMgr.addResource(SourceMgr* sm, u32 name, const void* data, u32 size) @(unused) {
+public fn i32 SourceMgr.addResource(SourceMgr* sm, const char* name, const void* data, u32 size) @(unused) {
 #if PrintGenerated
-    stdio.printf("------ RESOURCE (%s) ------\n%s\n", sm.pool.idx2str(name), data);
+    stdio.printf("------ RESOURCE (%s) ------\n%s\n", name, data);
 #endif
-    return sm.addFile(name, (void *)data, size, false, true, true);
+    return sm.addFile(name, (void *)data, size, true, true);
 }
 
-// Note: filename must be allocated in pool passed to SourceMgr
-public fn i32 SourceMgr.open(SourceMgr* sm, u32 filename, SrcLoc loc, bool is_source) {
-    // first check if file is already loaded
-    // TODO: use hashing
-    for (u32 i = 0; i < sm.num_files; i++) {
-        if (sm.files[i].filename == filename) {
-            return (i32)i;
+public fn i32 SourceMgr.loadFile(SourceMgr* sm, const char* filename, SrcLoc sloc) {
+    file_utils.File file.init("", filename);
+    if (!file.load()) {
+        char[256] tmp;
+        *tmp = '\0';
+        if (sloc) {
+            Location loc = sm.locate(sloc);
+            if (loc.line_start) {
+                stdio.snprintf(tmp, elemsof(tmp), "%s:%d:%d: ", loc.filename, loc.line, loc.column);
+            }
         }
+        // TODO only color if enabled (cannot use console since we need source loc first)
+        stdio.fprintf(stdio.stderr, "%s%serror:%s cannot open %s: %s\n",
+                      tmp, color.Red, color.Normal, filename, file.getError());
+        return -1;
     }
-
     u32 size;
-    void *data = sm.loadFile(filename, loc, &size);
-    if (!data) return -1;
-    return sm.addFile(filename, data, size, is_source, false, false);
+    void *data = file.detach(&size);
+    return sm.addFile(filename, data, size, false, false);
 }
 
-fn i32 SourceMgr.addFile(SourceMgr* sm, u32 filename, void* data, u32 size,
-                         bool is_source, bool is_generated, bool is_const) {
+fn i32 SourceMgr.addFile(SourceMgr* sm, const char* filename, void* data, u32 size,
+                         bool is_generated, bool is_const) {
 
     if (sm.num_files == sm.max_files) sm.resize();
 
@@ -223,11 +202,10 @@ fn i32 SourceMgr.addFile(SourceMgr* sm, u32 filename, void* data, u32 size,
     File* f = &sm.files[sm.num_files];
     string.memset(f, 0, sizeof(File));
 
-    f.filename = filename;
+    f.filename = sm.pool.addStr(filename, true);
     f.offset = sm.max_offset;
     f.data_size = size; // does not include null terminator byte
-    f.data_ = data;
-    f.is_source = is_source;
+    f.data = data;
     f.is_const = is_const;
     f.is_generated = is_generated;
     sm.max_offset += (size + FileIndexSize) & -FileIndexSize;
@@ -253,12 +231,9 @@ fn i32 SourceMgr.addFile(SourceMgr* sm, u32 filename, void* data, u32 size,
     return file_id;
 }
 
-public fn void SourceMgr.close(SourceMgr* sm, i32 file_id) {
-}
-
 public fn const char* SourceMgr.get_content(SourceMgr* sm, i32 handle) {
     assert((u32)handle < sm.num_files);
-    return sm.files[handle].data();
+    return sm.files[handle].data;
 }
 
 public fn u32 SourceMgr.get_offset(SourceMgr* sm, i32 handle) {
@@ -295,7 +270,7 @@ public fn Location SourceMgr.locate(SourceMgr* sm, SrcLoc loc) {
         CheckPoint pos = f.findCheckPoint(offset);
         l.line = pos.line + 1;
         l.column = pos.column + 1;
-        l.line_start = f.data_ + offset - pos.column;
+        l.line_start = f.data + offset - pos.column;
         l.filename = sm.pool.idx2str(f.filename);
     }
     //stdio.printf("    -> %s:%d:%d\n", l.filename, l.line, l.column);
@@ -313,28 +288,14 @@ public fn const char* SourceMgr.loc2str(SourceMgr* sm, SrcLoc sloc) {
     return tmp;
 }
 
-public fn void SourceMgr.report(SourceMgr* sm) {
-    u32 other_count = 0;
-    u32 other_size = 0;
-    u32 sources_count = 0;
-    u32 sources_size = 0;
-    for (u32 i = 0; i < sm.num_files; i++) {
-        const File* f = &sm.files[i];
-        if (f.is_source) {
-            sources_count++;
-            sources_size += f.size();
-        } else {
-            other_count++;
-            other_size += f.size();
-        }
-    }
-    stdio.printf("source-mgr: %d files, %d sources (%d bytes), %d other (%d bytes)\n",
-        sm.num_files, sources_count, sources_size, other_count, other_size);
-#if 1
+public fn void SourceMgr.report(SourceMgr* sm, bool full) {
     u32 total_size = sizeof(SourceMgr) + sm.max_files * sizeof(File) + sm.index_capacity * sizeof(u16);
+    u32 total_bytes = 0;
     u32 total_lines = 0;
-    for (u32 i=0; i<sm.num_files; i++) {
+    if (full) stdio.printf("source-mgr: %d files\n", sm.num_files);
+    for (u32 i = 0; i < sm.num_files; i++) {
         File* f = &sm.files[i];
+        total_bytes += f.data_size;
         total_size += f.data_size + 1;
         u32 lines = 0;
         if (f.data_size && f.checkpoints) {
@@ -344,10 +305,12 @@ public fn void SourceMgr.report(SourceMgr* sm) {
             lines = loc.line;
             total_lines += lines;
         }
-        stdio.printf("  %7d  %6d  %4d  %s%s\n",
-                     f.offset, f.data_size, lines, sm.pool.idx2str(f.filename),
-                     f.is_generated ? " (generated)" : "");
+        if (full) {
+            stdio.printf("  %7d  %6d  %4d  %s%s\n",
+                         f.offset, f.data_size, lines, sm.pool.idx2str(f.filename),
+                         f.is_generated ? " (generated)" : "");
+        }
     }
-    stdio.printf("  Total: %d bytes, %d lines\n", total_size, total_lines);
-#endif
+    stdio.printf("source-mgr: %d files, %d bytes, %d total size, %d lines\n",
+                 sm.num_files, total_bytes, total_size, total_lines);
 }

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -74,7 +74,7 @@ public type Options struct {
     bool print_symbols;
     bool print_external_symbols;
     bool print_ast_stats;
-    bool print_reports;
+    u8 print_reports;
     bool show_libs;
     bool print_ir;
     bool print_all_ir;
@@ -100,9 +100,10 @@ public fn void build(string_pool.Pool* auxPool,
     c.build(auxPool, sm, diags, build_info, target, opts, pluginHandler, &info);
 
     if (opts.print_reports) {
-        c.sm.report();
+        c.sm.report(opts.print_reports > 1);
         c.context.report();
-        c.astPool.report();
+        c.astPool.report("astPool");
+        c.auxPool.report("auxPool");
     }
 
     diags.printStatus();
@@ -174,8 +175,8 @@ type Compiler struct {
     bool is_image; // require build-file, dont allow dynamic libs, dont allow module exports
 
     component.Component* mainComp;  // no ownership
-    u32 main_idx;  // in astpool
-    u32 libc_name; // in auxpool
+    u32 main_idx;  // in astPool
+    u32 libc_name; // in auxPool
     ast.Decl* mainFunc;
 
     // used to parse external components
@@ -364,21 +365,18 @@ fn void Compiler.build(Compiler* c,
     u64 t1_start = utils.now();
     for (u32 j=0; j<target.numFiles(); j++) {
         const build_target.File* f = target.getFile(j);
-        i32 file_id = sm.open(f.name, f.loc, true);
+        i32 file_id = sm.loadFile(auxPool.idx2str(f.name), f.loc);
         if (file_id == -1) return;   // note: error already printed
         console.debug("parsing %s", sm.getFileName(file_id));
 
         // parse error indicator updated in c.parser state
         c.parser.parse(file_id, false, false);
-        sm.close(file_id);
     }
     if (c.opts.trace_calls) {
-        i32 file_id = sm.addResource(c.auxPool.addStr("generator/c2_trace.c2", true),
-                                     C2_trace, elemsof(C2_trace) - 1);
+        i32 file_id = sm.addResource("generator/c2_trace.c2", C2_trace, elemsof(C2_trace) - 1);
         if (file_id == -1) return;   // note: error already printed
         console.debug("parsing %s", sm.getFileName(file_id));
         c.parser.parse(file_id, false, false);
-        sm.close(file_id);
     }
 
     u64 t1_end = utils.now();
@@ -554,10 +552,9 @@ fn void Compiler.free(Compiler* c) {
 
 fn void Compiler.add_source(void* arg, const char* name, string_buffer.Buf* content) {
     Compiler* c = arg;
-    u32 name2 = c.auxPool.addStr(name, false);
     u32 size;
     void *data = content.detach(&size);
-    i32 file_id = c.sm.addGenerated(name2, data, size);
+    i32 file_id = c.sm.addGenerated(name, data, size);
     c.parser.parse(file_id, false, true);
 }
 

--- a/compiler/compiler_libs.c2
+++ b/compiler/compiler_libs.c2
@@ -97,8 +97,7 @@ fn void Compiler.open_lib(Compiler* c, Component* comp) {
 
     char[file_utils.Max_path] fullname;
     if (!file_utils.make_path(fullname, elemsof(fullname), libdir, constants.manifest_name)) return;
-    u32 filename_idx = c.auxPool.addStr(fullname, false);
-    i32 file_id = c.sm.open(filename_idx, 0, false);
+    i32 file_id = c.sm.loadFile(fullname, 0);
     if (file_id == -1) return;
 
     u32 dirname = c.auxPool.addStr(libdir, false);
@@ -138,8 +137,6 @@ fn void Compiler.open_lib(Compiler* c, Component* comp) {
         // Note: for now only support dynamic lib dependencies here
         c.createComponent(depname, false, false);
     }
-
-    c.sm.close(file_id);
 }
 
 fn bool Compiler.has_component(Compiler* c, u32 name) {
@@ -171,16 +168,13 @@ fn void Compiler.parseExternalModule(void* arg, ast.Module* m) {
     if (!file_utils.make_path_ext(filename, elemsof(filename), c.current.getPath(), m.getName(), ".c2i"))
         return;
 
-    u32 name = c.auxPool.addStr(filename, false);
-    i32 file_id = c.sm.open(name, 0, false);
+    i32 file_id = c.sm.loadFile(filename, 0);
     if (file_id == -1) return;   // note: error already printed
 
     m.setLoaded();
     console.debug("parsing %s", filename);
     // on parse error, c.parser state has already been updated
     c.parser.parse(file_id, true, false);
-
-    c.sm.close(file_id);
 }
 
 // parse all used <modules>.c2i
@@ -250,12 +244,10 @@ fn void Compiler.showLibs(Compiler* c, string_buffer.Buf* out, const char* dirna
             ||  !file_utils.is_file(fullname))
                 continue;
 
-            u32 filename_idx = c.auxPool.addStr(fullname, false);
-
             out.indent(2);
             out.print("%-12s", name);
             {
-                i32 file_id = c.sm.open(filename_idx, 0, false);
+                i32 file_id = c.sm.loadFile(fullname, 0);
                 if (file_id == -1) return;
 
                 u32 name_idx = c.auxPool.addStr(name, true);
@@ -295,7 +287,6 @@ fn void Compiler.showLibs(Compiler* c, string_buffer.Buf* out, const char* dirna
                     }
                 }
 
-                c.sm.close(file_id);
                 out.color(color.Normal);
                 out.newline();
             }

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -338,7 +338,7 @@ fn void parse_opts(i32 argc, char** argv, compiler.Options* comp_opts, Options* 
                     opts.output_name = argv[i];
                     break;
                 case 'r':
-                    comp_opts.print_reports = true;
+                    comp_opts.print_reports += 1;
                     break;
                 case 's':
                     comp_opts.print_symbols = true;
@@ -465,9 +465,7 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
                           constants.recipe_name);
             exit(EXIT_FAILURE);
         }
-        u32 recipe_idx = c.auxPool.addStr(constants.recipe_name, false);
-
-        c.recipe_id = c.sm.open(recipe_idx, 0, false);
+        c.recipe_id = c.sm.loadFile(constants.recipe_name, 0);
         if (c.recipe_id == -1) exit(EXIT_FAILURE);
         if (!c.recipe.parse(c.recipe_id)) exit(EXIT_FAILURE);
         // keep c.recipe_id open so we can close source files in source_mgr

--- a/tools/c2loc.c2
+++ b/tools/c2loc.c2
@@ -86,7 +86,7 @@ fn void handle_target(build_target.Target* t, const char* name) {
     for (u32 i=0; i<t.numFiles(); i++) {
         const build_target.File* file = t.getFile(i);
         const char* filename = pool.idx2str(file.name);
-        i32 file_id = sm.open(file.name, 0, true);
+        i32 file_id = sm.loadFile(filename, 0);
         if (file_id == -1) return;
 
         const char* data = sm.get_content(file_id);
@@ -95,7 +95,6 @@ fn void handle_target(build_target.Target* t, const char* name) {
         if (verbose) {
             printf("  %6d %s\n", loc, filename);
         }
-        sm.close(file_id);
     }
     if (verbose) {
         printf("total %d loc\n", total_loc);
@@ -119,8 +118,7 @@ public fn i32 main(i32 argc, const char** argv)
     sm = source_mgr.create(pool);
     c2recipe.Recipe* recipe = c2recipe.create(sm, pool);
 
-    u32 recipe_idx = pool.addStr(constants.recipe_name, false);
-    i32 file_id = sm.open(recipe_idx, 0, false);
+    i32 file_id = sm.loadFile(constants.recipe_name, 0);
     if (file_id == -1) return -1;
     if (!recipe.parse(file_id)) return -1;
 
@@ -140,7 +138,6 @@ public fn i32 main(i32 argc, const char** argv)
     }
 
     recipe.free();
-    sm.close(file_id);
     sm.free();
 
     return 0;


### PR DESCRIPTION
* pass actual strings, let the source manager internalize in the astPool
* remove duplicate filename test