### PR TITLE
Compiler: improve split_paths

### DIFF
--- a/common/string_utils.c2
+++ b/common/string_utils.c2
@@ -58,17 +58,12 @@ public type PathHandler fn void (void* arg, const char* path, u32 len);
 public fn void split_paths(const char* input, void* arg, PathHandler handler) @(unused) {
     // split by ':'
     const char* start = input;
-    const char* cp = start;
-    while (1) {
-        if (*cp == 0) {
+    for (const char* cp = start;; cp++) {
+        if (*cp == '\0' || *cp == ':') {
             if (cp != start) handler(arg, start, (u32)(cp - start));
-            return;
+            if (*cp == '\0') return;
+            start = cp + 1;
         }
-        if (*cp == ':') {
-            if (cp != start) handler(arg, start, (u32)(cp - start));
-            start = cp+1;
-        }
-        cp++;
     }
 }
 

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -84,7 +84,7 @@ public type Options struct {
     bool asan;
     bool msan;
     bool ubsan;
-    const char* libdir; // no ownership, from environment varible C2_LIBDIR
+    const char* libdir; // no ownership, from environment variable C2_LIBDIR
     char *target_triple;
 }
 
@@ -280,7 +280,7 @@ fn void Compiler.build(Compiler* c,
         }
         if (c.opts.libdir) {
             // parse into multiple, add each to string-pool
-            string_utils.split_paths(c.opts.libdir, c, handle_path);
+            string_utils.split_paths(c.opts.libdir, c, Compiler.addLibPath);
         }
         c.targetInfo.getNative();
     }
@@ -684,7 +684,7 @@ fn void Compiler.addGlobalDefine(Compiler* c, const char* prefix, const char* ta
 }
 
 // NOTE: paths are not 0-terminated
-fn void handle_path(void* arg, const char* path, u32 len) {
+fn void Compiler.addLibPath(void* arg, const char* path, u32 len) {
     Compiler* c = arg;
     u32 path_idx = c.auxPool.add(path, len, true);
     //stdio.printf("PATH [%s]\n", c.auxPool.idx2str(path_idx));


### PR DESCRIPTION
* factorize code in `split_paths()`
* rename `handle_path` as more explicit `Compiler.addLibPath()`