### PR TITLE
Compiler: allow constant enum variables in global initializers

### DIFF
--- a/bootstrap/bootstrap.c
+++ b/bootstrap/bootstrap.c
@@ -37581,7 +37581,7 @@ static _Bool c_generator_emitAsDefine(const ast_VarDecl* vd)
    } else {
       if (!ast_QualType_isConst(&qt)) return false;
       if (ast_QualType_isVolatile(&qt)) return false;
-      if (ast_QualType_isBuiltin(&canon)) return true;
+      if (ast_QualType_isBuiltin(&canon) || ast_QualType_isEnum(&canon)) return true;
    }
    return false;
 }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -530,7 +530,7 @@ fn bool emitAsDefine(const VarDecl* vd) {
     } else {
         if (!qt.isConst()) return false;
         if (qt.isVolatile()) return false;
-        if (canon.isBuiltin()) return true;
+        if (canon.isBuiltin() || canon.isEnum()) return true;
     }
     return false;
 }

--- a/test/c_generator/constants/init_const_enum.c2t
+++ b/test/c_generator/constants/init_const_enum.c2t
@@ -1,0 +1,32 @@
+// @recipe bin
+    $warnings no-unused
+    $backend c
+
+// @file{file1}
+module test;
+
+type Enum enum u8 { Zero }
+
+const Enum My_Zero = Zero;
+
+// this constant is initialized from a constant enum variable
+const Enum My_Zero2 = My_Zero;
+
+public fn i32 main() { return My_Zero2; }
+
+// @expect{atleast, cgen/build.c}
+
+typedef uint8_t test_Enum;
+enum test_Enum {
+   test_Enum_Zero,
+};
+
+#define test_My_Zero test_Enum_Zero
+#define test_My_Zero2 test_My_Zero
+int32_t main(void);
+
+int32_t main(void)
+{
+   return test_My_Zero2;
+}
+


### PR DESCRIPTION
* ensure const enums are generated as defines