### PR TITLE
tester: add duplicate error detection

### DIFF
--- a/test/types/struct/bitfield_packed.c2
+++ b/test/types/struct/bitfield_packed.c2
@@ -1,4 +1,3 @@
-// @skip
 // @warnings{no-unused}
 module test;
 

--- a/tools/tester/issues.c2
+++ b/tools/tester/issues.c2
@@ -24,12 +24,13 @@ import unistd; // getcwd()
 
 type Issue struct {
     u32 filename; // into Issues' string pool
-    i32 line_nr;
+    u32 line_nr;
     u32 msg;    // index into Issues' string pool
+    bool found;
 }
 
 public type Iter struct {
-    const Issues* issues;
+    Issues* issues;
     u32 idx;
 }
 
@@ -44,12 +45,22 @@ public fn const char* relativeFilename(const char *name) {
     return name;
 }
 
+public fn bool Iter.find(Iter* iter, const char* filename, u32 line_nr) {
+    const Issues* i = iter.issues;
+    for (; iter.more(); iter.next()) {
+        const Issue* cur = &i.issues[iter.idx];
+        if (cur.line_nr == line_nr && !strcmp(&i.pool[cur.filename], filename))
+            return true;
+    }
+    return false;
+}
+
 public fn const char* Iter.getFilename(const Iter* iter) {
     const Issue* cur = &iter.issues.issues[iter.idx];
     return relativeFilename(&iter.issues.pool[cur.filename]);
 }
 
