### PR TITLE
Analyser: improve function flow analysis

### DIFF
--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -268,6 +268,7 @@ fn QualType Analyser.analyseConditionalOperator(Analyser* ma, Expr** e_ptr) {
     assert(lcanon.isValid());
     assert(rcanon.isValid());
 
+    // TODO: refine this by selecting branch depending on cond value
     if (cond.getCond().isCtv()) e.combineConstantFlags(cond.getLHS(), cond.getRHS());
 
     u8 res = CondOpTable[lcanon.getKind()][rcanon.getKind()];

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -204,7 +204,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             ma.error(fd.asDecl().getLoc(), "pure functions cannot be variadic");
             return;
         }
-        if (!fd.hasReturn()) {
+        if (rtype.isVoid()) {
             ma.error(rtype.getLoc(), "pure functions must return a value");
             return;
         }
@@ -213,7 +213,6 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             ma.error(v.asDecl().getLoc(), "pure functions cannot have auto-arguments");
             return;
         }
-        // must have body (even in libs)
     }
 }
 
@@ -244,12 +243,12 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
     ma.has_error = false;
     ma.labels.reset();
 
-    ma.analyseCompoundStmt(body);
+    FlowBits flow = ma.analyseCompoundStmt(body);
 
     // check for return stmt if function returns a value
     QualType rtype = fd.getRType();
     if (!rtype.isVoid()) {
-        if (!hasReturn((Stmt*)body)) {
+        if (flow & FlowNext) {
             // error loc is closing brace of the function body
             ma.error(body.getEndLoc() - 1, "control reaches end of non-void function");
         }

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -16,108 +16,104 @@
 module module_analyser;
 
 import ast local;
+import ctv_analyser;
 import label_vector local;
 import scope;
 
-fn bool hasReturn(const Stmt* s) {
-
-    switch (s.getKind()) {
-        case Return:
-            return true;
-        case If:
-            const IfStmt* i = (IfStmt*)s;
-            if (!hasReturn(i.getThen())) return false;
-            const Stmt* e = i.getElse();
-            if (e && hasReturn(e)) return true;
-            break;
-        case While:
-            // TODO only allow while(true/1), no breaks and only return
-            break;
-        case For:
-            // TODO
-            break;
-        case Switch:
-            // TODO
-            break;
-        case Label:
-            // TODO
-            const LabelStmt* ls = (LabelStmt*)s;
-            const Stmt* lss = ls.getStmt();
-            if (!lss) return false;
-            return hasReturn(lss);
-        case Compound:
-            const CompoundStmt* cs = (CompoundStmt*)s;
-            const Stmt* last = cs.getLastStmt();
-            if (!last) return false;
-            return hasReturn(last);
-        default:
-            break;
-    }
-
-    return false;
+type Flow enum u8 {
+    Next,
+    Return,
+    Break,
+    Continue,
+    Goto,
+    NoReturn,
+    Error,
 }
 
-fn void Analyser.analyseStmt(Analyser* ma, Stmt* s, bool checkEffect) {
-    if (ma.scope.isUnreachable() && s.getKind() != StmtKind.Label) {
-        ma.warn(s.getLoc(), "unreachable code");
+type FlowBits u32;
+
+const FlowBits FlowNext      = 1 << Flow.Next;
+const FlowBits FlowReturn    = 1 << Flow.Return;
+const FlowBits FlowBreak     = 1 << Flow.Break;
+const FlowBits FlowContinue  = 1 << Flow.Continue;
+const FlowBits FlowGoto      = 1 << Flow.Goto;
+const FlowBits FlowNoReturn  = 1 << Flow.NoReturn;
+const FlowBits FlowError     = 1 << Flow.Error;
+
+fn Expr* getCondExpr(const Stmt* cond) {
+    if (cond) {
+        if (cond.isExpr()) return cast<Expr*>(cond);
+        if (cond.isDecl()) return cast<DeclStmt*>(cond).getDecl(0).getInit();
+    }
+    return nil;
+}
+
+fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt* s, bool checkEffect) {
+    FlowBits flow = 0;
+    if (ma.scope.isUnreachable()) {
+        if (s.getKind() != StmtKind.Label && !ma.warnings.no_unreachable_code) {
+            ma.warn(s.getLoc(), "unreachable code");
+        }
+        ma.scope.setReachable();  // prevent multiple warnings
     }
     switch (s.getKind()) {
     case Return:
         ma.analyseReturnStmt(s);
-        ma.scope.setUnreachable();  // Note: can have label after that is reachable!
-        break;
+        ma.scope.setUnreachable();
+        return FlowReturn;
     case Expr:
         // TODO need a different set, since this one uses the Stack of Globals
         ma.analyseExpr((Expr**)&s, false, 0);
         Expr* e = (Expr*)s;
         if (checkEffect && !e.hasEffect()) ma.errorRange(e.getLoc(), e.getRange(), "expression without effect");
-        break;
+        return FlowNext;  // TODO: check for call to noreturn function
     case If:
-        ma.analyseIfStmt(s);
+        flow = ma.analyseIfStmt(s);
         break;
     case While:
-        ma.analyseWhileStmt(s);
+        flow = ma.analyseWhileStmt(s);
         break;
     case For:
-        ma.analyseForStmt(s);
+        flow = ma.analyseForStmt(s);
         break;
     case Switch:
-        ma.analyseSwitchStmt(s);
+        flow = ma.analyseSwitchStmt(s);
         break;
     case Break:
         ma.analyseBreakStmt(s);
         ma.scope.setUnreachable();
-        break;
+        return FlowBreak;
     case Continue:
         ma.analyseContinueStmt(s);
         ma.scope.setUnreachable();
-        break;
+        return FlowContinue;
     case Fallthrough:
         ma.analyseFallthroughStmt(s);
-        break;
+        return FlowNext;
     case Label:
-        ma.scope.setReachable();
-        ma.analyseLabelStmt(s);
+        flow = ma.analyseLabelStmt(s);
         break;
     case Goto:
         ma.analyseGotoStmt(s);
         ma.scope.setUnreachable();
-        break;
+        return FlowGoto;
     case Compound:
         ma.scope.enter(scope.Decl);
-        ma.analyseCompoundStmt((CompoundStmt*)s);
+        flow = ma.analyseCompoundStmt((CompoundStmt*)s);
         ma.scope.exit(ma.has_error);
         break;
     case Decl:
         ma.analyseDeclStmt(s);
-        break;
+        return FlowNext;
     case Asm:
         ma.analyseAsmStmt(s);
-        break;
+        return FlowNext;
     case Assert:
         ma.analyseAssertStmt(s);
-        break;
+        return FlowNext;
     }
+    if (!(flow & FlowNext)) ma.scope.setUnreachable();
+    return flow;
 }
 
 fn void Analyser.analyseBreakStmt(Analyser* ma, Stmt* s) {
@@ -137,7 +133,7 @@ fn void Analyser.analyseFallthroughStmt(Analyser* ma, Stmt* s) {
     ma.error(s.getLoc(), "'fallthrough' statement cannot be used here");
 }
 
-fn void Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {
     LabelStmt* ls = (LabelStmt*)s;
     u32 name = ls.getNameIdx();
 
@@ -157,7 +153,8 @@ fn void Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {
     }
 
     Stmt* lss = ls.getStmt();
-    if (lss) ma.analyseStmt(lss, true);
+    if (!lss) return FlowNext;
+    return ma.analyseStmt(lss, true);
 }
 
 fn void Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {
@@ -174,14 +171,18 @@ fn void Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {
     }
 }
 
-fn void Analyser.analyseCompoundStmt(Analyser* ma, CompoundStmt* c) {
+fn FlowBits Analyser.analyseCompoundStmt(Analyser* ma, CompoundStmt* c) {
+    FlowBits flow = 0;
+    FlowBits flow2 = FlowNext;
     u32 count = c.getCount();
     Stmt** stmts = c.getStmts();
     for (u32 i=0; i<count; i++) {
         Stmt* s = stmts[i];
-        ma.analyseStmt(s, true);
-        if (ma.has_error) break;
+        flow2 = ma.analyseStmt(s, true);
+        flow |= flow2 & (FlowReturn | FlowBreak | FlowContinue | FlowGoto | FlowNoReturn | FlowError);
+        if (ma.has_error) return flow;
     }
+    return flow | flow2; // return FlowNext if last statement has FlowNext or empty block
 }
 
 fn QualType Analyser.analyseCondition(Analyser* ma, Stmt** s_ptr, bool check_assign) {
@@ -212,28 +213,34 @@ fn QualType Analyser.analyseCondition(Analyser* ma, Stmt** s_ptr, bool check_ass
     return qt;
 }
 
-fn void Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
+    FlowBits flow = FlowNext;
     IfStmt* i = (IfStmt*)s;
     ma.scope.enter(scope.Decl);
 
     ma.analyseCondition(i.getCond2(), true);
     if (ma.has_error) goto done;
+    // TODO: handle constant conditions
 
     ma.scope.enter(scope.Decl);
-    ma.analyseStmt(i.getThen(), true);
+    flow = ma.analyseStmt(i.getThen(), true);
     ma.scope.exit(ma.has_error);
 
+    FlowBits flow2 = FlowNext;
     Stmt* else_ = i.getElse();
     if (else_) {
         ma.scope.enter(scope.Decl);
-        ma.analyseStmt(else_, true);
+        flow2 = ma.analyseStmt(else_, true);
         ma.scope.exit(ma.has_error);
     }
+    flow |= flow2;
 done:
     ma.scope.exit(ma.has_error);
+    return flow;
 }
 
-fn void Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
+    FlowBits flow = FlowNext;
     ForStmt* f = (ForStmt*)s;
 
     ma.scope.enter(scope.Break | scope.Continue | scope.Decl | scope.Control);
@@ -248,6 +255,16 @@ fn void Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
         QualType qt = ma.analyseExpr(cond, true, RHS);
         if (qt.isInvalid()) goto done;
         ma.checker.check(builtins[BuiltinKind.Bool], qt, cond, (*cond).getLoc());
+        if ((*cond).isCtv()) {
+            Value v = ctv_analyser.get_value((*cond));
+            if (v.isZero()) {
+                // TODO: body is never reached
+            } else {
+                flow = 0;
+            }
+        }
+    } else {
+        flow = 0;
     }
 
     Expr** cont = f.getCont2();
@@ -256,22 +273,40 @@ fn void Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
         if (qt.isInvalid()) goto done;
     }
 
-    ma.analyseStmt(f.getBody(), true);
+    FlowBits flow2 = ma.analyseStmt(f.getBody(), true);
+    flow |= flow2 & (FlowReturn | FlowGoto | FlowNoReturn | FlowError);
+    if (flow2 & FlowBreak) flow |= FlowNext;
 done:
     ma.scope.exit(ma.has_error);
+    return flow;
 }
 
-fn void Analyser.analyseWhileStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseWhileStmt(Analyser* ma, Stmt* s) {
+    FlowBits flow = FlowNext;
     WhileStmt* w = (WhileStmt*)s;
+
     ma.scope.enter(scope.Decl);
     ma.analyseCondition(w.getCond2(), true);
     if (ma.has_error) goto done;
 
+    Expr* cond = getCondExpr(w.getCond());
+    if (cond.isCtv()) {
+        Value v = ctv_analyser.get_value(cond);
+        if (v.isZero()) {
+            // TODO: body is never reached
+        } else {
+            flow = 0;
+        }
+    }
+
     ma.scope.enter(scope.Break | scope.Continue | scope.Decl | scope.Control);
-    ma.analyseStmt(w.getBody(), true);
+    FlowBits flow2 = ma.analyseStmt(w.getBody(), true);
     ma.scope.exit(ma.has_error);
+    flow |= flow2 & (FlowReturn | FlowGoto | FlowNoReturn | FlowError);
+    if (flow2 & FlowBreak) flow |= FlowNext;
 done:
     ma.scope.exit(ma.has_error);
+    return flow;
 }
 
 fn QualType Analyser.analyseDeclStmt(Analyser* ma, Stmt* s) {

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -23,7 +23,8 @@ import scope;
 import string_buffer;
 import string;
 
-fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
+    FlowBits flow = 0;
     SwitchStmt* sw = (SwitchStmt*)s;
 
     ma.scope.enter(scope.Decl);
@@ -35,7 +36,7 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
     QualType ct = ma.analyseExpr(sw.getCond2(), true, RHS);
     if (ct.isInvalid()) {
         ma.scope.exit(ma.has_error);
-        return;
+        return FlowNext | FlowError;
     }
 
     bool isCharPtr = ct.isCharPointer();
@@ -56,14 +57,13 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
     if (numCases == 0) {
         ma.error(s.getLoc(), "switch without cases or default");
         ma.scope.exit(ma.has_error);
-        return;
+        return FlowNext | FlowError;
     }
 
     SwitchCase* defaultCase = nil;
 
     init_checker.Checker* checker = ma.getInitChecker();
 
-    bool ok = true;
     for (u32 i = 0; i < numCases; i++) {
         SwitchCase* c = cases[i];
         bool is_last = (i+1 == numCases);
@@ -71,29 +71,32 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
         if (c.isDefault()) {
             if (defaultCase) {
                 ma.error(c.getLoc(), "multiple default labels");
-                ok = false;
+                flow |= FlowError;
             } else
             if (!is_last) {
                 ma.error(c.getLoc(), "default case must be last in switch");
-                ok = false;
+                flow |= FlowError;
             }
             defaultCase = c;
         }
 
         ma.scope.enter(scope.Decl | scope.Break);
-        ok &= ma.analyseCase(c, checker, etd, is_string, is_last);
+        FlowBits flow2 = ma.analyseCase(c, checker, etd, is_string, is_last);
         ma.scope.exit(ma.has_error);
+        flow |= flow2 & (FlowReturn | FlowContinue | FlowGoto | FlowNoReturn | FlowError);
+        if (flow2 & FlowBreak) flow |= FlowNext;
     }
 
     ma.scope.exit(ma.has_error);
 
-    if (ok && etd) {
+    if (!(flow & FlowError) && etd) {
         const u32 numConstants = etd.getNumConstants();
 
         if (defaultCase) {
             // check for default with all cases covered
             if (checker.getCount() >= numConstants) {
                 ma.error(defaultCase.getLoc(), "default label in switch which covers all enumeration values");
+                flow |= FlowError;
             }
         } else {
             // check for uncovered cases
@@ -116,51 +119,60 @@ fn void Analyser.analyseSwitchStmt(Analyser* ma, Stmt* s) {
 
                 if (missing) {
                     ma.error(s.getLoc(), "unhandled enumeration value%s: %s", missing > 1 ? "s" : "", out.data());
+                    flow |= FlowError;
                 }
                 out.free();
             }
         }
     }
+    // TODO: handle complete coverage
+    if (!defaultCase) flow |= FlowNext;
 
     ma.putInitChecker(checker);
+    return flow;
 }
 
-fn bool Analyser.analyseCase(Analyser* ma,
-                             SwitchCase* c,
-                             init_checker.Checker* checker,
-                             EnumTypeDecl* etd,
-                             bool is_string,
-                             bool is_last) {
+fn FlowBits Analyser.analyseCase(Analyser* ma,
+                                 SwitchCase* c,
+                                 init_checker.Checker* checker,
+                                 EnumTypeDecl* etd,
+                                 bool is_string,
+                                 bool is_last)
+{
+    FlowBits flow = 0;
     bool is_default = c.isDefault();
     if (!is_default) {
-        if (!ma.analyseCaseCondition(c, checker, etd, is_string)) return false;
+        if (!ma.analyseCaseCondition(c, checker, etd, is_string)) return FlowError;
     }
 
     const u32 count = c.getNumStmts();
     if (count == 0) {
         c.setHasFallthrough();
-        return true;
+        return FlowNext;
     }
     bool has_decls = false;
+    FlowBits flow2 = FlowNext;
     for (u32 i = 0; i < count; i++) {
         Stmt* st = c.getStmt(i);
         if (st.isFallthrough() && !is_last) {
             c.setHasFallthrough();
             if (i + 1 != count) {
                 ma.error(st.getLoc(), "'fallthrough' statement must be last statement in case");
-                return false;
+                return FlowError;
             }
             continue;
         }
-        ma.analyseStmt(st, true);
-        if (ma.has_error) return false;
+        flow2 = ma.analyseStmt(st, true);
+        flow |= flow2 & (FlowReturn | FlowBreak | FlowContinue | FlowGoto | FlowNoReturn | FlowError);
+        if (ma.has_error) return FlowError;
         if (st.isDecl()) has_decls = true;
     }
+    flow |= flow2;
     if (has_decls) c.setHasDecls();
 
     Stmt* last = c.getStmt(count-1);
     if (isTerminatingStmt(last, is_default))
-        return true;
+        return flow;
 
     SrcLoc loc = last.getLoc();
     if (!loc) loc = c.getLoc();
@@ -169,7 +181,7 @@ fn bool Analyser.analyseCase(Analyser* ma,
     } else {
         ma.error(loc, "no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case");
     }
-    return false;
+    return FlowError;
 }
 
 fn bool Analyser.analyseCaseCondition(Analyser* ma,

--- a/common/build_target.c2
+++ b/common/build_target.c2
@@ -129,6 +129,8 @@ public fn Target* create(u32 name_idx, SrcLoc loc, Kind kind, string_pool.Pool* 
     Target* t = stdlib.calloc(1, sizeof(Target));
     t.name_idx = name_idx;
     t.loc = loc;
+    // remove this once the bootstrap handles improved flow analysis
+    t.warnings.no_unreachable_code = true;
     t.kind = kind;
     t.max_files = 8;
     t.features.init(pool);
@@ -200,6 +202,7 @@ public fn void Target.disableWarnings(Target* t) {
     t.warnings.no_unused_public = true;
     t.warnings.no_unused_label = true;
     t.warnings.no_unused_enum_constant = true;
+    t.warnings.no_unreachable_code = true;
 }
 
 public fn void Target.enableWarnings(Target* t) {
@@ -213,6 +216,7 @@ public fn void Target.enableWarnings(Target* t) {
     t.warnings.no_unused_public = false;
     t.warnings.no_unused_label = false;
     t.warnings.no_unused_enum_constant = false;
+    t.warnings.no_unreachable_code = false;
 }
 
 public fn const warning_flags.Flags* Target.getWarnings(const Target* t) {

--- a/common/warning_flags.c2
+++ b/common/warning_flags.c2
@@ -26,6 +26,7 @@ public type Flags struct {
     bool no_unused_public;
     bool no_unused_label;
     bool no_unused_enum_constant;
+    bool no_unreachable_code;
     bool are_errors;
 }
 

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -209,6 +209,23 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(nore
     longjmp(&p.jmpbuf, 1);
 }
 
+fn void Parser.warning(Parser* p, const char* format @(printf_format), ...) {
+    char[128] msg;
+    va_list args;
+    va_start(args, format);
+    vsnprintf(msg, sizeof(msg), format, args);
+    va_end(args);
+
+    char[256] locstr;
+    p.sm.loc2str(p.token.loc, locstr, elemsof(locstr));
+
+    if (color.useColor()) {
+        fprintf(stderr, "%s: %swarning:%s %s\n", locstr, color.Red, color.Normal, msg);
+    } else {
+        fprintf(stderr, "%s: warning: %s\n", locstr, msg);
+    }
+}
+
 fn void Parser.consumeToken(Parser* p) {
     p.lex(&p.token);
 #if 0
@@ -533,51 +550,59 @@ fn void Parser.parseWarnings(Parser* p) {
     // TODO no need to store in string pool
     while (p.is(Kind.Text)) {
         const char* option = p.pool.idx2str(p.token.value);
+        bool disable = false;
+        if (!string.strncmp(option, "no-", 3)) {
+            disable = true;
+            option += 3;
+        }
         switch (option) {
-        case "no-unused":
-            warnings.no_unused = true;
-            warnings.no_unused_variable = true;
-            warnings.no_unused_function = true;
-            warnings.no_unused_parameter = true;
-            warnings.no_unused_type = true;
-            warnings.no_unused_module = true;
-            warnings.no_unused_import = true;
-            warnings.no_unused_public = true;
-            warnings.no_unused_label = true;
-            warnings.no_unused_enum_constant = true;
+        case "unused":
+            warnings.no_unused = disable;
+            warnings.no_unused_variable = disable;
+            warnings.no_unused_function = disable;
+            warnings.no_unused_parameter = disable;
+            warnings.no_unused_type = disable;
+            warnings.no_unused_module = disable;
+            warnings.no_unused_import = disable;
+            warnings.no_unused_public = disable;
+            warnings.no_unused_label = disable;
+            warnings.no_unused_enum_constant = disable;
             break;
-        case "no-unused-variable":
-            warnings.no_unused_variable = true;
+        case "unused-variable":
+            warnings.no_unused_variable = disable;
             break;
-        case "no-unused-function":
-            warnings.no_unused_function = true;
+        case "unused-function":
+            warnings.no_unused_function = disable;
             break;
-        case "no-unused-parameter":
-            warnings.no_unused_parameter = true;
+        case "unused-parameter":
+            warnings.no_unused_parameter = disable;
             break;
-        case "no-unused-type":
-            warnings.no_unused_type = true;
+        case "unused-type":
+            warnings.no_unused_type = disable;
             break;
-        case "no-unused-module":
-            warnings.no_unused_module = true;
+        case "unused-module":
+            warnings.no_unused_module = disable;
             break;
-        case "no-unused-import":
-            warnings.no_unused_import = true;
+        case "unused-import":
+            warnings.no_unused_import = disable;
             break;
-        case "no-unused-public":
-            warnings.no_unused_public = true;
+        case "unused-public":
+            warnings.no_unused_public = disable;
             break;
-        case "no-unused-label":
-            warnings.no_unused_label = true;
+        case "unused-label":
+            warnings.no_unused_label = disable;
             break;
-        case "no-unused-enum-constant":
-            warnings.no_unused_enum_constant = true;
+        case "unused-enum-constant":
+            warnings.no_unused_enum_constant = disable;
+            break;
+        case "unreachable-code":
+            warnings.no_unreachable_code = disable;
             break;
         case "promote-to-error":
-            warnings.are_errors = true;
+            warnings.are_errors = !disable;
             break;
         default:
-            p.error("unknown warning '%s'", option);
+            p.warning("unknown warning '%s'", option);
             break;
         }
         p.consumeToken();

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -134,6 +134,7 @@ const char[] Recipe_help =
     "             <no-unused-public>\n"
     "             <no-unused-label> \n"
     "             <no-unused-enum-constant>\n"
+    "             <no-unreachable-code>\n"
     "             <promote-to-error> \n"
     "   $backend [c|ir] <check>\n"
     "              <fast>\n"

--- a/recipe.txt
+++ b/recipe.txt
@@ -155,6 +155,8 @@ executable c2c
     $warnings no-unused-variable
     $warnings no-unused-parameter
     $warnings no-unused-enum-constant
+# This is not supported by the bootstrap yet
+#    $warnings unreachable-code
 #    $warnings promote-to-error
     $use pthread dynamic
 

--- a/test/c_generator/functions/inline/inline_stmts.c2t
+++ b/test/c_generator/functions/inline/inline_stmts.c2t
@@ -34,7 +34,7 @@ public fn i32 test_fn(const char* format, ...) @(inline) {
         continue;
     }
     while (format) continue;
-    for (;;) {
+    for (; format;) {
     }
     for (;;) break;
     for (;;) {
@@ -87,7 +87,7 @@ fn i32 test_fn(const char* format, ...) {
       continue;
    }
    while (format) continue;
-   for (;;) {
+   for (; format;) {
    }
    for (;;) break;
    for (;;) {
@@ -147,7 +147,7 @@ int32_t test1_test_fn(const char* format, ...)
       continue;
   }
   while (format) continue;
-  for (;;) {
+  for (; format;) {
   }
   for (;;) break;
   for (;;) {

--- a/test/c_generator/stmts/for_loop_ok.c2t
+++ b/test/c_generator/stmts/for_loop_ok.c2t
@@ -5,18 +5,31 @@
 // @file{file1}
 module test;
 
+fn void forever() {
+    for (;;) {}
+}
+
 public fn i32 main(i32 argc, const char** argv) {
     i32 a = 0;
     for (a=0; a<10; a++) {}
 
     for (i32 b=0; b<10; b++) {}
 
-    for (;;) {}
+    forever();
 
     return 0;
 }
 
 // @expect{atleast, cgen/build.c}
+
+static void test_forever(void);
+int32_t main(int32_t argc, const char** argv);
+
+static void test_forever(void)
+{
+    for (;;) {
+    }
+}
 
 int32_t main(int32_t argc, const char** argv)
 {
@@ -27,8 +40,8 @@ int32_t main(int32_t argc, const char** argv)
     for (int32_t b = 0; b < 10; b++) {
     }
 
-    for (;;) {
-    }
+    test_forever();
+
     return 0;
 }
 

--- a/test/c_generator/stmts/if_stmt_expr.c2t
+++ b/test/c_generator/stmts/if_stmt_expr.c2t
@@ -15,7 +15,7 @@ public fn i32 main(i32 argc, const char** argv) {
         else
             return 1;
 
-    if (true) {
+    if (false) {
         return 2;
     }
 
@@ -36,7 +36,7 @@ int32_t main(int32_t argc, const char** argv)
         else return 1;
     }
 
-    if (true) {
+    if (false) {
         return 2;
     }
 

--- a/test/c_generator/stmts/while_stmt_expr.c2t
+++ b/test/c_generator/stmts/while_stmt_expr.c2t
@@ -12,9 +12,9 @@ public fn i32 main(i32 argc, const char** argv) {
         if (argc == 2) break;
     }
 
-    while (i32 b = 10) {}
+    while (i32 b = 0) {}
 
-    while (true) {}
+    while (false) {}
 
     return 0;
 }
@@ -31,11 +31,11 @@ int32_t main(int32_t argc, const char** argv)
 
     {
         int32_t b;
-        while ((b = 10)) {
+        while ((b = 0)) {
         }
     }
 
-    while (true) {
+    while (false) {
     }
 
     return 0;

--- a/test/init/pure_function/fib-error.c2
+++ b/test/init/pure_function/fib-error.c2
@@ -10,6 +10,47 @@ fn u32 rec(u32 n) @(pure) {
     return n == 0 ? n : rec(n - 1) + 1;
 }
 
+fn u32 fib_if(u32 n) @(pure) {
+    if (n <= 2)
+        return 1;
+    else
+        return fib_if(n - 1) + fib_if(n - 2);
+}
+
+fn u32 fib_for(u32 n) @(pure) {
+    for (;;) {
+        return n <= 2 ? 1 : fib_for(n - 1) + fib_for(n - 2);
+    }
+}
+
+fn u32 fib_while(u32 n) @(pure) {
+    while (1) {
+        return n <= 2 ? 1 : fib_while(n - 1) + fib_while(n - 2);
+    }
+}
+
+fn u32 fib_goto(u32 n) @(pure) {
+    return n <= 2 ? 1 : fib_goto(n - 1) + fib_goto(n - 2);
+loop:                 // should have warning{unreachable code}
+    goto loop;
+}
+
+fn u32 fib_infinite(u32 n) @(pure) {
+    return n <= 2 ? 1 : fib_infinite(n - 1) + fib_infinite(n - 2);
+    for (;;) continue;  // @warning{unreachable code}
+}
+
+fn u32 fib_switch(u32 n) @(pure) {
+    switch (n) {
+    case 0:
+    case 1:
+    case 2:
+        return 1;
+    default:
+        return fib_switch(n - 1) + fib_switch(n - 2);
+    }
+}
+
 u32 fib0 = fib(0);       // @error{assertion failed}
 u32 fib90 = fib(90);     // @error{expression too complex}
 u32 fib1000 = fib(1000); // @error{recursion too deep}

--- a/test/scope/condition_decl_while.c2
+++ b/test/scope/condition_decl_while.c2
@@ -1,15 +1,17 @@
 // @warnings{no-unused}
 module test;
 
+import stdlib local;
+
 fn void foo() {
-    while (i32 a = 12) {
+    while (i32 a = rand()) {
         a--;
     }
     a++;            // @error{use of undeclared identifier 'a'}
 }
 
 fn void bar() {
-    while (i32 a = 12) {}
-    while (i32 a = 12) {}
+    while (i32 a = rand()) {}
+    while (i32 a = rand()) {}
 }
 

--- a/test/stmt/for_empty_stmts_ok.c2
+++ b/test/stmt/for_empty_stmts_ok.c2
@@ -1,8 +1,10 @@
 module test;
 
-public fn i32 main() {
+fn void forever() {
     for (;;) {}
-    return 0;
 }
 
-
+public fn i32 main() {
+    forever();
+    return 0;
+}

--- a/test/stmt/goto_unknown_label.c2
+++ b/test/stmt/goto_unknown_label.c2
@@ -1,10 +1,8 @@
 // @warnings{no-unused}
 module test;
 
-public fn i32 main() {
+fn void foo() {
     {
         goto begin;     // @error{use of undeclared label 'begin'}
     }
-    return 0;
 }
-

--- a/test/stmt/switch/switch_ok.c2
+++ b/test/stmt/switch/switch_ok.c2
@@ -17,6 +17,7 @@ fn void foo(i32 a) {
         case 5:
             on_error();
         }
+        break;
     }
 
     switch (a) {

--- a/test/vars/non_unused_condition_decl.c2
+++ b/test/vars/non_unused_condition_decl.c2
@@ -1,7 +1,9 @@
 module test;
 
+i32 x;
+
 public fn i32 main() {
-    if (i32 a = 12) {
+    if (i32 a = x) {
         return a;
     }
     return 0;

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -160,16 +160,15 @@ fn void Db.matchNote(Db* db, const char* filename, i32 linenr, const char* msg) 
     const char* match = db.notes.find(filename, linenr);
     if (match) {
         if (!same_string(match, msg)) {
-            color_print2(db.output, colError, "  wrong note at %s:%d:", filename, linenr);
+            color_print2(db.output, colError, "%s:%d: wrong note: %s", relativeFilename(filename), linenr, msg);
             color_print2(db.output, colError, "     expected: %s", match);
-            color_print2(db.output, colError, "     got: %s", msg);
             db.hasErrors = true;
         }
         db.notes.erase(filename, linenr);
         return;
     }
     // not expected
-    color_print2(db.output, colError, "  unexpected note on line %d: %s", linenr, msg);
+    color_print2(db.output, colError, "%s:%d: unexpected note: %s", relativeFilename(filename), linenr, msg);
     db.hasErrors = true;
 }
 
@@ -177,16 +176,15 @@ fn void Db.matchWarning(Db* db, const char* filename, i32 linenr, const char* ms
     const char* match = db.warnings.find(filename, linenr);
     if (match) {
         if (!same_string(match, msg)) {
-            color_print2(db.output, colError, "  wrong warning at %s:%d:", filename, linenr);
+            color_print2(db.output, colError, "%s:%d: wrong warning: %s", relativeFilename(filename), linenr, msg);
             color_print2(db.output, colError, "     expected: %s", match);
-            color_print2(db.output, colError, "     got: %s", msg);
             db.hasErrors = true;
         }
         db.warnings.erase(filename, linenr);
         return;
     }
     // not expected
-    color_print2(db.output, colError, "  unexpected warning on line %d: %s", linenr, msg);
+    color_print2(db.output, colError, "%s:%d: unexpected warning: %s", relativeFilename(filename), linenr, msg);
     db.hasErrors = true;
 }
 
@@ -637,6 +635,7 @@ public fn bool Db.parse(Db* db) {
     switch (db.kind) {
     case C2:
         db.recipe.add("executable test\n");
+        db.recipe.add("  $warnings unreachable-code\n");
         db.recipe.add("  $warnings no-unused-module\n");
         db.recipe.add("  $backend c\n");
 
@@ -670,6 +669,7 @@ public fn bool Db.parse(Db* db) {
         break;
     case C2A:
         db.recipe.add("executable test\n");
+        db.recipe.add("  $warnings unreachable-code\n");
         db.recipe.add("  $warnings no-unused\n");
         db.recipe.add("  $backend c skip\n");
         db.recipe.add("  $write-AST\n");


### PR DESCRIPTION
* add `analyseFlow(Stmt* s)` to analyse all exit paths
* rename ambiguous `hasReturn()` as `hasFlowNext()` and fix semantics
* fix erroneous cases of 'missing return statement'
* track more unreachable code cases: `if`, `while`, `for`, `switch`...
* improve warning control: "no-" is an optional prefix to disable the warning
* add $warning for unreachable-code:
  - disabled by default until bootstrap is regenerated
  - enabled by tester for tests
* unknown warning is now a warning, not an error
* fix tests for unreachable code