### PR TITLE
parser: reject reserved words as local names

### DIFF
--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -553,6 +553,10 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public) {
         if (!p.checkName(name, p.is_interface)) {
             p.error("a parameter name must start with a lower case character");
         }
+        if (p.tok.reserved) {
+            p.diags.error(loc, "reserved word '%s' cannot be used as parameter name",
+                          p.pool.idx2str(name));
+        }
         p.consumeToken();
     }
 

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -541,6 +541,10 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
 
         u32 name = p.tok.name_idx;
         SrcLoc loc = p.tok.loc;
+        if (p.tok.reserved) {
+            p.diags.error(loc, "reserved word '%s' cannot be used as local variable name",
+                          p.pool.idx2str(name));
+        }
         p.consumeToken();
 
         // TODO same as parseVarDecl()

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -124,6 +124,10 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
                 if (!p.checkName(name, p.is_interface)) {
                     p.error("a struct/union member name must start with a lower case character");
                 }
+                if (p.tok.reserved) {
+                    p.diags.error(loc, "reserved word '%s' cannot be used as struct/union member name",
+                                  p.pool.idx2str(name));
+                }
                 p.consumeToken();
             }
 
@@ -155,6 +159,10 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
 
                     if (!p.checkName(name, p.is_interface)) {
                         p.error("a struct/union member name must start with a lower case character");
+                    }
+                    if (p.tok.reserved) {
+                        p.diags.error(loc, "reserved word '%s' cannot be used as struct/union member name",
+                                      p.pool.idx2str(name));
                     }
                     p.consumeToken();
                 }

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -364,6 +364,10 @@ fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
             if (result.name_idx <= t.kwinfo.max_index) {
                 Kind k = t.kwinfo.indexes[result.name_idx];
                 assert(k != Kind.None);
+                if (k == Kind.Error) {
+                    result.reserved = true;
+                    return;
+                }
                 result.kind = k;    // turn into keyword
             }
             return;

--- a/parser/keywords.c2
+++ b/parser/keywords.c2
@@ -21,14 +21,29 @@ import token local;
 import string;
 
 public type Info struct {
-    // Note: should be big enough to hold all keywords (currently 350-ish)
-    Kind[512] indexes;
+    // Note: should be big enough to hold all keywords (4+436+216 with alignment)
+    Kind[656] indexes;
     u32 max_index;
 }
 
