### PR TITLE
Compiler: add local function statements and expressions

### DIFF
--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -185,6 +185,10 @@ public fn u32 Decl.getNameIdx(const Decl* d) {
     return d.name_idx;
 }
 
+public fn void Decl.setNameIdx(Decl* d, u32 name_idx) {
+    d.name_idx = name_idx;
+}
+
 // convenience function
 public fn const char* Decl.getModuleName(const Decl* d) {
     const AST* a = d.getAST();

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -35,6 +35,7 @@ public type DefKind enum u8 (const char* const name) {
     StructMember    : { "struct-member" }, // (in struct) fn void(..) member;
     Param           : { "param" },         // fn void a( fn void(..) cb)
     EnumValue       : { "enum-value" },    // type Enum enum u8 (var x) { .. }
+    Local           : { "local" },         // local function
     Template        : { "template" },      // ..
 }
 
@@ -264,6 +265,8 @@ public fn bool FunctionDecl.canBeNil(const FunctionDecl* d) {
         return false;
     case Template:
         break;
+    case Local:
+        return false;
     }
     return d.hasAttrWeak();
 }

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -877,9 +877,10 @@ public fn FunctionDecl* Builder.actOnFunctionDecl(Builder* b,
                                                     const Ref* prefix,
                                                     VarDecl** params,
                                                     u32 num_params,
-                                                    bool is_variadic)
+                                                    bool is_variadic,
+                                                    bool is_local)
 {
-    is_public |= b.is_interface;
+    is_public |= b.is_interface & !is_local;
     FunctionDecl* f = FunctionDecl.create(b.context,
                                           name,
                                           loc,
@@ -890,10 +891,12 @@ public fn FunctionDecl* Builder.actOnFunctionDecl(Builder* b,
                                           params,
                                           num_params,
                                           is_variadic,
-                                          Global);
+                                          is_local ? DefKind.Local : DefKind.Global);
     b.ast.addFunc(f);
-    if (!prefix) b.addSymbol(name, f.asDecl());
-    if (b.is_interface) f.asDecl().setExternal();
+    if (!is_local) {
+        if (!prefix) b.addSymbol(name, f.asDecl());
+        if (b.is_interface) f.asDecl().setExternal();
+    }
     return f;
 }
 
@@ -1239,7 +1242,7 @@ public fn void Builder.insertImplicitCast(Builder* b,
     *e_ptr = ic;
 }
 
