### PR TITLE
Compiler: small fixes

### DIFF
--- a/ast/explicit_cast_expr.c2
+++ b/ast/explicit_cast_expr.c2
@@ -94,8 +94,9 @@ fn void ExplicitCastExpr.printLiteral(const ExplicitCastExpr* e, string_buffer.B
     } else {
         out.add("cast<");
         e.dest.print(out, true);
-        out.add1('>');
+        out.add(">(");
         e.inner.printLiteral(out);
+        out.add1(')');
     }
 }
 

--- a/generator/c2_trace.c2
+++ b/generator/c2_trace.c2
@@ -40,7 +40,6 @@ fn bool match_name(const char *name, const char *pattern) {
         }
         return (!c1 && (c2 == ',' || c2 == ';'));
     }
-    return false;
 }
 
 fn bool match_pattern(const char *name, const char *pattern) {


### PR DESCRIPTION
* fix literal output for `cast<T>(expr)`
* fix compilation error for c2_trace code