### PR TITLE
source-mgr: remove static buffer used in `source_mgr.loc2str()`

### DIFF
--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -277,13 +277,12 @@ public fn Location SourceMgr.locate(SourceMgr* sm, SrcLoc loc) {
     return l;
 }
 
-public fn const char* SourceMgr.loc2str(SourceMgr* sm, SrcLoc sloc) {
-    local char[256] tmp;
+public fn char* SourceMgr.loc2str(SourceMgr* sm, SrcLoc sloc, char* tmp, usize tmp_size) {
     Location loc = sm.locate(sloc);
-    tmp[0] = '-';
-    tmp[1] = '\0';
     if (loc.line_start) {
-        stdio.snprintf(tmp, elemsof(tmp), "%s:%d:%d", loc.filename, loc.line, loc.column);
+        stdio.snprintf(tmp, tmp_size, "%s:%d:%d", loc.filename, loc.line, loc.column);
+    } else {
+        stdio.snprintf(tmp, tmp_size, "-");
     }
     return tmp;
 }

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -195,13 +195,16 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(nore
     char[128] msg;
     va_list args;
     va_start(args, format);
-    vsnprintf(msg, sizeof(msg)-1, format, args);
+    vsnprintf(msg, sizeof(msg), format, args);
     va_end(args);
 
+    char[256] locstr;
+    p.sm.loc2str(p.token.loc, locstr, elemsof(locstr));
+
     if (color.useColor()) {
-        fprintf(stderr, "%s: %serror:%s %s\n", p.sm.loc2str(p.token.loc), color.Red, color.Normal, msg);
+        fprintf(stderr, "%s: %serror:%s %s\n", locstr, color.Red, color.Normal, msg);
     } else {
-        fprintf(stderr, "%s: error: %s\n", p.sm.loc2str(p.token.loc), msg);
+        fprintf(stderr, "%s: error: %s\n", locstr, msg);
     }
     longjmp(&p.jmpbuf, 1);
 }
@@ -209,7 +212,9 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(nore
 fn void Parser.consumeToken(Parser* p) {
     p.lex(&p.token);
 #if 0
-    printf("  %s   %s", p.sm.loc2str(p.token.loc), kind_names[p.token.kind]);
+    char[256] locstr;
+    p.sm.loc2str(p.token.loc, locstr, elemsof(locstr));
+    printf("  %s   %s", locstr, kind_names[p.token.kind]);
     switch (p.token.kind) {
     case PluginOptions:
     case Text:

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -798,7 +798,9 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
     out.print("%12s", tok.kind.str());
     if (tok.kind.isKeyword())
         out.color(color.Normal);
-    out.print("  %6d %s  ", tok.loc, p.sm.loc2str(tok.loc));
+    char[256] locstr;
+    p.sm.loc2str(tok.loc, locstr, elemsof(locstr));
+    out.print("  %6d %s  ", tok.loc, locstr);
 
     out.color(color.Cyan);
     switch (tok.kind) {


### PR DESCRIPTION
* pass destination buffer instead of using `local` buffer