### PR TITLE
Parser: reject reserved words as global variable names

### DIFF
--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -666,6 +666,10 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
 
         u32 name = p.tok.name_idx;
         SrcLoc loc = p.tok.loc;
+        if (p.tok.reserved) {
+            p.diags.error(loc, "reserved word '%s' cannot be used as variable name",
+                          p.pool.idx2str(name));
+        }
         p.consumeToken();
 
         need_semi = true;
@@ -674,14 +678,21 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
 
         p.parseOptionalAttributes();
 
-        if (p.tok.kind == Kind.Dot)
-            p.error("global variables cannot have an init call");
-
-        if (p.tok.kind == Kind.Equal) {
+        switch (p.tok.kind) {
+        case Equal:
             assignLoc = p.tok.loc;
             p.consumeToken();
             need_semi = (p.tok.kind != Kind.LBrace);
             initValue = p.parseInitValue(false);
+            break;
+        case Dot:
+            p.error("global variables cannot have an init call");
+            break;
+        case LSquare:
+            p.error("array indices should go after type");
+            break;
+        default:
+            break;
         }
 
         bool has_embed = p.builder.hasEmbedAttr();

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -536,7 +536,7 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
         u32 name = p.tok.name_idx;
         SrcLoc loc = p.tok.loc;
         if (p.tok.reserved) {
-            p.diags.error(loc, "reserved word '%s' cannot be used as local variable name",
+            p.diags.error(loc, "reserved word '%s' cannot be used as variable name",
                           p.pool.idx2str(name));
         }
         p.consumeToken();

--- a/test/parser/reserved_words.c2
+++ b/test/parser/reserved_words.c2
@@ -56,28 +56,53 @@ fn void foo(
         ) {}
 
 fn void bar() {
-    u32 alignas;    // @error{reserved word 'alignas' cannot be used as local variable name}
-    u32 alignof;    // @error{reserved word 'alignof' cannot be used as local variable name}
-    u32 auto;       // @error{reserved word 'auto' cannot be used as local variable name}
-    u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as local variable name}
-    u32 do;         // @error{reserved word 'do' cannot be used as local variable name}
-    u32 double;     // @error{reserved word 'double' cannot be used as local variable name}
-    u32 extern;     // @error{reserved word 'extern' cannot be used as local variable name}
-    u32 float;      // @error{reserved word 'float' cannot be used as local variable name}
-    u32 inline;     // @error{reserved word 'inline' cannot be used as local variable name}
-    u32 int;        // @error{reserved word 'int' cannot be used as local variable name}
-    u32 long;       // @error{reserved word 'long' cannot be used as local variable name}
-    u32 nullptr;    // @error{reserved word 'nullptr' cannot be used as local variable name}
-    u32 register;   // @error{reserved word 'register' cannot be used as local variable name}
-    u32 restrict;   // @error{reserved word 'restrict' cannot be used as local variable name}
-    u32 short;      // @error{reserved word 'short' cannot be used as local variable name}
-    u32 signed;     // @error{reserved word 'signed' cannot be used as local variable name}
-    u32 static;     // @error{reserved word 'static' cannot be used as local variable name}
-    u32 thread_local;   // @error{reserved word 'thread_local' cannot be used as local variable name}
-    u32 typedef;    // @error{reserved word 'typedef' cannot be used as local variable name}
-    u32 typeof;     // @error{reserved word 'typeof' cannot be used as local variable name}
-    u32 typeof_unqual;  // @error{reserved word 'typeof_unqual' cannot be used as local variable name}
-    u32 unsigned;   // @error{reserved word 'unsigned' cannot be used as local variable name}
-    u32 size_t;     // @error{reserved word 'size_t' cannot be used as local variable name}
-    u32 ssize_t;    // @error{reserved word 'ssize_t' cannot be used as local variable name}
+    u32 alignas;    // @error{reserved word 'alignas' cannot be used as variable name}
+    u32 alignof;    // @error{reserved word 'alignof' cannot be used as variable name}
+    u32 auto;       // @error{reserved word 'auto' cannot be used as variable name}
+    u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as variable name}
+    u32 do;         // @error{reserved word 'do' cannot be used as variable name}
+    u32 double;     // @error{reserved word 'double' cannot be used as variable name}
+    u32 extern;     // @error{reserved word 'extern' cannot be used as variable name}
+    u32 float;      // @error{reserved word 'float' cannot be used as variable name}
+    u32 inline;     // @error{reserved word 'inline' cannot be used as variable name}
+    u32 int;        // @error{reserved word 'int' cannot be used as variable name}
+    u32 long;       // @error{reserved word 'long' cannot be used as variable name}
+    u32 nullptr;    // @error{reserved word 'nullptr' cannot be used as variable name}
+    u32 register;   // @error{reserved word 'register' cannot be used as variable name}
+    u32 restrict;   // @error{reserved word 'restrict' cannot be used as variable name}
+    u32 short;      // @error{reserved word 'short' cannot be used as variable name}
+    u32 signed;     // @error{reserved word 'signed' cannot be used as variable name}
+    u32 static;     // @error{reserved word 'static' cannot be used as variable name}
+    u32 thread_local;   // @error{reserved word 'thread_local' cannot be used as variable name}
+    u32 typedef;    // @error{reserved word 'typedef' cannot be used as variable name}
+    u32 typeof;     // @error{reserved word 'typeof' cannot be used as variable name}
+    u32 typeof_unqual;  // @error{reserved word 'typeof_unqual' cannot be used as variable name}
+    u32 unsigned;   // @error{reserved word 'unsigned' cannot be used as variable name}
+    u32 size_t;     // @error{reserved word 'size_t' cannot be used as variable name}
+    u32 ssize_t;    // @error{reserved word 'ssize_t' cannot be used as variable name}
 }
