### PR TITLE
Literals: improve literal type consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ output/c2c_trace/c2c_trace: $(C2C_DEPS)
 	$(C2C) c2c --trace-calls -o c2c_trace --fast
 
 trace_calls: $(C2C) output/c2c_trace/c2c_trace
-	C2_TRACE="min=10;min2=1;mode=3;name=*;fd=2" output/c2c_trace/c2c_trace c2c --test 2> output/c2c/calls
+	C2_TRACE="min=10;min2=1;mode=3;name=*;fd=2" output/c2c_trace/c2c_trace c2c -o c2c_calls --test 2> output/c2c/calls
 
 trace: trace_calls
 	cat output/c2c/calls
 
 alloc_trace: $(C2C) output/c2c_trace/c2c_trace
-	C2_TRACE="min=10;min2=1;mode=3;name=stdlib.malloc,stdlib.calloc;fd=2" output/c2c_trace/c2c_trace c2c --test 2> output/c2c/calls
+	C2_TRACE="min=10;min2=1;mode=3;name=stdlib.malloc,stdlib.calloc;fd=2" output/c2c_trace/c2c_trace c2c -o c2c_alloc --test 2> output/c2c/calls
 	cat output/c2c/calls
 
 errors:

--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -259,8 +259,12 @@ fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon
         c.conversionError("implicit conversion turns floating-point number into integer:");
         break;
     case 6:     // loss of FP-precision
-        // TODO: is this just a warning?
-        c.conversionError("implicit conversion loses floating-point precision:");
+        if ((*c.expr_ptr).isCtv()) {
+            c.builder.insertImplicitCast(ImplicitCastKind.IntegralCast, c.expr_ptr, c.lhs);
+        } else {
+            // TODO: is this just a warning?
+            c.conversionError("implicit conversion loses floating-point precision:");
+        }
         break;
     case 7:     // ok, no conversion needed
         break;

