### PR TITLE
debug: use common string_buffer for dump functions

### DIFF
--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -250,11 +250,9 @@ public fn void Decl.setGenerated(Decl* d) { d.declBits.is_generated = 1; }
 public fn void Decl.clearGenerated(Decl* d) { d.declBits.is_generated = 0; }
 
 public fn void Decl.dump(const Decl* d) {
-    string_buffer.Buf* out = string_buffer.create(10*4096, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     d.print(out, 0);
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 public fn bool Decl.isTypeDecl(const Decl* d) {

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -17,7 +17,6 @@ module ast;
 
 import src_loc local;
 import string_buffer;
-import stdio;
 
 public type ExprKind enum u8 {
     IntegerLiteral,
@@ -500,11 +499,9 @@ public fn bool Expr.needsSemi(const Expr* e) {
 }
 
 public fn void Expr.dump(const Expr* e) {
-    string_buffer.Buf* out = string_buffer.create(10*4096, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     e.print(out, 0);
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 fn void Expr.print(const Expr* e, string_buffer.Buf* out, u32 indent) {

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -16,9 +16,9 @@
 module ast;
 
 import ast_context;
-import string_buffer;
 import src_loc local;
-import stdio;
+import string_buffer;
+
 import string;
 
 public const u32 MemberExprMaxDepth = 7;
@@ -321,7 +321,7 @@ fn void MemberExpr.printLiteral(const MemberExpr* e, string_buffer.Buf* out) {
 }
 
 public fn void MemberExpr.dump(const MemberExpr* m) @(unused) {
-    string_buffer.Buf* out = string_buffer.create(4096, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     out.color(col_Expr);
     out.print("MemberExpr expr %d ref %d/%d\n", m.hasExpr(), m.base.base.memberExprBits.num_decls, m.getNumRefs());
     const MemberExprBits* bits = &m.base.base.memberExprBits;
@@ -350,8 +350,6 @@ public fn void MemberExpr.dump(const MemberExpr* m) @(unused) {
         }
 
     }
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -15,7 +15,6 @@
 
 module ast;
 
-import color;
 import string_buffer;
 import stdio local;
 
@@ -422,18 +421,15 @@ public fn const char* QualType.diagNameBare(const QualType* qt) {
 }
 
 public fn void QualType.dump(const QualType* qt) @(unused) {
-    string_buffer.Buf* out = string_buffer.create(512, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     qt.printInner(out, false, true, false);
-    out.color(color.Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 public fn void QualType.dump_full(const QualType* qt) {
-    string_buffer.Buf* out = string_buffer.create(512, useColor(), 1);
+    string_buffer.Buf* out = ast.getDumpBuf();
     qt.fullPrint(out, 0);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 fn void QualType.printQuoted(const QualType* qt, string_buffer.Buf* out) {

--- a/ast/stmt.c2
+++ b/ast/stmt.c2
@@ -15,10 +15,8 @@
 
 module ast;
 
-import string_buffer;
 import src_loc local;
-
-import stdio;
+import string_buffer;
 
 public type StmtKind enum u8 {
     Return,
@@ -171,11 +169,9 @@ public fn SrcLoc Stmt.getLoc(const Stmt* s) {
 }
 
 public fn void Stmt.dump(const Stmt* s) {
-    string_buffer.Buf* out = string_buffer.create(10*4096, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     s.print(out, 0);
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 fn void Stmt.print(const Stmt* s, string_buffer.Buf* out, u32 indent) {

--- a/ast/symbol_table.c2
+++ b/ast/symbol_table.c2
@@ -15,10 +15,9 @@
 
 module ast;
 
-import string_buffer;
 import color;
+import string_buffer;
 
-import stdio local;
 import stdlib;
 import string;
 
@@ -144,7 +143,7 @@ public fn void SymbolTable.print(const SymbolTable* t, string_buffer.Buf* out) {
 }
 
 public fn void SymbolTable.dump(const SymbolTable* t) @(unused) {
-    string_buffer.Buf* out = string_buffer.create(4096, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     u32 count = t.num_public + t.num_private;
 
     out.add("Symbols:\n");
@@ -153,7 +152,6 @@ public fn void SymbolTable.dump(const SymbolTable* t) @(unused) {
         const char* name = ast.idx2name(name_idx);
         out.print("  [%2d]  %6d  %s\n", i, name_idx, name);
     }
-    fputs(out.data(), stdout);
-    out.free();
+    ast.flushDumpBuf(out);
 }
 

--- a/ast/type.c2
+++ b/ast/type.c2
@@ -15,9 +15,7 @@
 
 module ast;
 
-import color;
 import string_buffer;
-import stdio;
 
 public type TypeKind enum u8 {
     Builtin,
@@ -109,11 +107,10 @@ public fn bool Type.isVoidType(const Type* t) {
 }
 
 public fn void Type.dump(const Type* t) @(unused) {
-    string_buffer.Buf* out = string_buffer.create(256, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     t.print(out);
-    out.color(color.Normal);
-    stdio.printf("%s\n", out.data());
-    out.free();
+    out.newline();
+    ast.flushDumpBuf(out);
 }
 
 fn u32 Type.getAlignment(const Type* t) {

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -187,8 +187,8 @@ public fn void TypeRefHolder.setPrefix(TypeRefHolder* h, SrcLoc loc, u32 name_id
 }
 
 public fn void TypeRefHolder.dump(const TypeRefHolder* h) @(unused) {
+    string_buffer.Buf* out = ast.getDumpBuf();
     const TypeRef* r = (TypeRef*)&h.ref;
-    string_buffer.Buf* out = string_buffer.create(128, useColor(), 2);
     r.print(out, false);
     for (u32 i=0; i<r.getNumArrays(); i++) {
         out.add1('[');
@@ -196,9 +196,7 @@ public fn void TypeRefHolder.dump(const TypeRefHolder* h) @(unused) {
         if (size) h.arrays[i].printLiteral(out);
         out.add1(']');
     }
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 
@@ -532,16 +530,14 @@ fn void TypeRef.print(const TypeRef* r, string_buffer.Buf* out, bool filled) {
 
 // Note: only use on filled TypeRef
 public fn void TypeRef.dump(const TypeRef* r) @(unused) {
-    string_buffer.Buf* out = string_buffer.create(128, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     r.print(out, true);
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 // Note: only use on filled TypeRef
 public fn void TypeRef.dump_full(const TypeRef* r) @(unused) {
-    string_buffer.Buf* out = string_buffer.create(1024, useColor(), 2);
+    string_buffer.Buf* out = ast.getDumpBuf();
     out.add("TypeRef:\n");
     out.indent(1);
     out.add("flags:");
@@ -560,10 +556,7 @@ public fn void TypeRef.dump_full(const TypeRef* r) @(unused) {
         const Ref* ref = &r.refs[i];
         out.print("ref[%d] loc %d  name_idx %d  decl %p\n", i, ref.loc, ref.name_idx, ref.decl);
     }
-
-    out.color(col_Normal);
-    stdio.puts(out.data());
-    out.free();
+    ast.flushDumpBuf(out);
 }
 
 public fn const char* TypeRef.diagName(const TypeRef* r) {

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -18,8 +18,10 @@ module ast;
 import attr;
 import color;
 import ast_context local;
+import string_buffer;
 import string_pool;
 
+import stdio;
 import stdlib;
 import string;
 
@@ -111,6 +113,7 @@ public type Globals struct @(opaque) {
 
     u32[elemsof(attr.AttrKind)] attr_name_indexes;
 
+    string_buffer.Buf* dump_buf;
 #if AstStatistics
     Stats stats;
 #endif
@@ -141,6 +144,7 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
     globals.ast_count = 1;
     globals.ast_capacity = 0;
     globals.ast_list = nil;
+    globals.dump_buf = string_buffer.create(4096, use_color, 2);
 #if AstStatistics
     globals.stats.reset();
 #endif
@@ -192,13 +196,14 @@ public fn void deinit(bool print_stats) {
     globals.string_types.clear();
     stdlib.free(globals);
     stdlib.free(builtins);
+    globals.dump_buf.free();
 }
 
 public fn u32 getWordSize() {
     return globals.wordsize;
 }
 
-fn bool useColor() {
+public fn bool useColor() @(unused) {
     return globals.use_color;
 }
 
@@ -249,6 +254,16 @@ public fn u32 ast2idx(const AST* ast_) {
 fn AST* idx2ast(u32 idx) {
     if (idx == 0) return nil;
     return globals.ast_list[idx];
+}
+
+fn string_buffer.Buf* getDumpBuf() {
+    return globals.dump_buf;
+}
+
+fn void flushDumpBuf(string_buffer.Buf* out) {
+    out.color(col_Normal);
+    stdio.puts(out.data());
+    out.clear();
 }
 
 // Note: qt must be valid

--- a/common/component.c2
+++ b/common/component.c2
@@ -192,7 +192,6 @@ public fn void Component.print(const Component* c, bool show_funcs) {
     for (u32 i=0; i<c.mods.length(); i++) {
         mods[i].print(out, show_funcs);
     }
-
     out.color(color.Normal);
     stdio.puts(out.data());
     out.free();


### PR DESCRIPTION
* add `ast.globals.dump_buf` for dump functions
* add `ast.getDumpBuf()` and `ast.flushDumpBuf()` for dump functions