+
+u32 alignas;    // @error{reserved word 'alignas' cannot be used as variable name}
+u32 alignof;    // @error{reserved word 'alignof' cannot be used as variable name}
+u32 auto;       // @error{reserved word 'auto' cannot be used as variable name}
+u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as variable name}
+u32 do;         // @error{reserved word 'do' cannot be used as variable name}
+u32 double;     // @error{reserved word 'double' cannot be used as variable name}
+u32 extern;     // @error{reserved word 'extern' cannot be used as variable name}
+u32 float;      // @error{reserved word 'float' cannot be used as variable name}
+u32 inline;     // @error{reserved word 'inline' cannot be used as variable name}
+u32 int;        // @error{reserved word 'int' cannot be used as variable name}
+u32 long;       // @error{reserved word 'long' cannot be used as variable name}
+u32 nullptr;    // @error{reserved word 'nullptr' cannot be used as variable name}
+u32 register;   // @error{reserved word 'register' cannot be used as variable name}
+u32 restrict;   // @error{reserved word 'restrict' cannot be used as variable name}
+u32 short;      // @error{reserved word 'short' cannot be used as variable name}
+u32 signed;     // @error{reserved word 'signed' cannot be used as variable name}
+u32 static;     // @error{reserved word 'static' cannot be used as variable name}
+u32 thread_local;   // @error{reserved word 'thread_local' cannot be used as variable name}
+u32 typedef;    // @error{reserved word 'typedef' cannot be used as variable name}
+u32 typeof;     // @error{reserved word 'typeof' cannot be used as variable name}
+u32 typeof_unqual;  // @error{reserved word 'typeof_unqual' cannot be used as variable name}
+u32 unsigned;   // @error{reserved word 'unsigned' cannot be used as variable name}
+u32 size_t;     // @error{reserved word 'size_t' cannot be used as variable name}
+u32 ssize_t;    // @error{reserved word 'ssize_t' cannot be used as variable name}


### PR DESCRIPTION
* improve consistency between `Parser.parseDeclStmt` and `Parser.parseVarDecl`