### PR TITLE
Parser: simplify type parsing

### DIFF
--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -27,7 +27,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
 
         // check rtype for array-type
         TypeRef* rtype = fd.getReturnTypeRef();
-        if (rtype.getNumArrays()) {
+        if (rtype.isArray()) {
             ma.error(rtype.getLoc(), "functions are not allowed to return array types");
         }
 
@@ -37,7 +37,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
         for (u32 i=0; i<num_params; i++) {
             VarDecl* v = params[i];
             TypeRef* ref = v.getTypeRef();
-            if (ref.getNumArrays()) {
+            if (ref.isArray()) {
                 ma.error(ref.getLoc(), "array types are not allowed here");
             }
         }

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -157,7 +157,7 @@ fn QualType Analyser.analyseUserTypeRef(Analyser* ma, TypeRef* ref) {
     //TODO already checked in findSymbolInModule
     //if (!ma.scope.checkAccess(d, user.loc)) return QualType_Invalid;
 
-    bool full = (ref.getNumPointers() == 0);
+    bool full = !ref.isPointer();
     DeclCheckState state = d.getCheckState();
 
     if (full && state == DeclCheckState.InProgress) {

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -109,6 +109,11 @@ public fn void TypeRefHolder.setVolatile(TypeRefHolder* h) {
     r.flags.is_volatile = 1;
 }
 
+public fn bool TypeRefHolder.isPointer(const TypeRefHolder* h) {
+    TypeRef* r = cast<TypeRef*>(&h.ref);
+    return r.flags.num_ptrs != 0;
+}
+
 public fn void TypeRefHolder.addPointer(TypeRefHolder* h) {
     TypeRef* r = cast<TypeRef*>(&h.ref);
     assert(r.flags.num_ptrs != 3);
@@ -130,9 +135,16 @@ public fn u32 TypeRefHolder.getNumArrays(const TypeRefHolder* h) {
     return r.getNumArrays();
 }
 
+#if 0
 public fn u32 TypeRefHolder.getNumPointers(const TypeRefHolder* h) {
     TypeRef* r = cast<TypeRef*>(&h.ref);
     return r.getNumPointers();
+}
+#endif
+
+public fn bool TypeRefHolder.isArray(const TypeRefHolder* h) {
+    TypeRef* r = cast<TypeRef*>(&h.ref);
+    return r.flags.num_arrays != 0;
 }
 
 public fn void TypeRefHolder.addArray(TypeRefHolder* h, Expr* array) {
@@ -337,6 +349,10 @@ public fn SrcLoc TypeRef.getLoc(const TypeRef* r) {
     return r.loc;
 }
 
+public fn bool TypeRef.isPointer(const TypeRef* r) {
+    return r.flags.num_ptrs != 0;
+}
+
 public fn u32 TypeRef.getNumPointers(const TypeRef* r) {
     return r.flags.num_ptrs;
 }
@@ -367,6 +383,10 @@ public fn void TypeRef.setPrefix(TypeRef* r, Decl* d) {
 
 public fn void TypeRef.setUser(TypeRef* r, Decl* d) {
     r.refs[0].decl = d;
+}
+
+public fn bool TypeRef.isArray(const TypeRef* r) {
+    return r.flags.num_arrays != 0;
 }
 
 public fn u32 TypeRef.getNumArrays(const TypeRef* r) {

--- a/generator/c/dep_finder.c2
+++ b/generator/c/dep_finder.c2
@@ -120,11 +120,11 @@ fn void Finder.handleEnumType(Finder* s, EnumTypeDecl* etd) {
 fn void Finder.handleTypeRef(Finder* f, TypeRef* r) {
     const Decl* refDecl = r.getUserDecl();
     if (refDecl) {
-        if (r.getNumPointers() && refDecl.isStructType()) {
+        if (r.isPointer() && refDecl.isStructType()) {
             // if pointing to another struct, dont add dep, since we already have a forward decl
             // note: this also filters 'self' pointers
         } else {
-            f.onDep(refDecl, r.getNumPointers() == 0);
+            f.onDep(refDecl, !r.isPointer());
         }
     }
 

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -422,7 +422,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
 
     TypeRefHolder rtype.init();
     // Note: dont check arrays in this phase, but in Analyser
-    p.parseTypeSpecifier(&rtype, true, true);
+    p.parseTypeSpecifier(&rtype);
 
     p.expectIdentifier();
     u32 func_name = p.tok.name_idx;
@@ -544,7 +544,7 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public, bool accept_default
 
     TypeRefHolder ref.init();
     // Note: dont check arrays in this phase, but in Analyser
-    p.parseTypeSpecifier(&ref, true, true);
+    p.parseTypeSpecifier(&ref);
 
     u32 name = 0;
     SrcLoc loc = p.tok.loc;
@@ -577,51 +577,32 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public, bool accept_default
     return param;
 }
 
-fn void Parser.parseTypeSpecifier(Parser* p,
-                                  TypeRefHolder* ref,
-                                  bool allow_qualifier,
-                                  bool allow_array) {
-    p.parseSingleTypeSpecifier(ref, allow_qualifier);
-    p.parseOptionalArray(ref, QualType_Invalid, allow_array);
+fn void Parser.parseTypeSpecifier(Parser* p, TypeRefHolder* ref) {
+    p.parseSingleTypeSpecifier(ref);
+    p.parseOptionalArray(ref);
 }
 
-fn void Parser.parseOptionalArray(Parser* p,
-                                  TypeRefHolder* ref,
-                                  QualType base,
-                                  bool allow_array) {
-    if (p.tok.kind != Kind.LSquare) return;
+fn void Parser.parseOptionalArray(Parser* p, TypeRefHolder* ref) {
+    while (p.tok.kind == Kind.LSquare) {
+        if (ref.getNumArrays() == 3) p.error("arrays cannot have more than 3 dimensions");
+        if (ref.isIncrArray()) p.error("incremental arrays cannot have more than 1 dimension");
 
-    if (!allow_array) p.error("array types are not allowed here");
-
-    if (ref.getNumArrays() == 3) p.error("arrays cannot have more than 3 dimensions");
-    if (ref.isIncrArray()) p.error("incremental arrays cannot have more than 1 dimension");
-
-    p.consumeToken();
-
-    //bool is_incremental = false;
-
-    // NOTE: 'inverse' order, so char[2][4] -> 2 x ( 4 x char )
-
-    Expr* size = nil;
-    if (p.tok.kind == Kind.RSquare) {
-        // []
-        ref.addArray(nil);
         p.consumeToken();
-    } else if (p.tok.kind == Kind.Plus && p.tokenizer.lookahead(1, nil) == Kind.RSquare) {
-        // [+]
-        if (ref.getNumArrays()) p.error("incremental arrays cannot have more than 1 dimension");
-        p.consumeToken();
-        ref.setIncrArray();
-        //is_incremental = true;
-        p.expectAndConsume(Kind.RSquare);
-    } else {
-        // [<expr>]
-        size = p.parseExpr();
-        ref.addArray(size);
+
+        // NOTE: 'transposed' order, so char[2][4] -> 2 x ( 4 x char )
+        if (p.tok.kind == Kind.Plus && p.tokenizer.lookahead(1, nil) == Kind.RSquare) {
+            // [+]
+            if (ref.isArray()) p.error("incremental arrays cannot have more than 1 dimension");
+            p.consumeToken();
+            ref.setIncrArray();
+        } else {
+            // [<expr>?]
+            Expr* size = nil;
+            if (p.tok.kind != Kind.RSquare) size = p.parseExpr();
+            ref.addArray(size);
+        }
         p.expectAndConsume(Kind.RSquare);
     }
-
-    p.parseOptionalArray(ref, base, true);
 }
 
 fn void Parser.parseArrayEntry(Parser* p) {
@@ -642,7 +623,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
 
     bool need_semi = true;
     TypeRefHolder ref.init();
-    p.parseTypeSpecifier(&ref, true, true);
+    p.parseTypeSpecifier(&ref);
 
     for (;;) {
         p.expectIdentifier();
@@ -674,7 +655,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
         if (p.tok.kind != Kind.Comma)
             break;
         p.consumeToken();
-        if (ref.getNumPointers() || ref.getNumArrays())
+        if (ref.isPointer() || ref.isArray())
             p.error("pointer and array variables must be defined separately");
     }
     p.consumeSemicolon(need_semi);
@@ -742,12 +723,9 @@ fn BuiltinKind tokKindToBuiltinKind(token.Kind kind) {
     return Tok2builtin[kind - Kind.KW_bool];
 }
 
-fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref, bool allow_qualifier) {
-    if (allow_qualifier) {
-        // TODO give error if we get a qualifier
-        u32 type_qualifier = p.parseOptionalTypeQualifier();
-        ref.setQualifiers(type_qualifier);
-    }
+fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref) {
+    u32 type_qualifier = p.parseOptionalTypeQualifier();
+    ref.setQualifiers(type_qualifier);
 
     Kind kind = p.tok.kind;
 

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -369,7 +369,7 @@ fn Expr* Parser.parsePostfixExprSuffix(Parser* p, Expr* lhs, bool couldBeTemplat
                 p.consumeToken();
 
                 TypeRefHolder ref.init();
-                p.parseTypeSpecifier(&ref, false, false);
+                p.parseTypeSpecifier(&ref);
 
                 p.expectAndConsume(Kind.Greater);
                 if (p.tok.kind != Kind.LParen) {
@@ -522,17 +522,16 @@ fn Expr* Parser.parseParenExpr(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
 
-    bool has_brackets = false;
-    if (p.parseAsCastType(0, Kind.RParen, &has_brackets)) {
+    if (p.parseAsCastType(0, Kind.RParen)) {
         TypeRefHolder ref.init();
-        p.parseTypeSpecifier(&ref, true, has_brackets);
+        p.parseTypeSpecifier(&ref);
         p.expectAndConsume(Kind.RParen);
         if (p.tok.kind == Kind.LBrace) {
             // compound literal
             p.error("Compound literals are not supported");
         } else {
             // C cast expression
-            if (has_brackets) p.error("array types are not allowed here");
+            if (ref.isArray()) p.error("array types are not allowed here");
             Expr* expr = p.parseCastExpr(false, false);
             u32 src_len = p.prev_loc - loc;
             return p.builder.actOnExplicitCast(loc, src_len, &ref, expr, true);
@@ -550,27 +549,34 @@ fn bool Parser.isTemplateFunctionCall(Parser* p) {
     assert(p.tok.kind == Kind.Less);
     // check if tokens after < could be type, followed by >(
     // longest token line could be mod.type**
-    u32 ahead = 1;
 
-    // fast path, just for builtintype
-    Kind kind = p.tokenizer.lookahead(ahead, nil);
-    if (kind.isBuiltinType()) return true;
+    // type must start with either a qualifier or an identifier
+    //   or a builtin not followed by a dot.
+    Kind kind = p.tokenizer.lookahead(1, nil);
+    if (kind != Kind.Identifier) {
+        if (kind.isQualifier()) return true;
+        return kind.isBuiltinType() && (p.tokenizer.lookahead(2, nil) != Kind.Dot);
+    }
 
-    // TODO keep mini state machine: 0 initial, 1-> seen id (dot changes nothing), 3-> * seen. if id in 3, return false (a*b)
-    while (ahead < 8) {
+    u32 stars = 0;
+    for (u32 ahead = 2; ahead < 8; ahead++) {
         switch (p.tokenizer.lookahead(ahead, nil)) {
         case Identifier:
+            if (stars) return false;
+            break;
         case Star:
+            stars++;
+            break;
         case Dot:
             break;
         case Greater:
             return p.tokenizer.lookahead(ahead+1, nil) == Kind.LParen;
         case KW_const:
+        case KW_volatile:
             return true;
         default:
             return false;
         }
-        ahead++;
     }
     return false;
 }
@@ -582,32 +588,16 @@ fn Expr* Parser.parseSizeof(Parser* p) {
     p.expectAndConsume(Kind.LParen);
 
     Expr* res = nil;
-    bool has_brackets = false;
-    SrcLoc type_loc = p.tok.loc;
-    if (p.parseAsType(&has_brackets)) {
-        if (has_brackets) {
-            while (p.tok.kind != Kind.LSquare) p.consumeToken();
-            p.error("arrays or subscripts expressions are not allowed inside a sizeof expression");
-        }
+    if (p.parseAsType()) {
+        // argument is unambiguously a type
+        SrcLoc type_loc = p.tok.loc;
         TypeRefHolder ref.init();
-        p.parseTypeSpecifier(&ref, false, true);
+        p.parseTypeSpecifier(&ref);
         u32 src_len = p.prev_loc - type_loc;
         res = p.builder.actOnTypeExpr(type_loc, src_len, &ref);
-    } else { // parse as variable
-        if (p.tok.kind != Kind.Identifier) {
-            p.error("expect a type or variable name");
-        }
-        res = p.parseFullIdentifier();
-
-        // parse optional array indexes (like array[0])
-        while (p.tok.kind == Kind.LSquare) {
-            SrcLoc loc1 = p.tok.loc;
-            p.consumeToken();
-            Expr* idx = p.parseExpr();
-            u32 src_len = p.tok.loc + 1 - loc1;
-            p.expectAndConsume(Kind.RSquare);
-            res = p.builder.actOnArraySubscriptExpr(loc1, src_len, res, idx);
-        }
+    } else {
+        // argument is an expression or an ambiguous name, parse as expression
+        res = p.parseExpr();
     }
 
     u32 src_len = p.tok.loc + 1 - loc;
@@ -706,8 +696,10 @@ fn Expr* Parser.parseExplicitCastExpr(Parser* p) {
 
     p.expectAndConsume(Kind.Less);
     TypeRefHolder ref.init();
-    p.parseTypeSpecifier(&ref, true, false);
+    p.parseTypeSpecifier(&ref);
     p.expectAndConsume(Kind.Greater);
+
+    if (ref.isArray()) p.error("array types are not allowed here");
 
     p.expectAndConsume(Kind.LParen);
     Expr* expr = p.parseExpr();
@@ -812,34 +804,52 @@ fn Expr* Parser.parseFullIdentifier(Parser* p) {
     test.Foo.a   - error (need instantiation)
     (test.)a*    - type (but will give error later)
 */
-fn bool Parser.parseAsType(Parser* p, bool* has_brackets) {
-    const Kind kind = p.tok.kind;
-    if (kind.isQualifier()) return true;
-    if (p.tok.kind != Kind.Identifier) {
-        if (kind.isBuiltinType())
-            return (p.tokenizer.lookahead(1, nil) != Kind.Dot);
+fn bool Parser.parseAsType(Parser* p) {
+    // type must start with either a qualifier or an identifier
+    //   or a builtin not followed by a dot.
+    Kind kind = p.tok.kind;
+    if (kind != Kind.Identifier) {
+        if (kind.isQualifier()) return true;
+        return kind.isBuiltinType() && (p.tokenizer.lookahead(1, nil) != Kind.Dot);
+    }
+    Token t2 = p.tok;
+    // parse potential member expression
+    u32 ahead = 1;
+    while (p.tokenizer.lookahead(ahead, nil) == Kind.Dot) {
+        if (p.tokenizer.lookahead(ahead + 1, &t2) != Kind.Identifier)
+            return false;
+        ahead += 2;
     }
 
-    u32 lookahead = 1;
-    while (1) {
-        switch (p.tokenizer.lookahead(lookahead, nil)) {
-        case Identifier:
-            break;
-        case Star:
-            return true;
-        case Dot:
-            break;
+    i32 stars = 0;
+    for (;; ahead++) {
+        switch (p.tokenizer.lookahead(ahead, nil)) {
+        case RParen:
+            if (stars) return true;
+            // ambiguous: could be a global constant or a type name
+            return false;   // resolve in analyser
         case LSquare:
-            *has_brackets = true;
-            return true;
+            if (stars) return true;  // sizeof(MyType*[...])
+            // if identifier is not uppercase, argument is not a type
+            if (!isupper(*p.pool.idx2str(t2.name_idx))) return false;
+            // ambiguous: could be a global constant element or an array type
+            return true;    // assume array type
+        case Star:
+            stars++;
+            break;
         case Less:
+            // if identifier is not uppercase, argument is not a type
+            if (!isupper(*p.pool.idx2str(t2.name_idx))) return false;
+            // ambiguous: could be a parametric type or a comparison with a global constant
+            return true;   // assume parametric type
+        case KW_const:
+        case KW_volatile:
             return true;
         default:
             return false;
         }
-        lookahead++;
     }
-
+    // never reached
     return false;
 }
 
@@ -852,31 +862,28 @@ fn bool Parser.parseAsType(Parser* p, bool* has_brackets) {
    Array syntax is rejected if `brackets` is nil, otherwise `*brackets` is
    set if an array type is parsed.
 */
-fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok, bool* brackets) {
+fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
     Token t2 = p.tok;
-    bool is_lower = false;
     bool ambiguous = true;
     for (;;) {
         if (ahead) p.tokenizer.lookahead(ahead, &t2);
         ahead++;
         Kind kind = t2.kind;
-        if (kind.isQualifier()) {
-            // const and volatile qualifiers must introduce a type
-            ambiguous = false;
-            continue;
-        }
         if (kind.isBuiltinType()) {
             // builtin type, non ambiguous
             ambiguous = false;
             break;
+        }
+        if (kind.isQualifier()) {
+            // const and volatile qualifiers must introduce a type
+            ambiguous = false;
+            continue;
         }
         // must have an identifier or a member expression
         // but still potentially ambiguous.
         if (kind != Kind.Identifier)
             return 0;
         for (;;) {
-            // is_lower is true if the last identifier starts with a lowercase letter
-            is_lower = islower(p.pool.idx2str(t2.name_idx)[0]);
             if (p.tokenizer.lookahead(ahead, nil) != Kind.Dot)
                 break;
             ahead++;
@@ -930,7 +937,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok, bool* bracke
             case Star:       // ambiguous: (func)*b
                 // for ambiguous combinations, rely on identifier case
                 // (A)(...) is a cast, (a)(...) is a function call
-                if (is_lower)
+                if (!isupper(p.pool.idx2str(t2.name_idx)[0]))
                     return 0;
                 return ahead;
             default:
@@ -938,9 +945,6 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok, bool* bracke
             }
             return 0;
         case LSquare:
-            if (!brackets)
-                return 0;
-            *brackets = true;
             // skip expression
             ahead = p.skipArray(ahead);
             if (!ahead)
@@ -949,7 +953,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok, bool* bracke
             break;
         case Less:
             // parametric type X<type>
-            ahead = p.parseAsCastType(ahead, Kind.Greater, nil);
+            ahead = p.parseAsCastType(ahead, Kind.Greater);
             if (!ahead)
                 return 0;
             stars = 0;

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -534,7 +534,7 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
 
     bool need_semi = true;
     TypeRefHolder ref.init();
-    p.parseTypeSpecifier(&ref, true, true);
+    p.parseTypeSpecifier(&ref);
 
     for (;;) {
         p.expectIdentifier();
@@ -596,7 +596,7 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
         p.consumeToken();
         if (isCondition)
             p.error("cannot define multiple variables in a condition");
-        if (ref.getNumPointers() || ref.getNumArrays())
+        if (ref.isPointer() || ref.isArray())
             p.error("pointer and array variables must be defined separately");
         if (num_decls >= elemsof(decls))
             p.error("too many variables defined in a single statement");

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -55,7 +55,7 @@ fn void Parser.parseFunctionType(Parser* p, u32 name, SrcLoc loc, bool is_public
     p.consumeToken(); // fn
 
     TypeRefHolder rtype.init();
-    p.parseSingleTypeSpecifier(&rtype, true);
+    p.parseSingleTypeSpecifier(&rtype);
 
     DeclList params.init();
 
@@ -156,7 +156,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             p.consumeToken(); // fn
 
             TypeRefHolder rtype.init();
-            p.parseSingleTypeSpecifier(&rtype, true);
+            p.parseSingleTypeSpecifier(&rtype);
 
             DeclList params.init();
 
@@ -185,7 +185,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             goto semi_colon;
         }
         TypeRefHolder ref.init();
-        p.parseTypeSpecifier(&ref, true, true);
+        p.parseTypeSpecifier(&ref);
 
         for (;;) {
             u32 name = 0;
@@ -211,7 +211,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             if (p.tok.kind != Kind.Comma)
                 break;
             p.consumeToken();
-            if (ref.getNumPointers() || ref.getNumArrays())
+            if (ref.isPointer() || ref.isArray())
                 p.error("pointer and array members must be defined separately");
         }
 semi_colon:
@@ -320,7 +320,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
 
 fn void Parser.parseAliasType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
     TypeRefHolder ref.init();
-    p.parseTypeSpecifier(&ref, true, true);
+    p.parseTypeSpecifier(&ref);
 
     Decl* d = p.builder.actOnAliasType(name, loc, is_public, &ref);
     p.parseOptionalAttributes();

--- a/test/builtins/sizeof_ok.c2
+++ b/test/builtins/sizeof_ok.c2
@@ -1,0 +1,11 @@
+module test;
+
+static_assert(sizeof(i8), sizeof(u8));
+static_assert(sizeof(i16), sizeof(u16));
+static_assert(sizeof(i32), sizeof(u32));
+static_assert(sizeof(i64), sizeof(u64));
+static_assert(sizeof(isize), sizeof(usize));
+static_assert(sizeof(void*), sizeof(usize));
+static_assert(sizeof(const char*), sizeof(char*));
+static_assert(sizeof(volatile char*), sizeof(char*));
+static_assert(sizeof(char*), sizeof(void*));

--- a/test/expr/sizeof/array.c2
+++ b/test/expr/sizeof/array.c2
@@ -3,5 +3,5 @@ module test;
 
 type Handle struct { i32 x; }
 
-i32 f = sizeof(Handle[3]);  // @error{arrays or subscripts expressions are not allowed inside a sizeof expression}
+static_assert(sizeof(Handle[3]), 12);
 

--- a/test/parser/sizeof_addrof.c2
+++ b/test/parser/sizeof_addrof.c2
@@ -1,8 +1,18 @@
 // @warnings{no-unused}
 module test;
 
+i32 g = 10;
+static_assert(sizeof(&g), sizeof(usize));
+
+i32[10] arr;
+static_assert(sizeof(i32[10]), 40);
+static_assert(sizeof(arr), 40);
+static_assert(sizeof(arr[0]), 4);
+static_assert(sizeof(*arr), 4);
+static_assert(sizeof(arr) / sizeof(arr[0]), 10);
+
 fn void test1() {
     i32 a = 10;
-    i32 c = sizeof(&a);  // @error{expect a type or variable name}
+    i32 c = sizeof(&a);
 }
 


### PR DESCRIPTION
* simplify `Parser.parseTypeSpecifier`: always accept qualifier and arrays
* simplify `Parser.parseSingleTypeSpecifier()`: always accept qualifier
* simplify `Parser.parseOptionalArray()`: always accept arrays, remove base and recursion
* simplify `Parser.parseAsType()`, `Parser.parseAsCastType()`, `Parser.isTemplateFunctionCall()`: remove `has_brackets` handling
* add `isArray()` and `isPointer()` type functions for `TypeRef` and `TypeRefHolder` for clarity and flexibility
* this fixes some problems:
  * `sizeof(const char*)` was rejected.
  * `a < i32.max` was interpreted as a template function call
  * `a < b * c > (d + 1)` was interpreted as a template function call (wrong error)
  * `sizeof(Handle[3])` now works for array types