### PR TITLE
Tests: fix modulo tests

### DIFF
--- a/test/expr/arithmetic/reminder_assert.c2
+++ b/test/expr/arithmetic/reminder_assert.c2
@@ -1,19 +1,10 @@
 // @warnings{no-unused}
 module test;
 
-static_assert( 10 %  20,  10);
-static_assert(-10 %  20, -10);
-static_assert( 10 % -20,  10);
-static_assert(-10 % -20, -10);
-static_assert(10.0 % 2,  0);    // @error{invalid operand for binary operation remainder}
-
-static_assert(10 % 2.0,  0);    // @error{invalid operand for binary operation remainder}
-
 fn void test1() {
-    const f32 a = 10 % 2.0;
+    f32 a = 10 % 2.0;    // @error{invalid operand for binary operation remainder}
 }
 
 fn void test2() {
-    const f32 a = 10.0 % 5;
+    f32 a = 10.0 % 5;    // @error{invalid operand for binary operation remainder}
 }
-

--- a/test/expr/arithmetic/reminder_static_assert.c2
+++ b/test/expr/arithmetic/reminder_static_assert.c2
@@ -1,0 +1,9 @@
+// @warnings{no-unused}
+module test;
+
+static_assert( 10 %  20,  10);
+static_assert(-10 %  20, -10);
+static_assert( 10 % -20,  10);
+static_assert(-10 % -20, -10);
+static_assert(10.0 % 2,  0);    // @error{invalid operand for binary operation remainder}
+static_assert(10 % 2.0,  0);    // @error{invalid operand for binary operation remainder}


### PR DESCRIPTION
* split test file so both `static_assert` and `assert` expressions may cause argument type errors to be reported.