-fn void Builder.addSymbol(Builder* b, u32 name_idx, Decl* d) {
+public fn void Builder.addSymbol(Builder* b, u32 name_idx, Decl* d) {
     Decl* old = b.mod.findSymbol(name_idx);
     if (old) {
         b.diags.error(d.getLoc(), "redefinition of '%s'", b.idx2name(name_idx));

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -377,7 +377,7 @@ fn void Parser.parseTopLevel(Parser* p) {
         break;
     case KW_fn:
         if (p.tokenizer.c_mode) goto invalid_c;
-        p.parseFuncDecl(is_public);
+        p.parseFuncDecl(is_public, false);
         break;
     case KW_import:
         p.error("no imports allowed after declarations");
@@ -509,27 +509,73 @@ fn void Parser.applyAttributes(Parser* p, Decl* d, u32 count) {
     if (count) p.builder.applyAttributes(d, count);
 }
 
-fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
-    p.consumeToken();
+fn u32 Parser.createLocalName(Parser* p, u32 name, SrcLoc loc, u32* plen) {
+    char[128] buf;
+    *plen = (u32)snprintf(buf, sizeof(buf), "%s__%d", p.pool.idx2str(name), loc);
+    return p.pool.addStr(buf, true);
+}
+
+fn Expr* Parser.parseLocalFuncExpr(Parser* p) {
+    SrcLoc loc = p.tok.loc;
+    FunctionDecl* f = p.parseFuncDecl(false, true);
+    Decl* d = f.asDecl();
+    u32 name = d.getNameIdx();
+    u32 len;
+    u32 local_name = p.createLocalName(name, loc, &len);
+    d.setNameIdx(local_name);
+    p.builder.addSymbol(local_name, d);
+    return p.builder.actOnIdentifier(loc, local_name, len);
+}
+
+fn Stmt* Parser.parseLocalFuncStmt(Parser* p) {
+    SrcLoc loc = p.tok.loc;
+    FunctionDecl* f = p.parseFuncDecl(false, true);
+    Decl* d = f.asDecl();
+    u32 name = d.getNameIdx();
+    u32 len;
+    u32 local_name = p.createLocalName(name, loc, &len);
+    d.setNameIdx(local_name);
+    p.builder.addSymbol(local_name, d);
+    Expr* fexpr = p.builder.actOnIdentifier(loc, local_name, len);
+    // TODO: use auto typing
+    TypeRefHolder ref.init();
+    ref.setVoid(loc);
+    ref.addPointer();
+    VarDecl* decl = p.builder.actOnVarDecl(name, loc, &ref, loc, fexpr, false, false);
+    return p.builder.actOnDeclStmt(&decl, 1);
+}
+
+fn FunctionDecl* Parser.parseFuncDecl(Parser* p, bool is_public, bool is_local) {
+    u32 func_name = 0;
+    SrcLoc func_loc = p.tok.loc;
+    Ref prefix_ref;
+    Ref* prefix = nil;
+
+    p.consumeToken();  // fn
 
     TypeRefHolder rtype.init();
     // Note: dont check arrays in this phase, but in Analyser
     p.parseTypeSpecifier(&rtype);
 
-    p.expectIdentifier();
-    u32 func_name = p.tok.name_idx;
-    SrcLoc func_loc = p.tok.loc;
-    p.consumeToken();
-
-    p.parseFunctionDecl2(func_name, func_loc, is_public, &rtype);
+    if (p.tok.kind == Identifier || !is_local) {
+        p.expectIdentifier();
+        func_name = p.tok.name_idx;
+        func_loc = p.tok.loc;
+        p.consumeToken();
+    }
+    return p.parseFunctionDecl2(func_name, func_loc, is_public, is_local, &rtype);
 }
 
-fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
-                                  bool is_public, TypeRefHolder* rtype)
+fn FunctionDecl* Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
+                                           bool is_public, bool is_local, TypeRefHolder* rtype)
 {
     Ref prefix_ref;
     Ref* prefix = nil;
+
     if (p.tok.kind == Dot) {
+        if (is_local) {
+            p.error("local functions cannot be type functions");
+        }
         p.consumeToken();
         p.expectIdentifier();
 
@@ -542,7 +588,7 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
         p.consumeToken();
     }
 
-    if (!p.checkName(func_name, p.is_interface)) {
+    if (func_name && !p.checkName(func_name, p.is_interface)) {
         p.errorAt(func_loc, "a function name must start with a lower case character");
     }
 
@@ -550,8 +596,19 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
 
     bool is_variadic = p.parseFunctionParams(&params, is_public, true);
 
+    if (p.tok.kind == LSquare && is_local) {
+        // TODO: parse capture specification
+        while (!p.tok.done && p.tok.kind != RSquare) {
+            p.consumeToken();
+        }
+        p.expectAndConsume(RSquare);
+    }
+
     FunctionDecl* f;
     if (p.tok.kind == KW_template) {
+        if (is_local) {
+            p.error("local functions cannot be template functions");
+        }
         p.consumeToken();
         p.expectIdentifier();
 
@@ -577,19 +634,21 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
                                         prefix,
                                         params.getData(),
                                         params.size(),
-                                        is_variadic);
+                                        is_variadic, is_local);
     }
 
     params.free();
 
-    u32 num_attr = p.parseOptionalAttributes();
-    p.applyAttributes((Decl*)f, num_attr);
+    if (!is_local) {
+        u32 num_attr = p.parseOptionalAttributes();
+        p.applyAttributes((Decl*)f, num_attr);
+    }
 
     if (p.is_interface) {
         if (p.tok.kind == Semicolon) {
             // function without body (eg. i32 printf(..); ) is allowed
             p.consumeToken();
-            return;
+            return f;
         }
 
         if (func_name != p.main_idx) {
@@ -598,9 +657,10 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
         }
     }
 
-    p.stmt_list_count = 0;
+    if (!is_local) p.stmt_list_count = 0;
     CompoundStmt* body = p.parseCompoundStmt();
     p.builder.actOnFunctionBody(f, body);
+    return f;
 }
 
 fn bool Parser.parseFunctionParams(Parser* p, VarDeclList* params, bool is_public, bool accept_default) {
@@ -780,7 +840,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
             if (!p.tokenizer.c_mode) {
                 p.error("function definitions require the 'fn' keyword");
             }
-            p.parseFunctionDecl2(name, loc, is_public, &ref);
+            p.parseFunctionDecl2(name, loc, is_public, false, &ref);
             return;
         }
 
@@ -790,7 +850,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
                     // Either a function definition or an init call
                     if (!p.tokenizer.c_mode)
                         p.error("global variables cannot have an init call");
-                    p.parseFunctionDecl2(name, loc, is_public, &ref);
+                    p.parseFunctionDecl2(name, loc, is_public, false, &ref);
                     return;
                 }
                 p.error("global type variables not supported");

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -208,6 +208,7 @@ const u8[Kind] CastExprTokenLookup = {
     [KW_usize] = 16,
     [KW_f32] = 16,
     [KW_f64] = 16,
+    [KW_fn] = 17,
 }
 
 // Note: tried lookup table, was slower..
@@ -313,6 +314,9 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
         } else {
             p.error("expected expression");
         }
+        break;
+    case 17: // KW_fn
+        res = p.parseLocalFuncExpr();
         break;
     }
     return p.parsePostfixExprSuffix(res, couldBeTemplateCall);

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -65,6 +65,8 @@ fn Stmt* Parser.parseStmt(Parser* p) {
         return p.parseDeclStmt(true, true, false);
     case KW_while:
         return p.parseWhileStmt();
+    case KW_fn:
+        return p.parseLocalFuncStmt();
     default:
         return p.parseExprStmt();
     }

--- a/test/parser/invalid_func.c2
+++ b/test/parser/invalid_func.c2
@@ -1,7 +1,7 @@
 module test;
 
 public fn i32 main() {
-    fn void() v = foo;    // @error{expected expression}
+    fn void() v = foo;    // @error{expected '{'}
     return 0;
 }
 


### PR DESCRIPTION
* local functions are defined using the standard syntax in the body of a function.
* they cannot be templates nor type functions
* they can be named or anonymous
* accept a capture list between square backets fater the parameter list (currently ignored)