### PR TITLE
Compiler: support dark-mode

### DIFF
--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -128,6 +128,24 @@ public fn void setGlobals(Globals* g) @(unused) { globals = g; }
 
 // wordsize in bytes, must NOT be called from Plugin!
 public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, bool use_color) {
+    if (use_color) {
+        // adjust colors for readability on dark mode terminals
+        const char* colorfgbg = stdlib.getenv("COLORFGBG");
+        const char* c2_colors = stdlib.getenv("C2_COLORS");
+        if (c2_colors && !string.strncmp(c2_colors, "none", 4)) {
+            use_color = false;
+        } else
+        if ((c2_colors && !string.strncmp(c2_colors, "dark", 4))
+        ||  (colorfgbg && *colorfgbg && !string.strcmp(colorfgbg + 1, ";0"))) {
+            // use brighter colors in dark mode
+            col_Attr = color.Bblue;
+            col_Template = color.Bgreen;
+            col_Type = color.Bgreen;
+            col_Error = color.Bred;
+            col_Calc = color.Byellow;
+        }
+    }
+
     Globals* g = stdlib.calloc(sizeof(Globals), 1);
     g.pointers.init(c);
     g.string_types.init(c);


### PR DESCRIPTION
* disable colors if `C2_COLORS` environment variable is set to `none`
* use brighter text colors in terminals with dark background by testing
  - if C2_COLORS is set to `dark`
  - if COLORFGBG specifies 0 background color