### PR TITLE
Parser: improve token lookahead system

### DIFF
--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -42,12 +42,17 @@ import ctype local;
 import stdio local;
 
 const u32 NumStmtLists = 16;    // max used for c2c is 8
+const u32 MaxLookahead = 64;    // must be power of 2
 
 public type Parser struct @(opaque) {
     c2_tokenizer.Tokenizer tokenizer;
     Token tok;
     SrcLoc prev_loc;
     i32 file_id;
+
+    u32 next_count;
+    u32 next_head;  // index of next token (circular index into next)
+    Token[MaxLookahead] next;
 
     SourceMgr* sm;
     diagnostics.Diags* diags;
@@ -169,9 +174,33 @@ fn void on_tokenizer_warning(void* arg, SrcLoc loc) {
 
 fn void Parser.consumeToken(Parser* p) {
     p.prev_loc = p.tok.loc + p.tok.len;
+    if (p.next_count) {
+        p.tok = p.next[p.next_head];
+        p.next_head = (p.next_head + 1) % MaxLookahead;
+        p.next_count--;
+        return;
+    }
     p.tokenizer.lex(&p.tok);
-
     // p.dump_token(&p.tok);
+}
+
+fn Kind Parser.peekToken(Parser* p, u32 n) {
+    assert(n > 0);
+    assert(n <= MaxLookahead);
+    while (p.next_count < n) {
+        const u32 slot = (p.next_head + p.next_count) % MaxLookahead;
+        p.tokenizer.lex(&p.next[slot]);
+        p.next_count++;
+    }
+    u32 slot = (p.next_head + n - 1) % MaxLookahead;
+    return p.next[slot].kind;
+}
+
+fn Kind Parser.peekToken2(Parser* p, u32 n, Token *tok) {
+    Kind kind = p.peekToken(n);
+    u32 slot = (p.next_head + n - 1) % MaxLookahead;
+    *tok = p.next[slot];
+    return p.next[slot].kind;
 }
 
 fn void Parser.consumeSemicolon(Parser* p, bool need_semi) {
@@ -310,8 +339,7 @@ fn void Parser.parseTopLevel(Parser* p) {
         case Eof:
             break;
         case Identifier:
-            Kind kind = p.tokenizer.lookahead(1, nil);
-            if (kind == Kind.PlusEqual) {
+            if (p.peekToken(1) == Kind.PlusEqual) {
                 if (is_public) p.error("incremental array entries cannot be public");
                 p.parseArrayEntry();
                 break;
@@ -590,7 +618,7 @@ fn void Parser.parseOptionalArray(Parser* p, TypeRefHolder* ref) {
         p.consumeToken();
 
         // NOTE: 'transposed' order, so char[2][4] -> 2 x ( 4 x char )
-        if (p.tok.kind == Kind.Plus && p.tokenizer.lookahead(1, nil) == Kind.RSquare) {
+        if (p.tok.kind == Kind.Plus && p.peekToken(1) == Kind.RSquare) {
             // [+]
             if (ref.isArray()) p.error("incremental arrays cannot have more than 1 dimension");
             p.consumeToken();

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -257,7 +257,7 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
     case 1: // Identifier
         // Fast-path, keep checking multiple identifier.identifier. etc
         // parse them all in a single MemberExpr
-        if (p.tokenizer.lookahead(1, nil) == Kind.Dot) {
+        if (p.peekToken(1) == Kind.Dot) {
             res = p.parsePureMemberExpr();
         } else {
             res = p.parseIdentifier().asExpr();
@@ -318,7 +318,7 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
         res = p.parseToContainerExpr();
         break;
     case 16: // builtin type
-        if (p.tokenizer.lookahead(1, nil) == Kind.Dot) {
+        if (p.peekToken(1) == Kind.Dot) {
             p.addImplicitImport(p.tok.name_idx, false);
             res = p.parsePureMemberExpr();
         } else {
@@ -552,15 +552,15 @@ fn bool Parser.isTemplateFunctionCall(Parser* p) {
 
     // type must start with either a qualifier or an identifier
     //   or a builtin not followed by a dot.
-    Kind kind = p.tokenizer.lookahead(1, nil);
+    Kind kind = p.peekToken(1);
     if (kind != Kind.Identifier) {
         if (kind.isQualifier()) return true;
-        return kind.isBuiltinType() && (p.tokenizer.lookahead(2, nil) != Kind.Dot);
+        return kind.isBuiltinType() && (p.peekToken(2) != Kind.Dot);
     }
 
     u32 stars = 0;
     for (u32 ahead = 2; ahead < 8; ahead++) {
-        switch (p.tokenizer.lookahead(ahead, nil)) {
+        switch (p.peekToken(ahead)) {
         case Identifier:
             if (stars) return false;
             break;
@@ -570,7 +570,7 @@ fn bool Parser.isTemplateFunctionCall(Parser* p) {
         case Dot:
             break;
         case Greater:
-            return p.tokenizer.lookahead(ahead+1, nil) == Kind.LParen;
+            return p.peekToken(ahead + 1) == Kind.LParen;
         case KW_const:
         case KW_volatile:
             return true;
@@ -773,7 +773,7 @@ fn Expr* Parser.parseToContainerExpr(Parser* p) {
 fn Expr* Parser.parseFullIdentifier(Parser* p) {
     p.expectIdentifier();
 
-    if (p.tokenizer.lookahead(1, nil) == Kind.Dot) {
+    if (p.peekToken(1) == Kind.Dot) {
         return p.parsePureMemberExpr();
     }
     return p.parseIdentifier().asExpr();
@@ -782,11 +782,9 @@ fn Expr* Parser.parseFullIdentifier(Parser* p) {
 /*
     parsing sizeof() is nasty, since the inner argument can be either an Expr or a Type!
 
-    The reason we forbid brackets [] inside a sizeof is that its ambiguous; it can be
-    an array (eg Foo[2]) or a subscript expression (a[2]). Also there is no real reason
-    to keep them. Keep it simple.
-
-    also: Foo can be type or Constant, just return Identifier (or Member if prefixed)
+    The reason we test brackets [] inside a sizeof is that it is potentially ambiguous;
+    it can be an array (eg Foo[2]) or a subscript expression (a[2]). We assume Foo to be
+    a type, but it could be a global Constant, in which case an error will be generated later.
 
     i8,u8,.      - type
     X*           - type
@@ -797,12 +795,14 @@ fn Expr* Parser.parseFullIdentifier(Parser* p) {
     test.Foo     - member (upper case, can be Constant or Type)
     f.a          - member (lower case)
     test.f.a     - member (lower case)
-    Foo[..]      - error ([] not allowed)
-    test.Foo[..] - error ([] not allowed)
-    (test.)a[..] - error ([] not allowed)
-    Foo.a        - error (need instantiation)
-    test.Foo.a   - error (need instantiation)
-    (test.)a*    - type (but will give error later)
+    Foo[..]      - can be Constant element or Type array, assume Type array
+    test.Foo[..] - can be Constant element or Type array, assume Type array
+    a[..]        - subscript expression
+    test.a[..]   - subscript expression
+    Foo.a        - error (need instantiation, should accept as extension)
+    test.Foo.a   - error (need instantiation, should accept as extension)
+    a*)          - type (but will give error later)
+    test.a*)     - type (but will give error later)
 */
 fn bool Parser.parseAsType(Parser* p) {
     // type must start with either a qualifier or an identifier
@@ -810,20 +810,20 @@ fn bool Parser.parseAsType(Parser* p) {
     Kind kind = p.tok.kind;
     if (kind != Kind.Identifier) {
         if (kind.isQualifier()) return true;
-        return kind.isBuiltinType() && (p.tokenizer.lookahead(1, nil) != Kind.Dot);
+        return kind.isBuiltinType() && (p.peekToken(1) != Kind.Dot);
     }
     Token t2 = p.tok;
     // parse potential member expression
     u32 ahead = 1;
-    while (p.tokenizer.lookahead(ahead, nil) == Kind.Dot) {
-        if (p.tokenizer.lookahead(ahead + 1, &t2) != Kind.Identifier)
+    while (p.peekToken(ahead) == Kind.Dot) {
+        if (p.peekToken2(ahead + 1, &t2) != Kind.Identifier)
             return false;
         ahead += 2;
     }
 
     i32 stars = 0;
     for (;; ahead++) {
-        switch (p.tokenizer.lookahead(ahead, nil)) {
+        switch (p.peekToken(ahead)) {
         case RParen:
             if (stars) return true;
             // ambiguous: could be a global constant or a type name
@@ -835,6 +835,7 @@ fn bool Parser.parseAsType(Parser* p) {
             // ambiguous: could be a global constant element or an array type
             return true;    // assume array type
         case Star:
+            if (stars) return true;  // sizeof(a**...)
             stars++;
             break;
         case Less:
@@ -866,7 +867,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
     Token t2 = p.tok;
     bool ambiguous = true;
     for (;;) {
-        if (ahead) p.tokenizer.lookahead(ahead, &t2);
+        if (ahead) p.peekToken2(ahead, &t2);
         ahead++;
         Kind kind = t2.kind;
         if (kind.isBuiltinType()) {
@@ -883,19 +884,16 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
         // but still potentially ambiguous.
         if (kind != Kind.Identifier)
             return 0;
-        for (;;) {
-            if (p.tokenizer.lookahead(ahead, nil) != Kind.Dot)
-                break;
-            ahead++;
-            if (p.tokenizer.lookahead(ahead, &t2) != Kind.Identifier)
+        while (p.peekToken(ahead) == Kind.Dot) {
+            if (p.peekToken2(ahead + 1, &t2) != Kind.Identifier)
                 return 0;
-            ahead++;
+            ahead += 2;
         }
         break;
     }
     i32 stars = 0;
     while (1) {
-        switch (p.tokenizer.lookahead(ahead, nil)) {
+        switch (p.peekToken(ahead)) {
         case Star:
             if (stars < 0) return 0;
             if (stars > 0) ambiguous = false;
@@ -908,7 +906,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
             ahead++;
             if (!ambiguous) return ahead;
             // disambiguate depending on the next token
-            switch (p.tokenizer.lookahead(ahead, nil)) {
+            switch (p.peekToken(ahead)) {
             case Identifier:
             case IntegerLiteral:
             case FloatLiteral:
@@ -946,7 +944,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
             return 0;
         case LSquare:
             // skip expression
-            ahead = p.skipArray(ahead);
+            ahead = p.skipArray(ahead + 1, RSquare);
             if (!ahead)
                 return 0;
             stars = -1; // no longer accept stars

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -108,38 +108,35 @@ fn bool Parser.isTypeSpec(Parser* p) {
 
     // State: 0 = ID1, 1 = ID2, 2 = pointers, 3 = arrays, 4 = hasname
     u32 state = 0;
-    u32 lookahead = 1;
+    u32 ahead = 1;
     // TODO check max lookahead otherwise Tokenizer can assert
     while (1) {
-        switch (p.tokenizer.lookahead(lookahead, nil)) {
+        switch (p.peekToken(ahead++)) {
         case Identifier:
             if (state == 4) return false;
             state = 4;
-            lookahead++;
             break;
         case LSquare:
             if (state == 4) return false;
-            lookahead = p.skipArray(lookahead);
+            ahead = p.skipArray(ahead, RSquare);
             state = 3;
             break;
         case Star:
             if (state >= 3) return false; // a[1] *, a * b * ..
             state = 2;
-            lookahead++;
             break;
         case Dot:
             if (state == 4) {
                 return true; // init call
             }
             if (state == 0) {
-                kind = p.tokenizer.lookahead(lookahead+1, nil);
+                kind = p.peekToken(ahead++);
                 if (kind != Kind.Identifier) {
                     // syntax error
                     return false;
                 }
                 // TODO: second identifier should have capital
                 state = 2;
-                lookahead += 2;
             } else {
                 return false; // a.b.c
             }
@@ -156,30 +153,32 @@ fn bool Parser.isTypeSpec(Parser* p) {
     return false;
 }
 
-fn u32 Parser.skipArray(Parser* p, u32 lookahead) {
-    lookahead++;
-
-    // TODO check max lookahead, otherwise Tokenizer can assert
-    u32 square_depth = 1;
-    u32 paren_depth = 0;
-    while (square_depth) {
+fn u32 Parser.skipArray(Parser* p, u32 ahead, Kind endKind) {
+    u32 depth = 1;
+    Kind[8] closeKind = { endKind }
+    while (depth > 0) {
         Token next;
-        switch (p.tokenizer.lookahead(lookahead, &next)) {
+        if (depth >= elemsof(closeKind) || ahead >= MaxLookahead) {
+            p.error("expression too complex");
+        }
+        switch (p.peekToken2(ahead++, &next)) {
         case LParen:
-            paren_depth++;
+            closeKind[depth++] = RParen;
             break;
         case RParen:
-            if (paren_depth == 0) {
+            if (closeKind[--depth] != RParen) {
                 p.tok.loc = next.loc;
                 p.error("expected ']'");
             }
-            paren_depth--;
             break;
         case LSquare:
-            square_depth++;
+            closeKind[depth++] = RSquare;
             break;
         case RSquare:
-            square_depth--;
+            if (closeKind[--depth] != RSquare) {
+                p.tok.loc = next.loc;
+                p.error("expected ')'");
+            }
             break;
         case Eof:
             p.tok.loc = next.loc;
@@ -188,10 +187,8 @@ fn u32 Parser.skipArray(Parser* p, u32 lookahead) {
         default:
             break;
         }
-        lookahead++;
     }
-
-    return lookahead;
+    return ahead;
 }
 
 /*
@@ -213,7 +210,7 @@ fn Stmt* Parser.parseDeclOrStmt(Parser* p) {
         return p.parseDeclStmt(true, true, false);
     }
 
-    Kind kind = p.tokenizer.lookahead(1, nil);
+    Kind kind = p.peekToken(1);
     if (kind == Kind.Colon) return p.parseLabelStmt();
 
     return p.parseExprStmt();
@@ -565,8 +562,8 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
             p.error("local variables cannot have attributes");
             break;
         case Dot:
-            if (p.tokenizer.lookahead(1, nil) == Kind.Identifier
-            &&  p.tokenizer.lookahead(2, nil) == Kind.LParen) {
+            if (p.peekToken(1) == Kind.Identifier
+            &&  p.peekToken(2) == Kind.LParen) {
                 if (has_local)
                     p.error("local qualified variables cannot have an init call");
                 if (isCondition)

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -32,8 +32,6 @@ import ctype local;
 import stdarg local;
 import stdio local;
 
-public const u32 MaxLookahead = 64;  // must be multiple of 2
-
 type Action enum u8 {
     INVALID = 0,  // ensure the default Action in Char_lookup is INVALID
     TABSPACE,
@@ -263,9 +261,6 @@ public type Tokenizer struct {
     const char* input_start;
 
     const keywords.Info* kwinfo;
-    Token[MaxLookahead] next;
-    u32 next_count;
-    u32 next_head;  // index of next token (circular index into next)
     const char* line_start;
 
     string_pool.Pool* pool; // no ownership
@@ -283,7 +278,7 @@ public type Tokenizer struct {
 
     char[256] error_msg;
 }
-static_assert(1448, sizeof(Tokenizer));
+static_assert(416, sizeof(Tokenizer));
 
 public fn void Tokenizer.init(Tokenizer* t,
                               string_pool.Pool* pool,
@@ -315,17 +310,6 @@ public fn void Tokenizer.init(Tokenizer* t,
 }
 
 public fn void Tokenizer.lex(Tokenizer* t, Token* result) {
-    if (t.next_count) {
-        string.memcpy(result, &t.next[t.next_head], sizeof(Token));
-
-        t.next_head = (t.next_head + 1) % MaxLookahead;
-        t.next_count--;
-        return;
-    }
-    t.lex_internal(result);
-}
-
-fn void Tokenizer.lex_internal(Tokenizer* t, Token* result) {
     // TODO if end/error stop (dont retry) (t.done = 1)
 
     while (1) {
@@ -686,20 +670,6 @@ invalid_char:
             t.error(result, "invalid char 0x%02X", *t.cur & 0xFF);
         return;
     }
-}
-
-public fn Kind Tokenizer.lookahead(Tokenizer* t, u32 n, Token *tok) {
-    assert(n > 0);
-    assert(n <= MaxLookahead);
-    while (t.next_count < n) {
-        const u32 slot = (t.next_head + t.next_count) % MaxLookahead;
-        t.lex_internal(&t.next[slot]);
-        t.next_count++;
-    }
-
-    u32 slot = (t.next_head + n - 1) % MaxLookahead;
-    if (tok) *tok = t.next[slot];
-    return t.next[slot].kind;
 }
 
 fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
@@ -1524,7 +1494,7 @@ fn bool Tokenizer.is_enabled(const Tokenizer* t) {
 
 fn Kind Tokenizer.lex_preproc(Tokenizer* t, Token* result) {
     t.stop_at_eol = true;
-    t.lex_internal(result);
+    t.lex(result);
     t.stop_at_eol = false;
     return result.kind;
 }


### PR DESCRIPTION
* move token lookahead queue from `Tokenizer` to `Parser`
* add `Parser.peekToken()` and `Parser.peekToken2()` (reads token value)
* better check for unbalanced parentheses and brackets
* produce proper error for bogus expressions in lookahead phases