-public fn i32 Iter.getLineNr(const Iter* iter) {
+public fn u32 Iter.getLineNr(const Iter* iter) {
     const Issue* cur = &iter.issues.issues[iter.idx];
     return cur.line_nr;
 }
@@ -57,6 +68,19 @@ public fn i32 Iter.getLineNr(const Iter* iter) {
 public fn const char* Iter.getMsg(const Iter* iter) {
     const Issue* cur = &iter.issues.issues[iter.idx];
     return &iter.issues.pool[cur.msg];
+}
+
+public fn bool Iter.getFound(const Iter* iter) {
+    const Issue* cur = &iter.issues.issues[iter.idx];
+    return cur.found;
+}
+
+public fn void Iter.setFound(const Iter* iter) {
+    Issue* cur = &iter.issues.issues[iter.idx];
+    if (!cur.found) {
+        cur.found = true;
+        iter.issues.found_count++;
+    }
 }
 
 public fn bool Iter.more(const Iter* iter) {
@@ -75,6 +99,8 @@ public type Issues struct @(opaque) {
     char* pool;
     u32 pool_count;
     u32 pool_capacity;
+
+    u32 found_count;
 }
 
 public fn Issues* create() {
@@ -101,12 +127,12 @@ fn void Issues.resizePool(Issues* i, u32 capacity) {
 }
 
 fn u32 Issues.addPool(Issues* i, const char* text) {
-    u32 len = (u32)strlen(text) + 1;      // includes 0-terminator
-    while (i.pool_count + len >= i.pool_capacity) i.resizePool(i.pool_capacity * 2);
+    u32 size = (u32)strlen(text) + 1;      // includes 0-terminator
+    while (i.pool_count + size > i.pool_capacity) i.resizePool(i.pool_capacity * 2);
 
     u32 idx = i.pool_count;
-    memcpy(i.pool + i.pool_count, text, len);
-    i.pool_count += len;
+    memcpy(i.pool + i.pool_count, text, size);
+    i.pool_count += size;
     return idx;
 }
 
@@ -125,42 +151,17 @@ public fn void Issues.add(Issues* i, const char* filename, u32 line_nr, const ch
 
     Issue* cur = &i.issues[i.count];
     cur.filename = i.addPool(filename);
-    cur.line_nr = (i32)line_nr;
+    cur.line_nr = line_nr;
     cur.msg = i.addPool(msg);
+    cur.found = false;
     i.count++;
 }
 
-fn void Issues.erase_idx(Issues* i, u32 idx) {
-    // Note: does not erase text from pool
-    for (u32 j = idx; j < i.count-1; j++) i.issues[j] = i.issues[j+1];
-    i.count--;
+public fn bool Issues.allFound(const Issues* i) {
+    return i.count == i.found_count;
 }
 
-public fn void Issues.erase(Issues* i, const char* filename, i32 line_nr) {
-    for (u32 j=0; j<i.count; j++) {
-        const Issue* cur = &i.issues[j];
-        if (cur.line_nr != line_nr) continue;
-        if (strcmp(&i.pool[cur.filename], filename) == 0) {
-            i.erase_idx(j);
-            return;
-        }
-    }
-}
-
-public fn const char* Issues.find(Issues* i, const char* filename, i32 line_nr) {
-    for (u32 j=0; j<i.count; j++) {
-        const Issue* cur = &i.issues[j];
-        if (cur.line_nr != line_nr) continue;
-        if (strcmp(&i.pool[cur.filename], filename) == 0) return &i.pool[cur.msg];
-    }
-    return nil;
-}
-
-public fn bool Issues.empty(const Issues* i) {
-    return i.count == 0;
-}
-
-public fn Iter Issues.getIter(const Issues* i) {
+public fn Iter Issues.getIter(Issues* i) {
     Iter iter = { i, 0 }
     return iter;
 }

--- a/tools/tester/line_db.c2
+++ b/tools/tester/line_db.c2
@@ -47,7 +47,7 @@ public fn u32 Db.size(const Db* db) {
     return db.count;
 }
 
-public fn void Db.resize(Db* db, u32 capacity) {
+fn void Db.resize(Db* db, u32 capacity) {
     Entry* entries2 = malloc(capacity * sizeof(Entry));
     if (db.count) {
         memcpy(entries2, db.entries, db.count * sizeof(Entry));

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -22,7 +22,6 @@ import stdlib local;
 import string local;
 import unistd local;
 
-import color;
 import expect_file local;
 import file_utils;
 import issues local;
@@ -156,15 +155,20 @@ fn void Db.addExpected(Db* db, ExpectFile* f) {
     db.expectedCount++;
 }
 
-fn void Db.matchNote(Db* db, const char* filename, i32 linenr, const char* msg) {
-    const char* match = db.notes.find(filename, linenr);
-    if (match) {
+fn void Db.matchNote(Db* db, const char* filename, u32 linenr, const char* msg) {
+    Iter iter = db.notes.getIter();
+    if (iter.find(filename, linenr)) {
+        const char* match = iter.getMsg();
+        if (iter.getFound()) {
+            color_print2(db.output, colError, "%s:%d: duplicate note: %s", relativeFilename(filename), linenr, msg);
+            db.hasErrors = true;
+        } else
         if (!same_string(match, msg)) {
             color_print2(db.output, colError, "%s:%d: wrong note: %s", relativeFilename(filename), linenr, msg);
             color_print2(db.output, colError, "     expected: %s", match);
             db.hasErrors = true;
         }
-        db.notes.erase(filename, linenr);
+        iter.setFound();
         return;
     }
     // not expected
@@ -172,15 +176,20 @@ fn void Db.matchNote(Db* db, const char* filename, i32 linenr, const char* msg) 
     db.hasErrors = true;
 }
 
-fn void Db.matchWarning(Db* db, const char* filename, i32 linenr, const char* msg) {
-    const char* match = db.warnings.find(filename, linenr);
-    if (match) {
+fn void Db.matchWarning(Db* db, const char* filename, u32 linenr, const char* msg) {
+    Iter iter = db.warnings.getIter();
+    if (iter.find(filename, linenr)) {
+        const char* match = iter.getMsg();
+        if (iter.getFound()) {
+            color_print2(db.output, colError, "%s:%d: duplicate warning: %s", relativeFilename(filename), linenr, msg);
+            db.hasErrors = true;
+        } else
         if (!same_string(match, msg)) {
             color_print2(db.output, colError, "%s:%d: wrong warning: %s", relativeFilename(filename), linenr, msg);
             color_print2(db.output, colError, "     expected: %s", match);
             db.hasErrors = true;
         }
-        db.warnings.erase(filename, linenr);
+        iter.setFound();
         return;
     }
     // not expected
@@ -188,15 +197,20 @@ fn void Db.matchWarning(Db* db, const char* filename, i32 linenr, const char* ms
     db.hasErrors = true;
 }
 
-fn void Db.matchError(Db* db, const char* filename, i32 linenr, const char* msg) {
-    const char* match = db.errors.find(filename, linenr);
-    if (match) {
+fn void Db.matchError(Db* db, const char* filename, u32 linenr, const char* msg) {
+    Iter iter = db.errors.getIter();
+    if (iter.find(filename, linenr)) {
+        const char* match = iter.getMsg();
+        if (iter.getFound()) {
+            color_print2(db.output, colError, "%s:%d: duplicate error: %s", relativeFilename(filename), linenr, msg);
+            db.hasErrors = true;
+        } else
         if (!same_string(match, msg)) {
             color_print2(db.output, colError, "%s:%d: wrong error: %s", relativeFilename(filename), linenr, msg);
             color_print2(db.output, colError, "     expected: %s", match);
             db.hasErrors = true;
         }
-        db.errors.erase(filename, linenr);
+        iter.setFound();
         return;
     }
     // not expected
@@ -381,9 +395,7 @@ fn bool Db.parseExpect(Db* db) {
     db.addExpected(db.currentExpect);
     while (*db.cur != 0 && !strstart(db.cur, "// @", nil)) {
         if (*db.cur != '\n') {
-            const char* end = db.cur;
-            while (*end != 0 && *end != '\n') end++;
-            db.currentExpect.addLine(db.line_nr, db.cur, end);
+            db.currentExpect.addLine(db.line_nr, db.cur, db.findEndOfLine());
         }
         db.skipLine();
     }
@@ -463,8 +475,7 @@ fn void Db.error(Db* db, const char* format @(printf_format), ...) {
     va_start(args, format);
     vsnprintf(msg, sizeof(msg), format, args);
     va_end(args);
-    // TODO use colError?
-    color_print2(db.output, color.Bred, "%s:%d: %s", db.filename, db.line_nr, msg);
+    color_print2(db.output, colError, "%s:%d: %s", db.filename, db.line_nr, msg);
     db.hasErrors = true;
 }
 
@@ -491,29 +502,30 @@ fn void Db.parseTags(Db* db, const char* start, const char* end) {
     char[128] msg;
     if (!db.readUntil(msg, elemsof(msg), cp, '}', "message"))
         return;
+    u32 line_nr = db.line_nr - db.line_offset;
     switch (kind) {
     case ERROR:
 #if TesterDebug
-        color_print(color.Blue, "  expecting error '%s' at %d", msg, db.line_nr - db.line_offset);
+        color_print(color.Blue, "  expecting error '%s' at %d", msg, line_nr);
 #endif
-        db.errors.add(db.current_file, db.line_nr - db.line_offset, msg);
+        db.errors.add(db.current_file, line_nr, msg);
         break;
     case WARNING:
 #if TesterDebug
-        color_print(color.Blue, "  expecting warning '%s' at %d", msg, db.line_nr - db.line_offset);
+        color_print(color.Blue, "  expecting warning '%s' at %d", msg, line_nr);
 #endif
-        db.warnings.add(db.current_file, db.line_nr - db.line_offset, msg);
+        db.warnings.add(db.current_file, line_nr, msg);
         break;
     case NOTE:
 #if TesterDebug
-        color_print(color.Blue, "  expecting note '%s' at %d", msg, db.line_nr - db.line_offset);
+        color_print(color.Blue, "  expecting note '%s' at %d", msg, line_nr);
 #endif
-        db.notes.add(db.current_file, db.line_nr - db.line_offset, msg);
+        db.notes.add(db.current_file, line_nr, msg);
         break;
     }
 }
 
-public fn void Db.parseLineOutside(Db* db, const char* start, const char* end) {
+fn void Db.parseLineOutside(Db* db, const char* start, const char* end) {
     const char* cp = start;
     skipInitialWhitespace(&cp, end);
     if (cp == end) return;
@@ -582,7 +594,7 @@ public fn void Db.parseLineOutside(Db* db, const char* start, const char* end) {
     db.parseTags(start, end);
 }
 
-public fn void Db.parseLineFile(Db* db, const char* start, const char* end) {
+fn void Db.parseLineFile(Db* db, const char* start, const char* end) {
     // if line starts with '// @' stop Infile mode
     if (strstart(start, "// @", nil)) {
         assert(db.file_start);
@@ -597,7 +609,7 @@ public fn void Db.parseLineFile(Db* db, const char* start, const char* end) {
     db.parseTags(start, end);
 }
 
-public fn void Db.parseLineExpect(Db* db, const char* start, const char* end) {
+fn void Db.parseLineExpect(Db* db, const char* start, const char* end) {
     // if line starts with '// @' stop InExpectFile mode
     if (strstart(start, "// @", nil)) {
         db.currentExpect = nil;
@@ -610,7 +622,7 @@ public fn void Db.parseLineExpect(Db* db, const char* start, const char* end) {
     // TODO add non-empty lines (stripped of heading+trailing whitespace) to list
 }
 
-public fn void Db.parseLine(Db* db, const char* start, const char* end) {
+fn void Db.parseLine(Db* db, const char* start, const char* end) {
     switch (db.mode) {
     case Outside:
         db.parseLineOutside(start, end);
@@ -721,7 +733,7 @@ public fn void Db.testFile(Db* db) {
         close(pipe_stderr[1]);
 
         // collect output and check errors
-        string_buffer.Buf* buf = string_buffer.create(4096, true, 2);
+        string_buffer.Buf* buf = string_buffer.create(4096, false, 2);
         for (;;) {
             char[64*1024] buffer;
             isize count = read(pipe_stderr[0], buffer, sizeof(buffer));
@@ -741,10 +753,7 @@ public fn void Db.testFile(Db* db) {
 
         if (!doWIFEXITED(status)) {  // child exited abnormally
             // TODO print pipe_stderr
-            db.output.color(colError);
-            db.output.add("c2c crashed!");
-            db.output.color(color.Normal);
-            db.output.newline();
+            color_print2(db.output, colError, "c2c crashed!");
             db.hasErrors = true;
             return;
         }
@@ -756,10 +765,7 @@ public fn void Db.testFile(Db* db) {
             exit(EXIT_FAILURE);
         }
         if (retcode == 254) { // from TODO/FATAL_ERROR macros
-            db.output.color(colError);
-            db.output.add("c2c returned error");
-            db.output.color(color.Normal);
-            db.output.newline();
+            color_print2(db.output, colError, "c2c returned error");
             db.hasErrors = true;
             return;
         }
@@ -768,7 +774,7 @@ public fn void Db.testFile(Db* db) {
         close(pipe_stderr[0]);
         wait(nil);
         db.checkExpectedFiles();
-        if (!db.errors.empty() || !db.warnings.empty()) db.hasErrors = true;
+        if (!db.errors.allFound() || !db.warnings.allFound()) db.hasErrors = true;
     }
 }
 
@@ -777,43 +783,34 @@ fn void Db.checkDiagnosticLine(Db* db, const char* line) {
     color_print(color.White, "line: '%s'", line);
 #endif
     // line syntax: '<filename>.c2:<linenr>:<offset>: error/warning/note: <msg>\n'
-    char[128] filename = "";
-    char[128] msg = "";
-    i32 error_line = 0;
-    i32 col = 0;
+    char[128] filename;
+    char[128] msg;
+    char[8] tag;
+    u32 error_line;
+    u32 col;
 
-    i32 res = sscanf(line, "%[^: ]:%d:%d: error: %[^\n]\n", filename, &error_line, &col, msg);
-    if (res == 4) {
-        // found error
+    if (sscanf(line, "%127[^: \n]:%u:%u: %7[a-z]: %127[^\n]", filename, &error_line, &col, tag, msg) != 5)
+        return;
+
+    switch (tag) {
+    case "error":
 #if TesterDebug
-        color_print(color.Cyan, "%s %d:%d '%s'", filename, error_line, col, msg);
+        color_print(color.Cyan, "%s %d:%d %s '%s'", filename, error_line, col, tag, msg);
 #endif
         db.matchError(filename, error_line, msg);
-    } else {
-        res = sscanf(line, "%[^: ]:%d:%d: warning: %[^\n]\n", filename, &error_line, &col, msg);
-        if (res == 4) {
-            // found warning
+        break;
+    case "warning":
 #if TesterDebug
-            color_print(color.Cyan, "%s %d:%d '%s'", filename, error_line, col, msg);
+        color_print(color.Cyan, "%s %d:%d %s '%s'", filename, error_line, col, tag, msg);
 #endif
-            db.matchWarning(filename, error_line, msg);
-        } else {
-            res = sscanf(line, "%[^: ]:%d:%d: note: %[^\n]\n", filename, &error_line, &col, msg);
-            if (res == 4) {
-                // found note
+        db.matchWarning(filename, error_line, msg);
+        break;
+    case "note":
 #if TesterDebug
-                color_print(color.Cyan, "%s %d:%d '%s'", filename, error_line, col, msg);
+        color_print(color.Cyan, "%s %d:%d %s '%s'", filename, error_line, col, tag, msg);
 #endif
-                db.matchNote(filename, error_line, msg);
-            }
-        }
-    }
-
-    if (res == 4) {
-        // match msg string and set cp to that to avoid duplicates on empty lines
-        const char* found = strstr(line, msg);
-        assert(found);
-        line = found;
+        db.matchNote(filename, error_line, msg);
+        break;
     }
 }
 
@@ -829,15 +826,17 @@ fn void Db.checkErrors(Db* db, const char* buffer, u32 size) {
         // cut up into lines
         if (*cp == ':') haveColon = true;
         if (*cp == '\n') {
-            char[512] data;
-            u32 len = (u32)(cp - line);
-            assert(len < sizeof(data));
-            memcpy(data, line, len);
-            data[len] = 0;
-            if (haveColon) db.checkDiagnosticLine(data);
+            if (haveColon) {
+                char[512] data;
+                u32 len = (u32)(cp - line);
+                assert(len < sizeof(data));
+                memcpy(data, line, len);
+                data[len] = 0;
+                db.checkDiagnosticLine(data);
+                haveColon = false;
+            }
             cp++;
             line = cp;
-            haveColon = false;
         } else {
             cp++;
         }
@@ -855,37 +854,23 @@ fn void Db.checkExpectedFiles(Db* db) {
 
 public fn bool Db.printIssues(const Db* db) {
     bool res = false;
-    issues.Iter iter = db.errors.getIter();
-    while (iter.more()) {
-        db.output.color(colError);
-        db.output.print("%s:%d: expected error '%s'",
-                iter.getFilename(), iter.getLineNr(), iter.getMsg());
-        db.output.color(color.Normal);
-        db.output.newline();
+    for (issues.Iter iter = db.errors.getIter(); iter.more(); iter.next()) {
+        if (iter.getFound()) continue;
+        color_print2(db.output, colError, "%s:%d: expected error '%s'",
+                     iter.getFilename(), iter.getLineNr(), iter.getMsg());
         res = true;
-        iter.next();
     }
-
-    iter = db.warnings.getIter();
-    while (iter.more()) {
-        db.output.color(colError);
-        db.output.print("%s:%d: expected warning '%s'",
-                iter.getFilename(), iter.getLineNr(), iter.getMsg());
-        db.output.color(color.Normal);
-        db.output.newline();
+    for (issues.Iter iter = db.warnings.getIter(); iter.more(); iter.next()) {
+        if (iter.getFound()) continue;
+        color_print2(db.output, colError, "%s:%d: expected warning '%s'",
+                     iter.getFilename(), iter.getLineNr(), iter.getMsg());
         res = true;
-        iter.next();
     }
-
-    iter = db.notes.getIter();
-    while (iter.more()) {
-        db.output.color(colError);
-        db.output.print("%s:%d: expected note '%s'",
-                iter.getFilename(), iter.getLineNr(), iter.getMsg());
-        db.output.color(color.Normal);
-        db.output.newline();
+    for (issues.Iter iter = db.notes.getIter(); iter.more(); iter.next()) {
+        if (iter.getFound()) continue;
+        color_print2(db.output, colError, "%s:%d: expected note '%s'",
+                     iter.getFilename(), iter.getLineNr(), iter.getMsg());
         res = true;
-        iter.next();
     }
     return res;
 }

--- a/tools/tester/test_utils.c2
+++ b/tools/tester/test_utils.c2
@@ -23,13 +23,13 @@ import string local;
 import color;
 import string_buffer;
 
-bool color_output;
+public bool color_output;
 const char* proc_name = "";
 
 public const char* colError = color.Bred;
 public const char* colSkip = color.Bcyan;
 public const char* colOk = color.Green;
-public const char* colDebug = color.Bmagenta;
+//public const char* colDebug = color.Bmagenta;
 
 // NOTE: end must point AFTER last valid char (could be 0-terminator)
 

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -25,6 +25,7 @@ import c_errno local;
 import unistd;
 import pthread;
 
+import color;
 import test_utils local;
 import test_db local;
 import string_buffer;
@@ -251,8 +252,8 @@ fn void Tester.run_test(Tester* t, Test* test) {
 
     t.numtests++;
 
-    string_buffer.Buf* buf = string_buffer.create(4096, true, 2);
-    buf.print("%s ", test.filename);
+    string_buffer.Buf* buf = string_buffer.create(4096, color_output, 2);
+    buf.print("%s\n", test.filename);
 
     file_utils.File file.init("", test.filename);
     if (!file.load()) {
@@ -260,18 +261,13 @@ fn void Tester.run_test(Tester* t, Test* test) {
         exit(EXIT_FAILURE);
     }
 
-    test_db.Db db;
-    db.init(buf, file.data(), test.filename, test.kind, t.tmp_dir, c2c_cmd, t.cwd, runSkipped);
-    bool print = verboseLevel > 1;
+    test_db.Db db.init(buf, file.data(), test.filename, test.kind, t.tmp_dir, c2c_cmd, t.cwd, runSkipped);
     bool skip = db.parse();
     if (skip) {
         t.numskipped++;
-        buf.clear();
         color_print2(buf, colSkip, "%s SKIPPED", test.filename);
-        if (verboseLevel >= 1) print = true;
     } else {
-        buf.newline();
-
+        bool print = verboseLevel > 1;
         if (!db.haveErrors()) {
             db.testFile();
             if (db.printIssues()) print = true;
@@ -281,9 +277,8 @@ fn void Tester.run_test(Tester* t, Test* test) {
             test.failed = true;
             t.numerrors++;
         }
+        if (print) fputs(buf.data(), stdout);
     }
-    if (print) printf("%s", buf.data());
-
     db.destroy();
     file.close();
     buf.free();
@@ -316,7 +311,7 @@ public fn i32 main(i32 argc, char** argv) {
 
     u64 t1 = now();
 
-    set_color_output(argv[0], unistd.isatty(1));
+    set_color_output(argv[0], color.useColor());
 
     for (i32 i = 1; i < argc; i++) {
         char *arg = argv[i];


### PR DESCRIPTION
* simplify `Db.checkDiagnosticLine`
* report duplicate errors/warnings/notes
* use iterator in Db.match code
* add `Issue.found` indicator, no longer delete issues
* add `Issues.count_found` to
* use `color.useColor()`
* use u32 for line numbers
* remove trailing spaces
* remove unused public