+const char[] C_keywords = "alignas alignof auto constexpr do double extern"
+    " float inline int long nullptr register restrict short signed static"
+    " thread_local typedef typeof typeof_unqual unsigned size_t ssize_t";
+
 public fn void Info.init(Info* info, string_pool.Pool* pool) {
     u32 idx = 0;
-    string.memset(info.indexes, 0, sizeof(info.indexes));
+    string.memset(info, 0, sizeof(Info));
+    const char *p = C_keywords;
+    while (*p) {
+        u32 len;
+        for (len = 0; p[len] && p[len] != ' '; len++)
+            continue;
+        idx = pool.add(p, len, true);
+        assert(idx < elemsof(info.indexes));
+        info.indexes[idx] = Error;
+        p += len;
+        while (*p == ' ') p++;
+    }
     for (Kind k = Kind.KW_bool; k <= Kind.KW_while; k++) {
         const char *s = k.str();
         idx = pool.add(s, string.strlen(s), true);

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -302,6 +302,7 @@ public type Token struct {
     bool done : 1;
     u8 radix : 2;   // number_radix.Radix: for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
     u8 raw : 1;     // for StringLiteral
+    bool reserved : 1;
     union {
         const char* error_msg;  // ERROR
         struct {           // StringLiteral, LineComment, BlockComment

--- a/test/parser/reserved_words.c2
+++ b/test/parser/reserved_words.c2
@@ -1,0 +1,83 @@
+// @warnings{no-unused}
+module test;
+
+type Foo struct {
+    u32 alignas;    // @error{reserved word 'alignas' cannot be used as struct/union member name}
+    u32 alignof;    // @error{reserved word 'alignof' cannot be used as struct/union member name}
+    u32 auto;       // @error{reserved word 'auto' cannot be used as struct/union member name}
+    u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as struct/union member name}
+    u32 do;         // @error{reserved word 'do' cannot be used as struct/union member name}
+    u32 double;     // @error{reserved word 'double' cannot be used as struct/union member name}
+    u32 extern;     // @error{reserved word 'extern' cannot be used as struct/union member name}
+    u32 float;      // @error{reserved word 'float' cannot be used as struct/union member name}
+    u32 inline;     // @error{reserved word 'inline' cannot be used as struct/union member name}
+    u32 int;        // @error{reserved word 'int' cannot be used as struct/union member name}
+    u32 long;       // @error{reserved word 'long' cannot be used as struct/union member name}
+    u32 nullptr;    // @error{reserved word 'nullptr' cannot be used as struct/union member name}
+    u32 register;   // @error{reserved word 'register' cannot be used as struct/union member name}
+    u32 restrict;   // @error{reserved word 'restrict' cannot be used as struct/union member name}
+    u32 short;      // @error{reserved word 'short' cannot be used as struct/union member name}
+    u32 signed;     // @error{reserved word 'signed' cannot be used as struct/union member name}
+    u32 static;     // @error{reserved word 'static' cannot be used as struct/union member name}
+    u32 thread_local;   // @error{reserved word 'thread_local' cannot be used as struct/union member name}
+    u32 typedef;    // @error{reserved word 'typedef' cannot be used as struct/union member name}
+    u32 typeof;     // @error{reserved word 'typeof' cannot be used as struct/union member name}
+    u32 typeof_unqual;  // @error{reserved word 'typeof_unqual' cannot be used as struct/union member name}
+    u32 unsigned;   // @error{reserved word 'unsigned' cannot be used as struct/union member name}
+    u32 size_t;     // @error{reserved word 'size_t' cannot be used as struct/union member name}
+    u32 ssize_t;    // @error{reserved word 'ssize_t' cannot be used as struct/union member name}
+}
+
+fn void foo(
+    u32 alignas,    // @error{reserved word 'alignas' cannot be used as parameter name}
+    u32 alignof,    // @error{reserved word 'alignof' cannot be used as parameter name}
+    u32 auto,       // @error{reserved word 'auto' cannot be used as parameter name}
+    u32 constexpr,  // @error{reserved word 'constexpr' cannot be used as parameter name}
+    u32 do,         // @error{reserved word 'do' cannot be used as parameter name}
+    u32 double,     // @error{reserved word 'double' cannot be used as parameter name}
+    u32 extern,     // @error{reserved word 'extern' cannot be used as parameter name}
+    u32 float,      // @error{reserved word 'float' cannot be used as parameter name}
+    u32 inline,     // @error{reserved word 'inline' cannot be used as parameter name}
+    u32 int,        // @error{reserved word 'int' cannot be used as parameter name}
+    u32 long,       // @error{reserved word 'long' cannot be used as parameter name}
+    u32 nullptr,    // @error{reserved word 'nullptr' cannot be used as parameter name}
+    u32 register,   // @error{reserved word 'register' cannot be used as parameter name}
+    u32 restrict,   // @error{reserved word 'restrict' cannot be used as parameter name}
+    u32 short,      // @error{reserved word 'short' cannot be used as parameter name}
+    u32 signed,     // @error{reserved word 'signed' cannot be used as parameter name}
+    u32 static,     // @error{reserved word 'static' cannot be used as parameter name}
+    u32 thread_local,   // @error{reserved word 'thread_local' cannot be used as parameter name}
+    u32 typedef,    // @error{reserved word 'typedef' cannot be used as parameter name}
+    u32 typeof,     // @error{reserved word 'typeof' cannot be used as parameter name}
+    u32 typeof_unqual,  // @error{reserved word 'typeof_unqual' cannot be used as parameter name}
+    u32 unsigned,   // @error{reserved word 'unsigned' cannot be used as parameter name}
+    u32 size_t,     // @error{reserved word 'size_t' cannot be used as parameter name}
+    u32 ssize_t,    // @error{reserved word 'ssize_t' cannot be used as parameter name}
+        ) {}
+
+fn void bar() {
+    u32 alignas;    // @error{reserved word 'alignas' cannot be used as local variable name}
+    u32 alignof;    // @error{reserved word 'alignof' cannot be used as local variable name}
+    u32 auto;       // @error{reserved word 'auto' cannot be used as local variable name}
+    u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as local variable name}
+    u32 do;         // @error{reserved word 'do' cannot be used as local variable name}
+    u32 double;     // @error{reserved word 'double' cannot be used as local variable name}
+    u32 extern;     // @error{reserved word 'extern' cannot be used as local variable name}
+    u32 float;      // @error{reserved word 'float' cannot be used as local variable name}
+    u32 inline;     // @error{reserved word 'inline' cannot be used as local variable name}
+    u32 int;        // @error{reserved word 'int' cannot be used as local variable name}
+    u32 long;       // @error{reserved word 'long' cannot be used as local variable name}
+    u32 nullptr;    // @error{reserved word 'nullptr' cannot be used as local variable name}
+    u32 register;   // @error{reserved word 'register' cannot be used as local variable name}
+    u32 restrict;   // @error{reserved word 'restrict' cannot be used as local variable name}
+    u32 short;      // @error{reserved word 'short' cannot be used as local variable name}
+    u32 signed;     // @error{reserved word 'signed' cannot be used as local variable name}
+    u32 static;     // @error{reserved word 'static' cannot be used as local variable name}
+    u32 thread_local;   // @error{reserved word 'thread_local' cannot be used as local variable name}
+    u32 typedef;    // @error{reserved word 'typedef' cannot be used as local variable name}
+    u32 typeof;     // @error{reserved word 'typeof' cannot be used as local variable name}
+    u32 typeof_unqual;  // @error{reserved word 'typeof_unqual' cannot be used as local variable name}
+    u32 unsigned;   // @error{reserved word 'unsigned' cannot be used as local variable name}
+    u32 size_t;     // @error{reserved word 'size_t' cannot be used as local variable name}
+    u32 ssize_t;    // @error{reserved word 'ssize_t' cannot be used as local variable name}
+}


### PR DESCRIPTION
* reject C keywords as function parameter and local variable names, as well
  as struct/union member names.
* add tests