--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -145,7 +145,7 @@ fn QualType Analyser.checkBinopIntArgs(Analyser* ma, BinaryOperator* b, QualType
 
     BuiltinType* bl = lcanon.getBuiltinTypeOrNil();
     BuiltinType* br = rcanon.getBuiltinTypeOrNil();
-    if (!bl || !br || lcanon.isVoid() || lcanon.isVoid()) {
+    if (!bl || !br || lcanon.isVoid() || rcanon.isVoid()) {
         Expr* e = (Expr*)b;
         ma.error(e.getLoc(), "invalid operands to binary expression ('%s' and '%s')", lhs.diagName(), rhs.diagName());
         return QualType_Invalid;
@@ -594,6 +594,7 @@ fn QualType Analyser.analyseBinaryOperator(Analyser* ma, Expr** e_ptr) {
     case And:
     case Xor:
     case Or:
+        if (!ma.checkFloat(lhs, rhs, "bitwise")) return QualType_Invalid;
         result = ma.checkBinopIntArgs(b, ltype, rtype);
         break;
     case LAnd:
@@ -612,6 +613,7 @@ fn QualType Analyser.analyseBinaryOperator(Analyser* ma, Expr** e_ptr) {
         break;
     case RemAssign:
         if (!ma.checkZero(rhs, "remainder")) return QualType_Invalid;
+        if (!ma.checkFloat(lhs, rhs, "remainder")) return QualType_Invalid;
         result = ma.checkBinopIntArgs(b, ltype, rtype);
         break;
     case AddAssign:
@@ -625,6 +627,7 @@ fn QualType Analyser.analyseBinaryOperator(Analyser* ma, Expr** e_ptr) {
     case AndAssign:
     case XorAssign:
     case OrAssign:
+        if (!ma.checkFloat(lhs, rhs, "bitwise")) return QualType_Invalid;
         result = ma.checkBinopIntArgs(b, ltype, rtype);
         break;
     }
@@ -638,8 +641,8 @@ fn bool Analyser.checkShiftArgs(Analyser* ma, Expr* lhs, Expr* rhs) {
     QualType qt = lhs.getType();
     QualType canon = qt.getCanonicalType();
     if (!canon.isBuiltin()) {
-        // TODO
-        ma.error(lhs.getLoc(), "cannot shift .. TODO");
+        QualType qt2 = rhs.getType();
+        ma.error(lhs.getLoc(), "invalid operands to binary expression ('%s' and '%s')", qt.diagName(), qt2.diagName());
         return false;
     }
     BuiltinType* bi = canon.getBuiltinTypeOrNil();

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -56,17 +56,12 @@ fn QualType Analyser.analyseExprInner(Analyser* ma, Expr** e_ptr, u32 side) {
 
     switch (e.getKind()) {
     case IntegerLiteral:
-        return e.getType();
     case FloatLiteral:
-        return e.getType();
     case BooleanLiteral:
-        return builtins[BuiltinKind.Bool];
     case CharLiteral:
-        return builtins[BuiltinKind.UInt8];
     case StringLiteral:
-        return e.getType(); // already set in creator
     case Nil:
-        return getVoidPtr();
+        return e.getType(); // already set in creator
     case Identifier:
         Decl* d = ma.analyseIdentifier(e_ptr, side);
         if (!d) break;
@@ -76,13 +71,7 @@ fn QualType Analyser.analyseExprInner(Analyser* ma, Expr** e_ptr, u32 side) {
     case Call:
         return ma.analyseCallExpr(e_ptr);
     case InitList:
-        (*e_ptr).dump();
-        assert(0);
-        break;
     case FieldDesignatedInit:
-        (*e_ptr).dump();
-        assert(0);
-        break;
     case ArrayDesignatedInit:
         (*e_ptr).dump();
         assert(0);

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -92,10 +92,12 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
 
         // TODO Canonical?
         if (expectedType.isBuiltin() && !res.isPointer()) {
-            // TODO not correct since conversion might be to something else?
+            // TODO should insert `BooleanCast` implicit cast
             if (expectedType.isBool()) return true;
             if (!ctv_analyser.check(ma.diags, expectedType, e)) return false;
-            e.setType(expectedType);
+            if (res.getType() != expectedType.getType()) {
+                ma.builder.insertImplicitCast(ImplicitCastKind.IntegralCast, e_ptr, expectedType);
+            }
             return true;
         }
     }

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -78,7 +78,10 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
                 return;
             }
             Value ctv = ctv_analyser.get_value(initval);
-
+            if (value.kind == ValueKind.Error) {
+                ma.errorRange(initval.getLoc(), initval.getRange(), "%s", ctv.error_msg);
+                return;
+            }
             if (!ctv_analyser.checkTypeRange(ma.diags, implType, &ctv, 0, initval)) return;
 
             if (i > 0 && ctv.is_less(&value)) {

--- a/ast/float_literal.c2
+++ b/ast/float_literal.c2
@@ -31,7 +31,7 @@ public type FloatLiteral struct @(opaque) {
     f64 val;
 }
 
-public fn FloatLiteral* FloatLiteral.create(ast_context.Context* c, SrcLoc loc, u32 src_len, f64 val, Radix radix) {
+public fn FloatLiteral* FloatLiteral.create(ast_context.Context* c, SrcLoc loc, u32 src_len, f64 val, Radix radix, BuiltinKind kind) {
     FloatLiteral* i = c.alloc(sizeof(FloatLiteral));
     i.base.init(ExprKind.FloatLiteral, loc, 1, 1, 0, ValType.RValue);
     i.base.base.floatLiteralBits.radix = radix;
@@ -40,7 +40,7 @@ public fn FloatLiteral* FloatLiteral.create(ast_context.Context* c, SrcLoc loc, 
 #if AstStatistics
     Stats.addExpr(ExprKind.FloatLiteral, sizeof(FloatLiteral));
 #endif
-    i.base.setType(ast.builtins[BuiltinKind.Float32]);    // TODO or f64
+    i.base.setType(ast.builtins[kind]);
 
     return i;
 }
@@ -72,5 +72,7 @@ public fn void FloatLiteral.printLiteral(const FloatLiteral* e, string_buffer.Bu
         out.add(ftoa(buf, elemsof(buf), e.val));
         break;
     }
+    QualType qt = e.base.getType();
+    if (qt.getBuiltinKind() == Float32) out.add1('F');
 }
 

--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -31,7 +31,7 @@ public type IntegerLiteral struct @(opaque) {
     u64 val;
 }
 
-public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc loc, u32 src_len, u64 val, Radix radix) {
+public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc loc, u32 src_len, u64 val, Radix radix, BuiltinKind kind) {
     IntegerLiteral* i = c.alloc(sizeof(IntegerLiteral));
     i.base.init(ExprKind.IntegerLiteral, loc, 1, 1, 0, ValType.RValue);
     i.base.base.integerLiteralBits.radix = radix;
@@ -40,10 +40,7 @@ public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc l
 #if AstStatistics
     Stats.addExpr(ExprKind.IntegerLiteral, sizeof(IntegerLiteral));
 #endif
-    //i.base.setType(integerVal2Type(val));
-    // just set to i32
-    // TODO: fix this for values larger than max_int32?
-    i.base.setType(builtins[BuiltinKind.Int32]);
+    i.base.setType(builtins[kind]);
 
     return i;
 }
@@ -102,10 +99,6 @@ public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffe
     switch (e.base.base.integerLiteralBits.radix) {
     case Radix.Default:
         out.print("%d", e.val);
-        if (c_style) {
-            if (e.val > 9223372036854775807) out.add1('u');
-            if (e.val > 4294967295) out.add1('l');
-        }
         break;
     case Radix.Hex:
         out.print("0x%x", e.val);
@@ -116,6 +109,12 @@ public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffe
     case Radix.Binary:
         printBinary(out, e.val);
         break;
+    }
+    if (c_style) {
+        QualType qt = e.base.getType();
+        BuiltinKind kind = qt.getBuiltinKind();
+        if (kind == UInt32 || kind == UInt64) out.add1('U');
+        if (kind == Int64 || kind == UInt64) out.add1('L');
     }
 }
 

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -215,6 +215,13 @@ public fn bool QualType.isFloat(const QualType* qt) {
     return bi.isFloatingPoint();
 }
 
+public fn BuiltinKind QualType.getBuiltinKind(const QualType* qt) {
+    const Type* t = qt.getTypeOrNil();
+    if (!t || !t.isBuiltinType()) return Void;
+    const BuiltinType* bi = (BuiltinType*)t;
+    return bi.getKind();
+}
+
 // Note: ignores const/volatile flags
 public fn bool QualType.isCharPointer(const QualType* qt) {
     // Note: we cannot compare with g_char_ptr since const char* is different!

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -216,7 +216,7 @@ public fn const char* idx2name(u32 idx) {
     return nil;
 }
 
-public fn QualType getVoidPtr() {
+fn QualType getVoidPtr() {
     return builtins[elemsof(BuiltinKind)];
 }
 

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -911,13 +911,12 @@ public fn IdentifierExpr* Builder.actOnIdentifier(Builder* b, SrcLoc loc, u32 na
     return IdentifierExpr.create(b.context, loc, name);
 }
 
-public fn Expr* Builder.actOnIntegerLiteral(Builder* b, SrcLoc loc, u32 src_len, u64 value, Radix radix) {
-    // TODO: pass qt?
-    return (Expr*)IntegerLiteral.create(b.context, loc, src_len, value, radix);
+public fn Expr* Builder.actOnIntegerLiteral(Builder* b, SrcLoc loc, u32 src_len, u64 value, Radix radix, BuiltinKind kind) {
+    return (Expr*)IntegerLiteral.create(b.context, loc, src_len, value, radix, kind);
 }
 
-public fn Expr* Builder.actOnFloatLiteral(Builder* b, SrcLoc loc, u32 src_len, f64 value, Radix radix) {
-    return (Expr*)FloatLiteral.create(b.context, loc, src_len, value, radix);
+public fn Expr* Builder.actOnFloatLiteral(Builder* b, SrcLoc loc, u32 src_len, f64 value, Radix radix, BuiltinKind kind) {
+    return (Expr*)FloatLiteral.create(b.context, loc, src_len, value, radix, kind);
 }
 
 public fn Expr* Builder.actOnCharLiteral(Builder* b, SrcLoc loc, u32 src_len, u8 value, Radix radix) {

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -154,6 +154,16 @@ fn void Generator.emitExpr2(Generator* gen, string_buffer.Buf* out, Expr* e, C_P
     case ImplicitCast:
         // TODO some casts might need to be explicit to prevent warnings
         ImplicitCastExpr* i = (ImplicitCastExpr*)e;
+        if (i.getKind() == IntegralCast) {
+            QualType qt = e.getType();
+            if (qt.getBuiltinKind() == Float32) {
+                if (prec > Prefix) out.lparen();
+                gen.emitCast(out, qt, false);
+                gen.emitExpr2(out, i.getInner(), Prefix);
+                if (prec > Prefix) out.rparen();
+                break;
+            }
+        }
         gen.emitExpr2(out, i.getInner(), prec);
         break;
     case Range:

--- a/generator/ir/ir_generator_binop.c2
+++ b/generator/ir/ir_generator_binop.c2
@@ -19,7 +19,7 @@ import ast local;
 import bit_utils;
 import ir local;
 import ir_context;
-import ctv_analyser local;
+import ctv_analyser;
 
 fn void Generator.emitAssign(Generator* gen, ir.Ref* result, const Expr* lhs, const Expr* rhs) {
     // special case is needed because setting Bitfield is not a simple store

--- a/libs/c2/c2.c2i
+++ b/libs/c2/c2.c2i
@@ -57,20 +57,20 @@ const u16 max_u16 = 65535;
 const i32 min_i32 = -2147483647-1;
 const i32 max_i32 = 2147483647;
 const u32 min_u32 = 0;
-const u32 max_u32 = 4294967295;
+const u32 max_u32 = 0xFFFFFFFF;
 const i64 min_i64 = -9223372036854775807-1;
 const i64 max_i64 = 9223372036854775807;
 const u64 min_u64 = 0;
-const u64 max_u64 = 18446744073709551615;
+const u64 max_u64 = 0xFFFFFFFFFFFFFFFF;
 
 #if ARCH_32BIT
 const isize min_isize = -2147483647-1;
 const isize max_isize = 2147483647;
 const usize min_usize = 0;
-const usize max_usize = 4294967295;
+const usize max_usize = 0xFFFFFFFF;
 #else
 const isize min_isize = -9223372036854775807-1;
 const isize max_isize = 9223372036854775807;
 const usize min_usize = 0;
-const usize max_usize = 18446744073709551615;
+const usize max_usize = 0xFFFFFFFFFFFFFFFF;
 #endif

--- a/libs/c2/f32.c2i
+++ b/libs/c2/f32.c2i
@@ -1,7 +1,7 @@
 module f32;
 
-const f32 min = -0x1.fffffep127;
-const f32 max = 0x1.fffffep127;
-const f32 inf = 1.0 / 0.0;
-const f32 nan = 0.0 / 0.0;
+const f32 min = -0x1.fffffep127F;
+const f32 max = 0x1.fffffep127F;
+const f32 inf = 1.0F / 0.0F;
+const f32 nan = 0.0F / 0.0F;
 const u8 width = 32;

--- a/libs/c2/u32.c2i
+++ b/libs/c2/u32.c2i
@@ -1,5 +1,5 @@
 module u32;
 
 const u32 min = 0;
-const u32 max = 4294967295;
+const u32 max = 0xFFFFFFFF;
 const u8 width = 32;

--- a/libs/c2/usize.c2i
+++ b/libs/c2/usize.c2i
@@ -2,10 +2,10 @@ module usize;
 
 #if ARCH_32BIT
 const usize min = 0;
-const usize max = 4294967295;
+const usize max = 0xFFFFFFFF;
 const u8 width = 32;
 #else
 const usize min = 0;
-const usize max = 18446744073709551615;
+const usize max = 0xFFFFFFFFFFFFFFFF;
 const u8 width = 64;
 #endif

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -858,6 +858,7 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
             out.add(ftoa(buf, elemsof(buf), tok.float_value));
             break;
         }
+        if (tok.suffix_F) out.add1('F');
         break;
     case CharLiteral:
         switch (tok.getRadix()) {

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -19,7 +19,7 @@ module c2_parser;
 import ast local;
 import c2_prec local;
 import constants;
-//import number_radix local;    // BUG: should have to be imported
+import number_radix local;
 import token local;
 import src_loc local;
 
@@ -269,11 +269,24 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
 */
         break;
     case 2: // IntegerLiteral
-        res = p.builder.actOnIntegerLiteral(p.tok.loc, p.tok.len, p.tok.int_value, p.tok.getRadix());
+        u64 val = p.tok.int_value;
+        BuiltinKind kind;
+        if (val <= i32.max)
+            kind = Int32;
+        else
+        if (val <= u32.max && p.tok.getRadix() != Radix.Default)
+            kind = UInt32;
+        else
+        if (val <= i64.max)
+            kind = Int64;
+        else
+            kind = UInt64;
+        res = p.builder.actOnIntegerLiteral(p.tok.loc, p.tok.len, p.tok.int_value, p.tok.getRadix(), kind);
         p.consumeToken();
         break;
     case 3: // FloatLiteral
-        res = p.builder.actOnFloatLiteral(p.tok.loc, p.tok.len, p.tok.float_value, p.tok.getRadix());
+        BuiltinKind kind = p.tok.suffix_F ? BuiltinKind.Float32 : BuiltinKind.Float64;
+        res = p.builder.actOnFloatLiteral(p.tok.loc, p.tok.len, p.tok.float_value, p.tok.getRadix(), kind);
         p.consumeToken();
         break;
     case 4: // CharLiteral

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -924,6 +924,10 @@ fn void Tokenizer.lex_floating_point(Tokenizer* t, Token* result, const char* st
                 p++;
         }
     }
+    if (*p == 'f' || *p == 'F') {
+        result.suffix_F = true;
+        p++;
+    }
     if (*p == '_' || isalpha(*p)) {
         t.lex_number_error(result, p, "floating point");
         return;
@@ -981,6 +985,10 @@ fn void Tokenizer.lex_floating_point_hex(Tokenizer* t, Token* result, const char
     } else {
         t.num_error(result, p, "hexadecimal floating constant requires an exponent");
         return;
+    }
+    if (*p == 'f' || *p == 'F') {
+        result.suffix_F = true;
+        p++;
     }
     if (*p == '_' || isalpha(*p)) {
         t.lex_number_error(result, p, "floating point");

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -303,11 +303,12 @@ public type Token struct {
     u8 radix : 2;   // number_radix.Radix: for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
     u8 raw : 1;     // for StringLiteral
     bool reserved : 1;
+    bool suffix_F : 1;
     union {
         const char* error_msg;  // ERROR
         struct {           // StringLiteral, LineComment, BlockComment
-            u32 text_idx;    // pool index of encoded string or comment
-            u32 text_len;    // length of converted string (without null terminator)
+            u32 text_idx;  // pool index of encoded string or comment
+            u32 text_len;  // length of converted string (without null terminator)
         }
         u32 name_idx;      // Identifier and all keywords
         u64 int_value;     // IntegerLiteral

--- a/test/expr/sizeof/sizeof_expr.c2
+++ b/test/expr/sizeof/sizeof_expr.c2
@@ -1,0 +1,368 @@
+module test;
+
+i8  v_i8;
+i16 v_i16;
+i32 v_i32;
+i64 v_i64;
+u8  v_u8;
+u16 v_u16;
+u32 v_u32;
+u64 v_u64;
+f32 v_f32;
+f64 v_f64;
+
+static_assert(sizeof(v_i8 + v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 + v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 + v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 + v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 + v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 + v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 + v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 + v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 + v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 + v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 + v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 + v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 + v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 + v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 + v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 + v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 + v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 + v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 + v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 + v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 + v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 + v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 + v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 + v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 + v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 + v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 + v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 + v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 + v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 + v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 - v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 - v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 - v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 - v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 - v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 - v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 - v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 - v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 - v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 - v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 - v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 - v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 - v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 - v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 - v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 - v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 - v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 - v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 - v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 - v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 - v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 - v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 - v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 - v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 - v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 - v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 - v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 - v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 - v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 - v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 * v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 * v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 * v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 * v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 * v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 * v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 * v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 * v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 * v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 * v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 * v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 * v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 * v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 * v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 * v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 * v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 * v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 * v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 * v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 * v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 * v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 * v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 * v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 * v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 * v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 * v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 * v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 * v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 * v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 * v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 / v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 / v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 / v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 / v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 / v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 / v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 / v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 / v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 / v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 / v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 / v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 / v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 / v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 / v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 / v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 / v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 / v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 / v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 / v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 / v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 / v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 / v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 / v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 / v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 / v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 / v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 / v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 / v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 / v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 / v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 % v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 % v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 % v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 % v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 % v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 % v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 % v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 % v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 % v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 % v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 % v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 % v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 % v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 % v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 % v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 % v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 % v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 % v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 % v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 % v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 % v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 % v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 % v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 % v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 % v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 % v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 % v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 % v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 % v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 % v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 | v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 | v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 | v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 | v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 | v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 | v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 | v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 | v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 | v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 | v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 | v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 | v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 | v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 | v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 | v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 | v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 | v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 | v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 | v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 | v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 | v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 | v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 | v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 | v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 | v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 | v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 | v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 | v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 | v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 | v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 & v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 & v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 & v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 & v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 & v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 & v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 & v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 & v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 & v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 & v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 & v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 & v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 & v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 & v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 & v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 & v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 & v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 & v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 & v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 & v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 & v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 & v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 & v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 & v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 & v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 & v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 & v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 & v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 & v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 & v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 ^ v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 ^ v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 ^ v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 ^ v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 ^ v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 ^ v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 ^ v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 ^ v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 ^ v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 ^ v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 ^ v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 ^ v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 ^ v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 ^ v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 ^ v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 ^ v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 ^ v_i32), sizeof(u32));
+static_assert(sizeof(v_u32 ^ v_i64), sizeof(i64));
+static_assert(sizeof(v_i64 ^ v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 ^ v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 ^ v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 ^ v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 ^ v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 ^ v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 ^ v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 ^ v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 ^ v_u32), sizeof(u32));
+static_assert(sizeof(v_u32 ^ v_u64), sizeof(u64));
+static_assert(sizeof(v_u64 ^ v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 ^ v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 << v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 << v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 << v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 << v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 << v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 << v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 << v_i32), sizeof(i32));
+//static_assert(sizeof(v_i32 << v_i64), sizeof(i32));
+static_assert(sizeof(v_i64 << v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 << v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 << v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 << v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 << v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 << v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 << v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 << v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 << v_i32), sizeof(u32));
+//static_assert(sizeof(v_u32 << v_i64), sizeof(u32));
+static_assert(sizeof(v_i64 << v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 << v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 << v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 << v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 << v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 << v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 << v_u32), sizeof(i32));
+static_assert(sizeof(v_u32 << v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 << v_u32), sizeof(u32));
+//static_assert(sizeof(v_u32 << v_u64), sizeof(u32));
+static_assert(sizeof(v_u64 << v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 << v_u64), sizeof(u64));
+
+static_assert(sizeof(v_i8 >> v_i8), sizeof(i32));
+static_assert(sizeof(v_i8 >> v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 >> v_i8), sizeof(i32));
+static_assert(sizeof(v_i16 >> v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 >> v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 >> v_i16), sizeof(i32));
+static_assert(sizeof(v_i32 >> v_i32), sizeof(i32));
+//static_assert(sizeof(v_i32 >> v_i64), sizeof(i32));
+static_assert(sizeof(v_i64 >> v_i32), sizeof(i64));
+static_assert(sizeof(v_i64 >> v_i64), sizeof(i64));
+
+static_assert(sizeof(v_u8 >> v_i8), sizeof(i32));
+static_assert(sizeof(v_u8 >> v_i16), sizeof(i32));
+static_assert(sizeof(v_i16 >> v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 >> v_i16), sizeof(i32));
+static_assert(sizeof(v_u16 >> v_i32), sizeof(i32));
+static_assert(sizeof(v_i32 >> v_u16), sizeof(i32));
+static_assert(sizeof(v_u32 >> v_i32), sizeof(u32));
+//static_assert(sizeof(v_u32 >> v_i64), sizeof(u32));
+static_assert(sizeof(v_i64 >> v_u32), sizeof(i64));
+static_assert(sizeof(v_u64 >> v_i64), sizeof(u64));
+
+static_assert(sizeof(v_u8 >> v_u8), sizeof(i32));
+static_assert(sizeof(v_u8 >> v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 >> v_u8), sizeof(i32));
+static_assert(sizeof(v_u16 >> v_u16), sizeof(i32));
+static_assert(sizeof(v_u16 >> v_u32), sizeof(i32));
+static_assert(sizeof(v_u32 >> v_u16), sizeof(u32));
+static_assert(sizeof(v_u32 >> v_u32), sizeof(u32));
+//static_assert(sizeof(v_u32 >> v_u64), sizeof(u32));
+static_assert(sizeof(v_u64 >> v_u32), sizeof(u64));
+static_assert(sizeof(v_u64 >> v_u64), sizeof(u64));
+
+static_assert(sizeof(+v_f32), sizeof(f32));
+static_assert(sizeof(+v_f64), sizeof(f64));
+static_assert(sizeof(-v_f32), sizeof(f32));
+static_assert(sizeof(-v_f64), sizeof(f64));
+
+static_assert(sizeof(v_f32 + v_f32), sizeof(f32));
+static_assert(sizeof(v_f32 + v_f64), sizeof(f64));
+static_assert(sizeof(v_f64 + v_f32), sizeof(f64));
+static_assert(sizeof(v_f64 + v_f64), sizeof(f64));
+
+static_assert(sizeof(v_f32 - v_f32), sizeof(f32));
+static_assert(sizeof(v_f32 - v_f64), sizeof(f64));
+static_assert(sizeof(v_f64 - v_f32), sizeof(f64));
+static_assert(sizeof(v_f64 - v_f64), sizeof(f64));
+
+static_assert(sizeof(v_f32 * v_f32), sizeof(f32));
+static_assert(sizeof(v_f32 * v_f64), sizeof(f64));
+static_assert(sizeof(v_f64 * v_f32), sizeof(f64));
+static_assert(sizeof(v_f64 * v_f64), sizeof(f64));
+
+static_assert(sizeof(v_f32 / v_f32), sizeof(f32));
+static_assert(sizeof(v_f32 / v_f64), sizeof(f64));
+static_assert(sizeof(v_f64 / v_f32), sizeof(f64));
+static_assert(sizeof(v_f64 / v_f64), sizeof(f64));
+

--- a/test/init/pure_function/pure_function_ok.c2
+++ b/test/init/pure_function/pure_function_ok.c2
@@ -16,8 +16,8 @@ type Foo struct {
     i32 x;
 }
 
-fn u32 Foo.bit(u32 x) @(pure) {
+fn i32 Foo.bit(u32 x) @(pure) {
     return 1 << x;
 }
 
-u32 b3 = Foo.bit(3);
+i32 b3 = Foo.bit(3);

--- a/test/literals/init_pointer.c2
+++ b/test/literals/init_pointer.c2
@@ -2,6 +2,7 @@
 module test;
 
 i32* a = 0;            // @error{incompatible integer to pointer conversion: 'i32' to 'i32*'}
-i32* b = 4294967295;   // @error{incompatible integer to pointer conversion: 'i32' to 'i32*'}
-i32* c = -1;           // @error{incompatible integer to pointer conversion: 'i32' to 'i32*'}
+i32* b = 2147483647;   // @error{incompatible integer to pointer conversion: 'i32' to 'i32*'}
+i32* c = 0xFFFFFFFF;   // @error{incompatible integer to pointer conversion: 'u32' to 'i32*'}
+i32* d = -1;           // @error{incompatible integer to pointer conversion: 'i32' to 'i32*'}
 

--- a/test/literals/sizeof_literals.c2
+++ b/test/literals/sizeof_literals.c2
@@ -1,0 +1,210 @@
+module test;
+
+import stdio local;
+
+static_assert(sizeof(""), 1);
+static_assert(sizeof("a"), 2);
+static_assert(sizeof("\0"), 2);
+static_assert(sizeof('a'), 1);
+static_assert(sizeof('\0'), 1);
+static_assert(sizeof(0), 4);
+static_assert(sizeof(1), 4);
+static_assert(sizeof(-1), 4);
+static_assert(sizeof(2147483647), 4);
+static_assert(sizeof(0x7fffffff), 4);
+static_assert(sizeof(0x80000000), 4);
+static_assert(sizeof(-2147483647), 4);
+static_assert(sizeof(-0x7fffffff), 4);
+static_assert(sizeof(-0x80000000), 4); // should flag the integer sign issue
+static_assert(sizeof(2147483647+1), 4); // should flag the integer overflow
+static_assert(sizeof(0x7fffffff+1), 4); // should flag the integer overflow
+static_assert(sizeof(0x80000000+1), 4);
+static_assert(sizeof(2147483648), 8);
+static_assert(sizeof(-2147483648), 8);
+static_assert(sizeof(2147483649), 8);
+static_assert(sizeof(-2147483649), 8);
+static_assert(sizeof(0x7fffffffffffffff), 8);
+static_assert(sizeof(0x8000000000000000), 8);
+static_assert(sizeof(9223372036854775807), 8);
+static_assert(sizeof(9223372036854775808), 8); // should flag the integer sign issue
+static_assert(sizeof(9223372036854775809), 8); // should flag the integer sign issue
+static_assert(sizeof(-9223372036854775807), 8);
+static_assert(sizeof(-9223372036854775808), 8); // should flag the integer sign issue
+static_assert(sizeof(-9223372036854775809), 8); // should flag the integer sign issue
+static_assert(sizeof(0.0), 8);
+static_assert(sizeof(0.0 / 0.0), 8);
+static_assert(sizeof(1.0 / 0.0), 8);
+static_assert(sizeof(0.0F), 4);
+static_assert(sizeof(0.0F / 0.0F), 4);
+static_assert(sizeof(1.0F / 0.0F), 4);
+static_assert(sizeof((f32)0.0), 4);
+static_assert(sizeof((f32)(0.0 / 0.0)), 4);
+static_assert(sizeof((f32)(1.0 / 0.0)), 4);
+static_assert(sizeof((f64)0.0), 8);
+static_assert(sizeof((f64)(0.0 / 0.0)), 8);
+static_assert(sizeof((f64)(1.0 / 0.0)), 8);
+
+static_assert(sizeof(i8.min), sizeof(i8));
+static_assert(sizeof(i8.max), sizeof(i8));
+static_assert(sizeof(i16.min), sizeof(i16));
+static_assert(sizeof(i16.max), sizeof(i16));
+static_assert(sizeof(i32.min), sizeof(i32));
+static_assert(sizeof(i32.max), sizeof(i32));
+static_assert(sizeof(i64.min), sizeof(i64));
+static_assert(sizeof(i64.max), sizeof(i64));
+static_assert(sizeof(u8.min), sizeof(u8));
+static_assert(sizeof(u8.max), sizeof(u8));
+static_assert(sizeof(u16.min), sizeof(u16));
+static_assert(sizeof(u16.max), sizeof(u16));
+static_assert(sizeof(u32.min), sizeof(u32));
+static_assert(sizeof(u32.max), sizeof(u32));
+static_assert(sizeof(u64.min), sizeof(u64));
+static_assert(sizeof(u64.max), sizeof(u64));
+static_assert(sizeof(isize.min), sizeof(isize));
+static_assert(sizeof(isize.max), sizeof(isize));
+static_assert(sizeof(usize.min), sizeof(usize));
+static_assert(sizeof(usize.max), sizeof(usize));
+static_assert(sizeof(f32.min), sizeof(f32));
+static_assert(sizeof(f32.max), sizeof(f32));
+static_assert(sizeof(f64.min), sizeof(f64));
+static_assert(sizeof(f64.max), sizeof(f64));
+
+fn void print_values() {
+    printf("'a' = %d\n", 'a');
+    printf("'\\0' = %d\n", '\0');
+    printf("0 = %d\n", 0);
+    printf("1 = %d\n", 1);
+    printf("-1 = %d\n", -1);
+    printf("2147483647 = %d\n", 2147483647);
+    printf("0x7fffffff = %d\n", 0x7fffffff);
+    printf("0x80000000 = %d\n", 0x80000000);
+    printf("-2147483647 = %d\n", -2147483647);
+    printf("-0x7fffffff = %d\n", -0x7fffffff);
+    printf("-0x80000000 = %d\n", -0x80000000);
+    printf("2147483647+1 = %d\n", 2147483647+1);
+    printf("0x7fffffff+1 = %d\n", 0x7fffffff+1);
+    printf("0x80000000+1 = %d\n", 0x80000000+1);
+    printf("2147483648 = %d\n", 2147483648);
+    printf("-2147483648 = %d\n", -2147483648);
+    printf("2147483649 = %d\n", 2147483649);
+    printf("-2147483649 = %d\n", -2147483649);
+    printf("0x7fffffffffffffff = %d\n", 0x7fffffffffffffff);
+    printf("0x8000000000000000 = %d\n", 0x8000000000000000);
+    printf("9223372036854775807 = %d\n", 9223372036854775807);
+    printf("9223372036854775808 = %d\n", 9223372036854775808);
+    printf("9223372036854775809 = %d\n", 9223372036854775809);
+    printf("-9223372036854775807 = %d\n", -9223372036854775807);
+    printf("-9223372036854775808 = %d\n", -9223372036854775808);
+    printf("-9223372036854775809 = %d\n", -9223372036854775809);
+
+    printf("0.0 = %g\n", 0.0);
+    printf("0.0 / 0.0 = %g\n", 0.0 / 0.0);
+    printf("1.0 / 0.0 = %g\n", 1.0 / 0.0);
+    printf("(f32)0.0 = %g\n", (f32)0.0);
+    printf("(f32)(0.0 / 0.0) = %g\n", (f32)(0.0 / 0.0));
+    printf("(f32)(1.0 / 0.0) = %g\n", (f32)(1.0 / 0.0));
+    printf("(f64)0.0 = %g\n", (f64)0.0);
+    printf("(f64)(0.0 / 0.0) = %g\n", (f64)(0.0 / 0.0));
+    printf("(f64)(1.0 / 0.0) = %g\n", (f64)(1.0 / 0.0));
+
+    printf("i8.min = %d\n", i8.min);
+    printf("i8.max = %d\n", i8.max);
+    printf("i16.min = %d\n", i16.min);
+    printf("i16.max = %d\n", i16.max);
+    printf("i32.min = %d\n", i32.min);
+    printf("i32.max = %d\n", i32.max);
+    printf("i64.min = %d\n", i64.min);
+    printf("i64.max = %d\n", i64.max);
+    printf("u8.min = %d\n", u8.min);
+    printf("u8.max = %d\n", u8.max);
+    printf("u16.min = %d\n", u16.min);
+    printf("u16.max = %d\n", u16.max);
+    printf("u32.min = %d\n", u32.min);
+    printf("u32.max = %d\n", u32.max);
+    printf("u64.min = %d\n", u64.min);
+    printf("u64.max = %d\n", u64.max);
+    printf("isize.min = %d\n", isize.min);
+    printf("isize.max = %d\n", isize.max);
+    printf("usize.min = %d\n", usize.min);
+    printf("usize.max = %d\n", usize.max);
+    printf("f32.min = %g\n", f32.min);
+    printf("f32.max = %g\n", f32.max);
+    printf("f64.min = %g\n", f64.min);
+    printf("f64.max = %g\n", f64.max);
+}
+
+fn void print_sizes() {
+    printf("sizeof(\"\") = %d\n", sizeof(""));
+    printf("sizeof(\"a\") = %d\n", sizeof("a"));
+    printf("sizeof(\"\\0\") = %d\n", sizeof("\0"));
+    printf("sizeof('a') = %d\n", sizeof('a'));
+    printf("sizeof('\\0') = %d\n", sizeof('\0'));
+    printf("sizeof(0) = %d\n", sizeof(0));
+    printf("sizeof(1) = %d\n", sizeof(1));
+    printf("sizeof(-1) = %d\n", sizeof(-1));
+    printf("sizeof(2147483647) = %d\n", sizeof(2147483647));
+    printf("sizeof(0x7fffffff) = %d\n", sizeof(0x7fffffff));
+    printf("sizeof(0x80000000) = %d\n", sizeof(0x80000000));
+    printf("sizeof(-2147483647) = %d\n", sizeof(-2147483647));
+    printf("sizeof(-0x7fffffff) = %d\n", sizeof(-0x7fffffff));
+    printf("sizeof(-0x80000000) = %d\n", sizeof(-0x80000000));
+    printf("sizeof(2147483647+1) = %d\n", sizeof(2147483647+1));
+    printf("sizeof(0x7fffffff+1) = %d\n", sizeof(0x7fffffff+1));
+    printf("sizeof(0x80000000+1) = %d\n", sizeof(0x80000000+1));
+    printf("sizeof(2147483648) = %d\n", sizeof(2147483648));
+    printf("sizeof(-2147483648) = %d\n", sizeof(-2147483648));
+    printf("sizeof(2147483649) = %d\n", sizeof(2147483649));
+    printf("sizeof(-2147483649) = %d\n", sizeof(-2147483649));
+    printf("sizeof(0x7fffffffffffffff) = %d\n", sizeof(0x7fffffffffffffff));
+    printf("sizeof(0x8000000000000000) = %d\n", sizeof(0x8000000000000000));
+    printf("sizeof(9223372036854775807) = %d\n", sizeof(9223372036854775807));
+    printf("sizeof(9223372036854775808) = %d\n", sizeof(9223372036854775808));
+    printf("sizeof(9223372036854775809) = %d\n", sizeof(9223372036854775809));
+    printf("sizeof(-9223372036854775807) = %d\n", sizeof(-9223372036854775807));
+    printf("sizeof(-9223372036854775808) = %d\n", sizeof(-9223372036854775808));
+    printf("sizeof(-9223372036854775809) = %d\n", sizeof(-9223372036854775809));
+
+    printf("sizeof(0.0) = %d\n", sizeof(0.0));
+    printf("sizeof(0.0 / 0.0) = %d\n", sizeof(0.0 / 0.0));
+    printf("sizeof(1.0 / 0.0) = %d\n", sizeof(1.0 / 0.0));
+    printf("sizeof(0.0F) = %d\n", sizeof(0.0F));
+    printf("sizeof(0.0F / 0.0F) = %d\n", sizeof(0.0F / 0.0F));
+    printf("sizeof(1.0F / 0.0F) = %d\n", sizeof(1.0F / 0.0F));
+    printf("sizeof((f32)0.0) = %d\n", sizeof((f32)0.0));
+    printf("sizeof((f32)(0.0 / 0.0)) = %d\n", sizeof((f32)(0.0 / 0.0)));
+    printf("sizeof((f32)(1.0 / 0.0)) = %d\n", sizeof((f32)(1.0 / 0.0)));
+    printf("sizeof((f64)0.0) = %d\n", sizeof((f64)0.0));
+    printf("sizeof((f64)(0.0 / 0.0)) = %d\n", sizeof((f64)(0.0 / 0.0)));
+    printf("sizeof((f64)(1.0 / 0.0)) = %d\n", sizeof((f64)(1.0 / 0.0)));
+
+    printf("sizeof(i8.min) = %d\n", sizeof(i8.min));
+    printf("sizeof(i8.max) = %d\n", sizeof(i8.max));
+    printf("sizeof(i16.min) = %d\n", sizeof(i16.min));
+    printf("sizeof(i16.max) = %d\n", sizeof(i16.max));
+    printf("sizeof(i32.min) = %d\n", sizeof(i32.min));
+    printf("sizeof(i32.max) = %d\n", sizeof(i32.max));
+    printf("sizeof(i64.min) = %d\n", sizeof(i64.min));
+    printf("sizeof(i64.max) = %d\n", sizeof(i64.max));
+    printf("sizeof(u8.min) = %d\n", sizeof(u8.min));
+    printf("sizeof(u8.max) = %d\n", sizeof(u8.max));
+    printf("sizeof(u16.min) = %d\n", sizeof(u16.min));
+    printf("sizeof(u16.max) = %d\n", sizeof(u16.max));
+    printf("sizeof(u32.min) = %d\n", sizeof(u32.min));
+    printf("sizeof(u32.max) = %d\n", sizeof(u32.max));
+    printf("sizeof(u64.min) = %d\n", sizeof(u64.min));
+    printf("sizeof(u64.max) = %d\n", sizeof(u64.max));
+    printf("sizeof(isize.min) = %d\n", sizeof(isize.min));
+    printf("sizeof(isize.max) = %d\n", sizeof(isize.max));
+    printf("sizeof(usize.min) = %d\n", sizeof(usize.min));
+    printf("sizeof(usize.max) = %d\n", sizeof(usize.max));
+    printf("sizeof(f32.min) = %d\n", sizeof(f32.min));
+    printf("sizeof(f32.max) = %d\n", sizeof(f32.max));
+    printf("sizeof(f64.min) = %d\n", sizeof(f64.min));
+    printf("sizeof(f64.max) = %d\n", sizeof(f64.max));
+}
+
+public fn i32 main() {
+    print_values();
+    print_sizes();
+    return 0;
+}

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -200,6 +200,7 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
             break;
         }
         out.add(tmp);
+        if (tok.suffix_F) out.add1('F');
         ctx.offset = tok.loc + len;
         break;
     case CharLiteral:


### PR DESCRIPTION
* insert implicit casts on constant expressions
* pass `BuiltinKind` to numeric literal ast constructors
* determine `BuiltinKind` according to C semantics: `2147483648` is an `i64` while `0x80000000` is a `u32`
* use literal's `BuiltinKind` to determine C output syntax
* use uppercase suffixes for readability
* fix c2 library definitions so there are no implicit conversions
* fix Makefile so trace targets do not pollute output/c2c
* add tests on literal `sizeof` expressions