### PR TITLE
String-buffer: improve API, allow for non allocated string buffers

### DIFF
--- a/ast/array_type.c2
+++ b/ast/array_type.c2
@@ -91,7 +91,7 @@ fn void ArrayType.printPreName(const ArrayType* t, string_buffer.Buf* out) {
 fn void ArrayType.printPostName(const ArrayType* t, string_buffer.Buf* out) {
     out.add1('[');
     if (t.base.arrayTypeBits.is_incremental) {
-        out.add("+");
+        out.add1('+');
     } else {
         out.print("%d", t.size);
     }

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -444,7 +444,7 @@ fn void FunctionDecl.print(const FunctionDecl* d, string_buffer.Buf* out, u32 in
     bool valid_type = d.base.qt.isValid();
     d.base.printKind(out, indent, valid_type);
     if (!valid_type) {
-        out.add(" ");
+        out.space();
         d.rtype.print(out, true);
     }
 

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -332,7 +332,7 @@ public fn void MemberExpr.dump(const MemberExpr* m) @(unused) {
     if (m.hasExpr()) {
         out.indent(1);
         out.color(col_Value);
-        out.print("<expr>\n");
+        out.add("<expr>\n");
         Expr* e = m.getExprBase();
         e.print(out, 1);
     }

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -398,13 +398,12 @@ public fn const char* QualType.diagName(const QualType* qt) {
     char* msg = msgs[msg_id];
     msg_id = (msg_id + 1) % elemsof(msgs);
 
-    string_buffer.Buf* buf = string_buffer.create_static(128, false, msg);
+    string_buffer.Buf buf.init(msg, 128, false, false, 0);
     // TODO need to create another print?
 
     //buf.add1('\'');
-    qt.printInner(buf, true, true, true);
+    qt.printInner(&buf, true, true, true);
     //buf.add1('\'');
-    buf.free();
 
     return msg;
 }
@@ -415,10 +414,9 @@ public fn const char* QualType.diagNameBare(const QualType* qt) {
     char* msg = msgs[msg_id];
     msg_id = (msg_id + 1) % elemsof(msgs);
 
-    string_buffer.Buf* buf = string_buffer.create_static(128, false, msg);
+    string_buffer.Buf buf.init(msg, 128, false, false, 0);
 
-    qt.printInner(buf, true, false, true);
-    buf.free();
+    qt.printInner(&buf, true, false, true);
 
     return msg;
 }

--- a/ast/static_assert.c2
+++ b/ast/static_assert.c2
@@ -58,7 +58,7 @@ public fn Expr* StaticAssert.getRhs(const StaticAssert* d) {
 fn void StaticAssert.print(const StaticAssert* d, string_buffer.Buf* out, u32 indent) {
     out.indent(indent);
     out.color(col_Decl);
-    out.print("StaticAssert\n");
+    out.add("StaticAssert\n");
     d.lhs.print(out, indent + 1);
     d.rhs.print(out, indent + 1);
 }

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -179,10 +179,10 @@ public fn void TypeRefHolder.dump(const TypeRefHolder* h) @(unused) {
     string_buffer.Buf* out = string_buffer.create(128, useColor(), 2);
     r.print(out, false);
     for (u32 i=0; i<r.getNumArrays(); i++) {
-        out.add("[");
+        out.add1('[');
         Expr* size = h.arrays[i];
         if (size) h.arrays[i].printLiteral(out);
-        out.add("]");
+        out.add1(']');
     }
     out.color(col_Normal);
     stdio.puts(out.data());
@@ -544,10 +544,9 @@ public fn void TypeRef.dump_full(const TypeRef* r) @(unused) {
 
 public fn const char* TypeRef.diagName(const TypeRef* r) {
     local char[128] result;
-    string_buffer.Buf* out = string_buffer.create_static(128, false, result);
-    r.print(out, true);
-    stdio.puts(out.data());
-    out.free();
+    string_buffer.Buf buf.init(result, elemsof(result), false, false, 0);
+    r.print(&buf, true);
+    stdio.puts(result);
     return result;
 }
 

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -20,45 +20,84 @@ import stdarg local;
 import stdlib local;
 import string local;
 
-public type Buf struct @(opaque) {
+public type Buf struct {
     u32 capacity;
     u32 size_;
     char* data_;
-    u32 indent_step;
+    bool own;       // data_ should be freed
+    bool grow;      // data_ should be reallocated
+    bool truncated;
     bool colors;
-    bool own;       // note: does not work with resize
+    u32 indent_step;
 }
 
 static_assert(24, sizeof(Buf));
 
-public fn Buf* create(u32 capacity, bool colors, u32 indent_step) {
-    Buf* buf = malloc(sizeof(Buf));
-    buf.capacity = capacity;
-    buf.size_ = 0;
-    buf.data_ = malloc(capacity);
-    buf.indent_step = indent_step;
-    buf.colors = colors;
-    buf.own = true;
-    buf.data_[0] = 0;
-    return buf;
-}
-
-// Note: no growing possible
-public fn Buf* create_static(u32 capacity, bool colors, char* data) {
-    Buf* buf = malloc(sizeof(Buf));
+public fn Buf* Buf.init(Buf* buf, char* data, u32 capacity, bool grow, bool use_colors, u32 indent_step) {
+    assert(capacity);
     buf.capacity = capacity;
     buf.size_ = 0;
     buf.data_ = data;
-    buf.indent_step = 0;
-    buf.colors = colors;
     buf.own = false;
-    buf.data_[0] = 0;
+    buf.truncated = false;
+    buf.grow = grow;
+    buf.colors = use_colors;
+    buf.indent_step = indent_step;
+    if (!data) {
+        buf.data_ = malloc(capacity);
+        buf.own = true;
+    }
+    buf.data_[0] = '\0';
     return buf;
 }
 
-public fn void Buf.free(Buf* buf) {
+public fn Buf* create(u32 capacity, bool use_colors, u32 indent_step) {
+    Buf* buf = malloc(sizeof(Buf));
+    return buf.init(nil, capacity, true, use_colors, indent_step);
+}
+
+#if 0
+// Note: no growing possible
+public fn Buf* create_static(u32 capacity, bool use_colors, char* data) {
+    Buf* buf = malloc(sizeof(Buf));
+    return buf.init(data, capacity, false, use_colors, 0);
+}
+#endif
+
+fn void Buf.deinit(Buf* buf) {
     if (buf.own) free(buf.data_);
-    free(buf);
+    buf.data_ = nil;
+}
+
+public fn void Buf.free(Buf* buf) {
+    if (buf) {
+        buf.deinit();
+        free(buf);
+    }
+}
+
+fn bool Buf.extend(Buf* buf, u32 len) {
+    if (!buf.grow) {
+        buf.truncated = true;
+        return false;
+    }
+    u32 new_cap = buf.capacity * 2;
+    while (buf.size_ + len + 1 > new_cap) new_cap *= 2;
+    buf.capacity = new_cap;
+    char* data2 = malloc(new_cap);
+    memcpy(data2, buf.data_, buf.size_);
+    if (buf.own) free(buf.data_);
+    buf.data_ = data2;
+    buf.own = true;
+    return true;
+}
+
+public fn void Buf.setColors(Buf* buf, bool colors) @(unused) {
+    buf.colors = colors;
+}
+
+public fn void Buf.setIndent(Buf* buf, u32 indent_step) @(unused) {
+    buf.indent_step = indent_step;
 }
 
 public fn u32 Buf.size(const Buf* buf) {
@@ -92,6 +131,7 @@ public fn void* Buf.detach(Buf* buf, u32 *psize) {
 
 public fn void Buf.clear(Buf* buf) {
     buf.size_ = 0;
+    buf.truncated = false;
 }
 
 public fn void Buf.color(Buf* buf, const char* color) {
@@ -100,9 +140,7 @@ public fn void Buf.color(Buf* buf, const char* color) {
 
 public fn void Buf.add1(Buf* buf, char c) {
     if (buf.size_ + 2 > buf.capacity) {
-        u32 new_cap = buf.capacity * 2;
-        while (buf.size_ + 2 > new_cap) new_cap *= 2;
-        buf.resize(new_cap);
+        if (!buf.extend(1)) return;
     }
     buf.data_[buf.size_] = c;
     buf.size_ += 1;
@@ -116,9 +154,8 @@ public fn void Buf.add(Buf* buf, const char* text) {
 
 public fn void Buf.add2(Buf* buf, const char* text, u32 len) {
     if (buf.size_ + len + 1 > buf.capacity) {
-        u32 new_cap = buf.capacity * 2;
-        while (buf.size_ + len + 1 > new_cap) new_cap *= 2;
-        buf.resize(new_cap);
+        // truncate if resize fails.
+        if (!buf.extend(len)) len = buf.capacity - buf.size_ - 1;
     }
     memcpy(&buf.data_[buf.size_], text, len);
     buf.size_ += len;
@@ -136,9 +173,9 @@ public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) {
     va_list args;
     va_start(args, format);
     i32 len = vsnprintf(tmp, sizeof(tmp), format, args);
+    va_end(args);
     assert(len < sizeof(tmp));
     buf.add2(tmp, (u32)len);
-    va_end(args);
 }
 
 public fn void Buf.vprintf(Buf* buf, const char* format, va_list args) {
@@ -158,12 +195,11 @@ public fn void Buf.unindent(Buf* buf) {
 }
 
 public fn void Buf.indent(Buf* buf, u32 indent) {
-    if (indent == 0) return;
-
     indent *= buf.indent_step;
     if (buf.size_ + indent + 1 > buf.capacity) {
-        buf.resize(buf.capacity * 2);
+        if (!buf.extend(indent)) indent = buf.capacity - buf.size_ - 1;
     }
+    if (indent == 0) return;
 
     char* cur = buf.data_ + buf.size_;
     for (u32 i=0; i<indent; i++) cur[i] = ' ';
@@ -173,16 +209,6 @@ public fn void Buf.indent(Buf* buf, u32 indent) {
 
 public fn bool Buf.endsWith(const Buf* buf, char c) {
     return (buf.size_ && buf.data_[buf.size_-1] == c);
-}
-
-fn void Buf.resize(Buf* buf, u32 capacity) {
-    assert(buf.own);
-    buf.capacity = capacity;
-    //if ((len + 1) >= (newcap - buf.size_)) newcap += buf.size_ + len + 1;
-    char* data2 = malloc(buf.capacity);
-    memcpy(data2, buf.data_, buf.size_);
-    free(buf.data_);
-    buf.data_ = data2;
 }
 
 public fn u32 Buf.encodeBytes(Buf* buf, const char* p, u32 len, char sep) {
@@ -238,12 +264,10 @@ public fn u32 Buf.encodeBytes(Buf* buf, const char* p, u32 len, char sep) {
 const u8[16] ToHex = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', }
 
 public fn void Buf.encodeHex(Buf* buf, const u8* data, u32 len) @(unused) {
-    if (len == 0) return;
-    if (buf.size_ + len * 3 >= buf.capacity) {
-        u32 new_cap = buf.capacity * 2;
-        while (buf.size_ + len * 3 >= new_cap) new_cap *= 2;
-        buf.resize(new_cap);
+    if (buf.size_ + len * 3 + 1 > buf.capacity) {
+        if (!buf.extend(len * 3)) len = (buf.capacity - buf.size_ - 1) / 3;
     }
+    if (len == 0) return;
 
     char* cp = &buf.data_[buf.size_];
     for (u32 i=0; i<len; i++) {

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -417,7 +417,7 @@ fn void Generator.emitStruct(Generator* gen, string_buffer.Buf* out, Decl* d, u3
     }
 
     if (std.isGlobal()) {
-        out.add("}");
+        out.add1('}');
         if (std.isPacked()) out.add(" __attribute__((packed))");
         out.add(";\n\n");
     } else {
@@ -457,7 +457,7 @@ fn void Generator.emitFunctionType(Generator* gen, string_buffer.Buf* out, Decl*
         out.add("...");
     }
     if (num_params == 0 && !fd.isVariadic()) out.add("void");
-    out.add(")");
+    out.add1(')');
     if (d.hasAttrUnused()) out.add(" __attribute__((unused))");
     out.add(";\n\n");
 }

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -150,7 +150,7 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
     case Range:
         const RangeExpr* b = cast<RangeExpr*>(e);
         gen.emitExpr(out, b.getLHS());
-        out.print(" ... ");
+        out.add(" ... ");
         gen.emitExpr(out, b.getRHS());
         return;
     }

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -113,7 +113,7 @@ fn void Generator.createMakefile(Generator* gen,
     out.add("headers := $(wildcard *.h)\n\n");
 
     out.add("%.o: %.c\n");
-    out.print("\t\t$(CC) $(CFLAGS) -o $@ -c $<\n\n");
+    out.add("\t\t$(CC) $(CFLAGS) -o $@ -c $<\n\n");
 
     switch (gen.target_kind) {
     case Image:
@@ -154,7 +154,7 @@ fn void Generator.createMakefile(Generator* gen,
             }
             if (c.isStaticLib()) {
                 if (gen.targetInfo.sys == target_info.System.Darwin) {
-                    out.print(" -L/opt/homebrew/lib");
+                    out.add(" -L/opt/homebrew/lib");
                 } else {
                     out.print(" -L%s/%s", c.getPath(), triplet);
                 }

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -244,7 +244,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         source_mgr.Location loc = gen.sm.locate(s.getLoc());
         const char* funcname = gen.cur_function.asDecl().getFullName();
 
-        out.add("(");
+        out.add1('(');
         Expr* inner = a.getInner();
         gen.emitExpr(out, inner);
         out.print(") || c2_assert(\"%s\", %d, \"%s\", \"", loc.filename, loc.line, funcname);

--- a/generator/c2i/c2i_generator_expr.c2
+++ b/generator/c2i/c2i_generator_expr.c2
@@ -125,7 +125,7 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, const Expr* e
     case ExplicitCast:
         ExplicitCastExpr* c = cast<ExplicitCastExpr*>(e);
         if (c.getCStyle()) {
-            out.add("(");
+            out.add1('(');
             gen.emitTypePre(out, c.getDestType());
             out.add1(')');
             gen.emitExpr(out, c.getInner());
@@ -134,7 +134,7 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, const Expr* e
             gen.emitTypePre(out, c.getDestType());
             out.add(">(");
             gen.emitExpr(out, c.getInner());
-            out.add(")");
+            out.add1(')');
         }
         break;
     case ImplicitCast:
@@ -144,7 +144,7 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, const Expr* e
     case Range:
         const RangeExpr* b = cast<RangeExpr*>(e);
         gen.emitExpr(out, b.getLHS());
-        out.print(" ... ");
+        out.add(" ... ");
         gen.emitExpr(out, b.getRHS());
         break;
     }

--- a/generator/c2i/c2i_generator_stmt.c2
+++ b/generator/c2i/c2i_generator_stmt.c2
@@ -276,7 +276,7 @@ fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) 
 
     out.indent(indent);
     if (c.isDefault()) {
-        out.print("default:\n");
+        out.add("default:\n");
     } else {
         out.add("case ");
         u32 num_conds = c.getNumConds();
@@ -284,7 +284,7 @@ fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) 
             if (i) out.add(", ");
             gen.emitExpr(out, c.getCond(i));
         }
-        out.print(":\n");
+        out.add(":\n");
     }
 
     const u32 num_stmts = c.getNumStmts();

--- a/generator/ir/ir_generator_stmt.c2
+++ b/generator/ir/ir_generator_stmt.c2
@@ -327,7 +327,7 @@ fn void Generator.emitAssertStmt(Generator* gen, const Stmt* s) {
         gen.assert_generated = true;
     }
     out.print("\tcall $dprintf(l 2, l %s, l %s, l %s, l %s)\n", name, self, loc_str.ref, cond_str.ref);
-    out.print("\tcall $abort()\n");
+    out.add("\tcall $abort()\n");
 
     gen.startBlock(join_blk, join_blk);
 }


### PR DESCRIPTION
* add `init` function
* allow for clean truncation for non growable string buffers
* avoid memory allocation where possible