### PR TITLE
Analyser: improve error message, add note

### DIFF
--- a/analyser/scope.c2
+++ b/analyser/scope.c2
@@ -370,6 +370,7 @@ public fn ast.Decl* Scope.findSymbolInModule(Scope* s, ast.Module* mod, u32 name
     if (mod != s.mod) {
         if (!d.isPublic()) {
             s.diags.error(loc, "symbol '%s' is not public", d.getFullName());
+            s.diags.note(d.getLoc(), "symbol definition is here");
             return nil;
         }
         d.setUsedPublic();

--- a/test/expr/offsetof/offsetof_public.c2t
+++ b/test/expr/offsetof/offsetof_public.c2t
@@ -4,7 +4,7 @@ $warnings no-unused
 // @file{file1}
 module foo;
 
-type Foo struct {
+type Foo struct {  // @note{symbol definition is here}
     i32 x;
 }
 

--- a/test/module/using_private_var.c2t
+++ b/test/module/using_private_var.c2t
@@ -4,7 +4,7 @@
 // @file{file1}
 module foo;
 
-i32 n;
+i32 n;  // @note{symbol definition is here}
 
 // @file{file2}
 module bar;

--- a/test/template/function/non_public_template.c2t
+++ b/test/template/function/non_public_template.c2t
@@ -4,7 +4,7 @@
 // @file{file1}
 module file1;
 
-fn void test1(X arg1) template X {
+fn void test1(X arg1) template X {  // @note{symbol definition is here}
 }
 
 // @file{file2}

--- a/test/types/use_non_public_symbol_mod_prefix.c2t
+++ b/test/types/use_non_public_symbol_mod_prefix.c2t
@@ -4,7 +4,7 @@
 // @file{file1}
 module foo;
 
-const i32 Priv = 0;
+const i32 Priv = 0;  // @note{symbol definition is here}
 
 // @file{file2}
 module bar;

--- a/test/vars/use_non_public_symbol.c2t
+++ b/test/vars/use_non_public_symbol.c2t
@@ -4,7 +4,7 @@
 // @file{file1}
 module foo;
 
-const i32 Priv = 0;
+const i32 Priv = 0;  // @note{symbol definition is here}
 
 // @file{file2}
 module bar;


### PR DESCRIPTION
* add a note for the symbol definition when a non-public symbol is used this makes it much easier to add the missing `public` keyword