### PR TITLE
Analyser: fix array initializer issues

### DIFF
--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -179,18 +179,6 @@ fn bool Analyser.analyseArrayDesignatedInit(Analyser* ma, Expr* e, QualType expe
     bool ok = ma.analyseInitExpr(ad.getInit2(), expectedType, val.getLoc(), false, false);
     if (!ok) return false;
 
-    if (!ma.curFunction) {
-        if (!val.isCtc()) {
-            ma.errorRange(val.getLoc(), val.getRange(), "initializer element is not a compile-time constant");
-            return false;
-        }
-
-        if (!val.isCtv() && expectedType.needsCtvInit()) {
-            ma.errorRange(val.getLoc(), val.getRange(), "initializer element is not a compile-time value");
-            return false;
-        }
-    }
-
     val = ad.getInit(); // re-read because of ImplicitCasts
     e.copyConstantFlags(val);
     e.setType(expectedType);
@@ -223,9 +211,9 @@ fn bool Analyser.analyseInitListArray(Analyser* ma, InitListExpr* ile, QualType 
         if (value.isArrayDesignatedInit()) {
             ok &= ma.analyseArrayDesignatedInit(value, et);
             have_designators = true;
-            continue;
+        } else {
+            ok &= ma.analyseInitExpr(&values[i], et, values[i].getLoc(), false, false);
         }
-        ok &= ma.analyseInitExpr(&values[i], et, values[i].getLoc(), false, false);
         ctc &= values[i].isCtc();
     }
     current_index = numValues;   // TODO also keep track of ArrayDesignatedInit
@@ -234,16 +222,17 @@ fn bool Analyser.analyseInitListArray(Analyser* ma, InitListExpr* ile, QualType 
     if (!ok) return false;
 
     if (have_designators) {
+        // Check for out of bound array designators or compute implied array length
         ile.setHasDesignators();
 
-        i32 array_size = -1; // will be determined by init-expr
-        if (at.hasSize()) array_size = (i32)at.getSize();
+        bool has_size = at.hasSize();
+        u32 array_size = at.getSize();
 
         init_checker.Checker* checker = ma.getInitChecker();
-        ok = ma.checkArrayDesignators(ile, &array_size, checker);
+        ok = ma.checkArrayDesignators(ile, has_size, &array_size, checker);
         ma.putInitChecker(checker);
 
-        if (!at.hasSize()) at.setSize((u32)array_size);
+        if (!has_size) at.setSize(array_size);
 
     } else {
         if (at.hasSize()) {
@@ -261,12 +250,13 @@ fn bool Analyser.analyseInitListArray(Analyser* ma, InitListExpr* ile, QualType 
     return ok;
 }
 
-fn bool Analyser.checkArrayDesignators(Analyser* ma, InitListExpr* ile, i32* size, init_checker.Checker* checker) {
+fn bool Analyser.checkArrayDesignators(Analyser* ma, InitListExpr* ile, bool has_size, u32 *size, init_checker.Checker* checker) {
     u32 numValues = ile.getNumValues();
     Expr** values = ile.getValues();
 
-    i32 max_index = 0;
-    i32 current_index = -1;
+    bool ok = true;
+    u32 max_index = 0;
+    u64 index64 = u64.max;
     for (u32 i=0; i<numValues; i++) {
         SrcLoc loc;
         Expr* value = values[i];
@@ -275,37 +265,47 @@ fn bool Analyser.checkArrayDesignators(Analyser* ma, InitListExpr* ile, i32* siz
             Expr* desig = ad.getDesignator();
             loc = desig.getLoc();
             Value idx = ctv_analyser.get_value(desig);
+            if (!idx.isDecimal()) {
+                ma.error(loc, "array designator expression must have integer type");
+                return false;
+            }
             if (idx.isNegative()) {
                 ma.error(loc, "array designator value '%s' is negative", idx.str());
                 return false;
             }
-            if (*size != -1 && (*size <= 0 || !idx.checkRange(0, (u64)*size - 1))) {
-                ma.error(loc, "array designator index (%s) exceeds array bounds (%d)", idx.str(), *size);
+            index64 = idx.as_u64();
+            if (has_size && index64 >= *size) {
+                ma.error(loc, "array designator index (%d) exceeds array bounds (%d)", index64, *size);
                 return false;
             }
-            current_index = idx.as_i32();
         } else {
             loc = value.getLoc();
-            current_index++;
+            index64++;
+            if (has_size && index64 >= *size) {
+                ma.error(value.getLoc(), "excess elements in array initializer");
+                return false;
+            }
         }
-        if (*size != -1 && current_index >= *size) {
-            ma.error(value.getLoc(), "excess elements in array initializer");
+        if (index64 >= u32.max) {
+            ma.error(loc, "array index %d is too large", index64);
             return false;
         }
 
+        u32 current_index = (u32)index64;
+
         // check for duplicate entries
-        SrcLoc duplicate = checker.find((u32)current_index);
+        SrcLoc duplicate = checker.find(current_index);
         if (duplicate) {
             ma.error(loc, "duplicate initialization of array index");
             ma.note(duplicate, "previous initialization is here");
+            ok = false;
         } else {
-            checker.add((u32)current_index, loc);
+            checker.add(current_index, loc);
         }
-
         if (current_index > max_index) max_index = current_index;
     }
-    if (*size == -1) *size = max_index + 1;
-    return true;
+    if (!has_size) *size = max_index + 1;
+    return ok;
 }
 
 type FillInfo struct {

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -79,7 +79,7 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
             }
             Value ctv = ctv_analyser.get_value(initval);
 
-            if (!ctv_analyser.checkRange(ma.diags, implType, &ctv, 0, initval)) return;
+            if (!ctv_analyser.checkTypeRange(ma.diags, implType, &ctv, 0, initval)) return;
 
             if (i > 0 && ctv.is_less(&value)) {
                 value.decr(); // to get the previous value
@@ -88,7 +88,7 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
             }
             value = ctv;
         } else {
-            if (!ctv_analyser.checkRange(ma.diags, implType, &value, cd.getLoc(), nil)) return;
+            if (!ctv_analyser.checkTypeRange(ma.diags, implType, &value, cd.getLoc(), nil)) return;
         }
         c.setValue(value);
         ecd.setChecked();

--- a/analyser_utils/ctv_analyser.c2
+++ b/analyser_utils/ctv_analyser.c2
@@ -274,7 +274,7 @@ public fn bool check(diagnostics.Diags* diags, QualType qt, const Expr* e) {
         diags.errorRange(e.getLoc(), e.getRange(), "%s", value.error_msg);
         return false;
     }
-    return checkRange(diags, qt, &value, 0, e);
+    return checkTypeRange(diags, qt, &value, 0, e);
 }
 
 public fn bool checkBitfield(diagnostics.Diags* diags, u8 bitfield_width, bool bitfield_signed, const Expr* e) {
@@ -294,7 +294,7 @@ public fn bool checkBitfield(diagnostics.Diags* diags, u8 bitfield_width, bool b
 }
 
 // Expr* e can be nil
-public fn bool checkRange(diagnostics.Diags* diags, QualType qt, Value* value, SrcLoc loc, const Expr* e) {
+public fn bool checkTypeRange(diagnostics.Diags* diags, QualType qt, Value* value, SrcLoc loc, const Expr* e) {
     QualType canon = qt.getCanonicalType();
     if (!canon.isBuiltin()) return true;  // TODO find out cases
     // hack to accept `u32 x = ~1;`

--- a/ast/ast_evaluator.c2
+++ b/ast/ast_evaluator.c2
@@ -350,7 +350,7 @@ fn Value Evaluator.eval_call(Evaluator* caller, const CallExpr* c) {
                     //fprintf(stderr, "calling funDD at %p\n", cname, fun.address);
                     return Value.createFloat(fun.funDD(eval.args[0].toFloat()));
                 }
-                printf("function prototype not supported");
+                fprintf(stderr, "function prototype not supported: %s\n", fd.getCName());
                 qt1.dump_full();
                 rt.dump_full();
                 return Value.error("function prototype not supported");

--- a/ast/value.c2
+++ b/ast/value.c2
@@ -154,7 +154,7 @@ public fn u16 Value.as_u16(Value* v) {
     return (u16)res;
 }
 
-public fn i32 Value.as_i32(Value* v) {
+public fn i32 Value.as_i32(Value* v) @(unused) {
     u64 res = 0;
     if (v.kind == ValueKind.Integer) {
         res = v.uvalue;

--- a/test/init/array/init_array_designator_nonint5.c2
+++ b/test/init/array/init_array_designator_nonint5.c2
@@ -1,0 +1,24 @@
+// @warnings{no-unused}
+module test;
+
+i32[] a1 = {
+    [0.0] = 0,  // @error{array designator expression must have integer type}
+}
+
+i32[] a2 = {
+    [0 / 0] = 0,  // @error{division by zero is undefined}
+}
+
+i32[] a3 = {
+    [0xFFFFFFFF] = 0,  // @error{array index 4294967295 is too large}
+}
+
+i32[] a4 = {
+    [0xFFFFFFFE] = 0,
+    0  // @error{array index 4294967295 is too large}
+}
+
+i32[] a5 = {
+    [0x100000000] = 0,  // @error{array index 4294967296 is too large}
+}
+

--- a/test/init/array/init_array_strings.c2
+++ b/test/init/array/init_array_strings.c2
@@ -1,0 +1,18 @@
+// @warnings{no-unused}
+module test;
+
+char[][16] a1 = {
+    "Hello",
+    "world",
+    "this",
+    "is",
+    "c2",
+}
+
+char[][16] a2 = {
+    [0] = "Hello",
+    [1] = "world",
+    [2] = "this",
+    [3] = "is",
+    [4] = "c2",
+}

--- a/test/init/struct/init_struct_strings.c2
+++ b/test/init/struct/init_struct_strings.c2
@@ -1,0 +1,16 @@
+// @warnings{no-unused}
+module test;
+
+type S struct {
+    char[16] s1;
+    char[16] s2;
+    char[16] s3;
+}
+
+S s1 = { "hello", "world", "!" }
+
+S s2 = {
+    .s1 = "hello",
+    .s2 = "world",
+    .s3 = "!",
+}


### PR DESCRIPTION
* accept string literals for 2D `char` array initializers with designators
* reject non integer array designators
* reject more out of range array designators
* rename `ctv_analyser.checkRange` as `ctv_analyser.checkTypeRange` for clarity
* simplify `analyseInitListArray()` and `checkArrayDesignators()`
* add tests