### PR TITLE
Compiler: remove last cpp style cast

### DIFF
--- a/ir/constant_list.c2
+++ b/ir/constant_list.c2
@@ -46,7 +46,7 @@ fn u32 ConstantList.add(ConstantList* l, const Constant* c) {
     if (l.count >= l.capacity) {
         l.capacity *= 2;
         void* constants2 = stdlib.malloc(l.capacity * sizeof(Constant));
-        void* old = (void*)l.constants;
+        void* old = l.constants;
         if (old) {
             memcpy(constants2, old, l.count * sizeof(Constant));
             stdlib.free(old);

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -323,5 +323,5 @@ public fn void Token.init(Token* tok) {
 }
 
 public fn Radix Token.getRadix(const Token* tok) {
-    return cast<Radix>(tok.radix);
+    return (Radix)tok.radix;
 }


### PR DESCRIPTION
* also remove redundant `(void*)` cast