### PR TITLE
Analyser: simplify switch case flow control analysis

### DIFF
--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -48,6 +48,18 @@ fn Expr* getCondExpr(const Stmt* cond) {
     return nil;
 }
 
+fn bool Analyser.isNoReturn(Analyser* ma, Expr* e) {
+    if (!e.isCall()) return false;
+    // get from CallExpr -> FunctionDecl
+    const CallExpr* c = (CallExpr*)e;
+    e = c.getFunc();
+    QualType qt = e.getType();
+    const FunctionType* ft = qt.getFunctionTypeOrNil();
+    if (!ft) return false;
+    const FunctionDecl* fd = ft.getDecl();
+    return fd.hasAttrNoReturn();
+}
+
 fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt* s, bool checkEffect) {
     FlowBits flow = 0;
     if (ma.scope.isUnreachable()) {
@@ -66,7 +78,8 @@ fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt* s, bool checkEffect) {
         ma.analyseExpr((Expr**)&s, false, 0);
         Expr* e = (Expr*)s;
         if (checkEffect && !e.hasEffect()) ma.errorRange(e.getLoc(), e.getRange(), "expression without effect");
-        return FlowNext;  // TODO: check for call to noreturn function
+        if (!ma.has_error && ma.isNoReturn(e)) return FlowNoReturn;
+        return FlowNext;
     case If:
         flow = ma.analyseIfStmt(s);
         break;

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -170,12 +170,12 @@ fn FlowBits Analyser.analyseCase(Analyser* ma,
     flow |= flow2;
     if (has_decls) c.setHasDecls();
 
-    Stmt* last = c.getStmt(count-1);
-    if (isTerminatingStmt(last, is_default))
-        return flow;
+    if (!(flow & FlowNext) || c.hasFallthrough()) return flow;
 
+    Stmt* last = c.getStmt(count-1);
     SrcLoc loc = last.getLoc();
     if (!loc) loc = c.getLoc();
+    // TODO: use simpler error message
     if (is_default) {
         ma.error(loc, "no terminating statement (break|return|continue|goto|noreturn-func) at end of default case");
     } else {
@@ -387,52 +387,3 @@ fn bool Analyser.checkEnumConstantCase(Analyser* ma,
     }
     return true;
 }
-
-fn bool isTerminatingStmt(const Stmt* s, bool is_default) {
-    if (!s) return false;
-    switch (s.getKind()) {
-    case Return:
-        return true;
-    case Expr:
-        const Expr* e = (Expr*)s;
-        if (!e.isCall()) break;
-        // get from CallExpr -> FunctionDecl
-        const CallExpr* c = (CallExpr*)e;
-        e = c.getFunc();
-        QualType qt = e.getType();
-        const FunctionType* ft = qt.getFunctionTypeOrNil();
-        assert(ft);
-        const FunctionDecl* fd = ft.getDecl();
-        if (fd.hasAttrNoReturn()) return true;
-        break;
-    case If:
-        const IfStmt* is = (IfStmt*)s;
-        return isTerminatingStmt(is.getThen(), is_default)
-        &&     isTerminatingStmt(is.getElse(), is_default);
-    case While:
-    case For:
-        // TODO: check constant condition and no break
-        break;
-    case Switch:
-        // TODO: check if unreachable
-        break;
-    case Break:
-    case Continue:
-    case Fallthrough:
-        return true;
-    case Label:
-        const LabelStmt* ls = (LabelStmt*)s;
-        const Stmt* stmt = ls.getStmt();
-        if (!stmt) return false;
-        return isTerminatingStmt(stmt, is_default);
-    case Goto:
-        return true;
-    case Compound:
-        CompoundStmt* c = (CompoundStmt*)s;
-        return isTerminatingStmt(c.getLastStmt(), is_default);
-    default:
-        break;
-    }
-    return false;
-}
-

--- a/ast/compound_stmt.c2
+++ b/ast/compound_stmt.c2
@@ -71,12 +71,6 @@ public fn Stmt** CompoundStmt.getStmts(CompoundStmt* s) {
     return nil;
 }
 
-public fn Stmt* CompoundStmt.getLastStmt(const CompoundStmt* s) {
-    u32 count = s.getCount();
-    if (count) return s.stmts[count-1];
-    return nil;
-}
-
 public fn SrcLoc CompoundStmt.getEndLoc(const CompoundStmt* e) {
     // e.base.loc is the location of the closing brace '}'
     return e.base.loc + 1;

--- a/test/stmt/switch/switch_terminating.c2
+++ b/test/stmt/switch/switch_terminating.c2
@@ -89,8 +89,7 @@ fn void foo5(i32 x, bool cond) {
 fn void foo6(i32 x) {
     switch (x) {
     case 0:
-        // TODO: this should not be an error
-        while (true) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+        while (true)
             return;
     default:
         break;
@@ -100,8 +99,7 @@ fn void foo6(i32 x) {
 fn void foo7(i32 x) {
     switch (x) {
     case 0:
-        // TODO: this should not be an error
-        for (;;) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+        for (;;)
             return;
     default:
         break;
@@ -111,8 +109,8 @@ fn void foo7(i32 x) {
 fn void foo8(i32 x) {
     switch (x) {
     case 0:
-        // TODO: this should not be an error but could be diagnosed as an infinite loop
-        while (true) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+        // TODO: this is not an error but could be diagnosed as an infinite loop
+        while (true)
             continue;
     default:
         break;
@@ -122,8 +120,8 @@ fn void foo8(i32 x) {
 fn void foo9(i32 x) {
     switch (x) {
     case 0:
-        // TODO: this should not be an error but could be diagnosed as an infinite loop
-        for (;;) // @error{no terminating statement (break|fallthrough|goto|return|continue|noreturn-func) at end of case}
+        // TODO: this is not an error but could be diagnosed as an infinite loop
+        for (;;)
             continue;
     default:
         break;


### PR DESCRIPTION
* use analyser `FlowBits` to check for missing `fallthrough`
* removed `Analyser.isTerminatingStmt()`
* removed `CompoundStmt.getLastStmt()`
* update tests