### PR TITLE
Compiler: prevent warnings in C compilation for older gcc

### DIFF
--- a/generator/c2refs.c2
+++ b/generator/c2refs.c2
@@ -342,8 +342,8 @@ fn void Lengths.fillDest(const Lengths* l, Dest* result, u32 offset, u32 start, 
     u32 last = start + count;
     u32 line = 1;
     for (u32 i = start; i < last; i++) {
-        u8 len = l.lengths[i];
-        if (offset < len) break;    // <=?
+        u32 len = l.lengths[i];
+        if (offset < len) break;
         offset -= len;
         line++;
     }

--- a/ir/context.c2
+++ b/ir/context.c2
@@ -434,7 +434,7 @@ public fn Ref Context.addLoadInstr(Context* c, Type t, Ref src) {
 
     Ref out.init(RefKind.Temp, c.b.tmp_info.instructions.getCount());
 
-    InstrKind k;
+    InstrKind k = None;     // prevent C warning
     switch (t) {
     case None:
         assert(0);


### PR DESCRIPTION
* prevent warning on signed/unsigned comparison for `u32 < u8`
* prevent warning on unintialized `k` after switch.