### PR TITLE
Analyser: simplify constant value analyser

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -139,7 +139,7 @@ public fn bool Checker.check(Checker* c, QualType lhs, QualType rhs, Expr** e_pt
         // TODO if bool, always allow, except in init?
         if (t1.isBool()) return true;
 
-        return ctv_analyser.check(c.diags, lhs, *e_ptr);
+        return ctv_analyser.checkRange(c.diags, lhs, *e_ptr);
     }
 
     const Type* lcanon = t1.getTypeOrNil();
@@ -434,7 +434,7 @@ fn bool Checker.checkEnum2Int(Checker* c, const Type* lcanon, const Type* rcanon
 
     // NOTE: EnumConstDecls are CTV, but variables of the type are not!
     if ((*c.expr_ptr).isCtv()) {
-        return ctv_analyser.check(c.diags, c.lhs, *c.expr_ptr);
+        return ctv_analyser.checkRange(c.diags, c.lhs, *c.expr_ptr);
     } else {
         // compare impl type
         const EnumType* et = (EnumType*)rcanon;

--- a/analyser/conversion_checker_expr.c2
+++ b/analyser/conversion_checker_expr.c2
@@ -16,7 +16,6 @@
 module conversion_checker;
 
 import ast local;
-import ctv_analyser;
 
 type ExprWidth struct {
     u8 width;   // in bits
@@ -47,7 +46,7 @@ fn ExprWidth getExprWidth(const Expr* e) {
     ExprWidth result = {}
 
     if (e.isCtv()) {
-        Value v = ctv_analyser.get_value(e);
+        Value v = ast.evalExpr(e);
         result.width = v.getWidth();
         result.is_signed = v.isNegative();
         return result;

--- a/analyser/ctv_analyser.c2
+++ b/analyser/ctv_analyser.c2
@@ -35,17 +35,13 @@ fn void Limit.init(Limit* l, u32 width, bool is_signed) {
     }
 }
 
-public fn Value get_value(const Expr* e) {
-    return ast.evalExpr(e);
-}
-
-public fn bool check(diagnostics.Diags* diags, QualType qt, const Expr* e) {
+public fn bool checkRange(diagnostics.Diags* diags, QualType qt, const Expr* e) {
     QualType canon = qt.getCanonicalType();
     if (!canon.isBuiltin()) return true;  // TODO find out cases
 
     assert(e.isCtv());
 
-    Value value = ctv_analyser.get_value((e));
+    Value value = ast.evalExpr((e));
 
     if (value.kind == ValueKind.Error) {
         diags.errorRange(e.getLoc(), e.getRange(), "%s", value.error_msg);
@@ -55,7 +51,7 @@ public fn bool check(diagnostics.Diags* diags, QualType qt, const Expr* e) {
 }
 
 public fn bool checkBitfield(diagnostics.Diags* diags, u8 bitfield_width, bool bitfield_signed, const Expr* e) {
-    Value value = ctv_analyser.get_value((e));
+    Value value = ast.evalExpr((e));
     if (value.kind == ValueKind.Error) {
         diags.errorRange(e.getLoc(), e.getRange(), "%s", value.error_msg);
         return false;

--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -15,11 +15,10 @@
 
 module module_analyser;
 
+import ast local;
 import ast_context;
 import ast_builder;
-import ast local;
 import attr;
-import ctv_analyser;
 import conversion_checker as conv;
 import diagnostics;
 import file_utils;
@@ -504,8 +503,8 @@ fn void Analyser.handleStaticAssert(void* arg, StaticAssert* d) {
 
     if (error) return;
 
-    Value val1 = ctv_analyser.get_value(lhs);
-    Value val2 = ctv_analyser.get_value(rhs);
+    Value val1 = ast.evalExpr(lhs);
+    Value val2 = ast.evalExpr(rhs);
 
     if (!val1.is_equal(&val2)) {
         ma.errorRange(rhs.getStartLoc(), rhs.getRange(), "static_assert failed, expected %s, got %s", val1.str(), val2.str());

--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -19,7 +19,6 @@ import ast local;
 import c_prec local;
 import c2_prec local;
 import conversion_checker;
-import ctv_analyser;
 
 fn bool validBinOpKind(QualType t) {
     t = t.getCanonicalType();
@@ -650,7 +649,7 @@ fn bool Analyser.checkShiftArgs(Analyser* ma, Expr* lhs, Expr* rhs) {
     // Do not reduce width of signed types to allow `i32 a = 1 << 31;`
 
     if (lhs.isCtv()) {
-        Value val = ctv_analyser.get_value(lhs);
+        Value val = ast.evalExpr(lhs);
         if (val.isNegative()) {
             ma.error(lhs.getLoc(), "shifting a negative signed value is undefined");
             return false;
@@ -659,7 +658,7 @@ fn bool Analyser.checkShiftArgs(Analyser* ma, Expr* lhs, Expr* rhs) {
 
     // check rhs
     if (rhs.isCtv()) {
-        Value val = ctv_analyser.get_value(rhs);
+        Value val = ast.evalExpr(rhs);
         if (val.isNegative()) {
             ma.error(rhs.getLoc(), "shift count is negative");
             return false;
@@ -678,7 +677,7 @@ fn bool Analyser.checkShiftArgs(Analyser* ma, Expr* lhs, Expr* rhs) {
 fn bool Analyser.checkZero(Analyser* ma, Expr* e, const char* operation) {
     if (!e.isCtv()) return true;
 
-    Value val = ctv_analyser.get_value(e);
+    Value val = ast.evalExpr(e);
     if (val.isDecimal()) {
         if (val.isZero()) {
             ma.error(e.getLoc(), "%s by zero is undefined", operation);

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -18,7 +18,6 @@ module module_analyser;
 import ast local;
 import ast_builder;
 import conversion_checker;
-import ctv_analyser;
 import src_loc local;
 
 fn QualType Analyser.analyseExpr(Analyser* ma, Expr** e_ptr, bool need_rvalue, u32 side) {
@@ -437,7 +436,7 @@ fn QualType Analyser.analyseArraySubscriptExpr(Analyser* ma, Expr** e_ptr, u32 s
             // check range
             u32 size = at.getSize();
             if (size != 0) { // dont give error if arrays has size 0 (allowed for struct members)
-                Value val = ctv_analyser.get_value(index);
+                Value val = ast.evalExpr(index);
                 u64 idx = val.as_u64();
                 if (idx >= size) {
                     ma.error(index.getLoc(), "array out-of-bounds access [%d] in array of [%d]", idx, size);
@@ -511,7 +510,7 @@ fn bool Analyser.analyseBitOffsetIndex(Analyser* ma, Expr** e_ptr, QualType base
     // TODO only allow CTV expressions
     if (!e.isCtv()) return false;
 
-    Value val = ctv_analyser.get_value(e);
+    Value val = ast.evalExpr(e);
     if (val.isNegative()) {
         ma.errorRange(e.getLoc(), e.getRange(), "bitoffset index value '%s' is negative", val.str());
         return false;

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -94,7 +94,7 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
         if (expectedType.isBuiltin() && !res.isPointer()) {
             // TODO should insert `BooleanCast` implicit cast
             if (expectedType.isBool()) return true;
-            if (!ctv_analyser.check(ma.diags, expectedType, e)) return false;
+            if (!ctv_analyser.checkRange(ma.diags, expectedType, e)) return false;
             if (res.getType() != expectedType.getType()) {
                 ma.builder.insertImplicitCast(ImplicitCastKind.IntegralCast, e_ptr, expectedType);
             }
@@ -266,7 +266,7 @@ fn bool Analyser.checkArrayDesignators(Analyser* ma, InitListExpr* ile, bool has
             ArrayDesignatedInitExpr* ad = (ArrayDesignatedInitExpr*)value;
             Expr* desig = ad.getDesignator();
             loc = desig.getLoc();
-            Value idx = ctv_analyser.get_value(desig);
+            Value idx = ast.evalExpr(desig);
             if (!idx.isDecimal()) {
                 ma.error(loc, "array designator expression must have integer type");
                 return false;

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -16,7 +16,6 @@
 module module_analyser;
 
 import ast local;
-import ctv_analyser;
 import label_vector local;
 import scope;
 
@@ -269,7 +268,7 @@ fn FlowBits Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
         if (qt.isInvalid()) goto done;
         ma.checker.check(builtins[BuiltinKind.Bool], qt, cond, (*cond).getLoc());
         if ((*cond).isCtv()) {
-            Value v = ctv_analyser.get_value((*cond));
+            Value v = ast.evalExpr((*cond));
             if (v.isZero()) {
                 // TODO: body is never reached
             } else {
@@ -304,7 +303,7 @@ fn FlowBits Analyser.analyseWhileStmt(Analyser* ma, Stmt* s) {
 
     Expr* cond = getCondExpr(w.getCond());
     if (cond.isCtv()) {
-        Value v = ctv_analyser.get_value(cond);
+        Value v = ast.evalExpr(cond);
         if (v.isZero()) {
             // TODO: body is never reached
         } else {

--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -16,7 +16,6 @@
 module module_analyser;
 
 import ast local;
-import ctv_analyser;
 import name_vector local;
 import size_analyser;
 
@@ -86,7 +85,7 @@ fn void Analyser.analyseStructMembers(Analyser* ma, StructTypeDecl* d) {
                     ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field size is not a compile-time value");
                     return;
                 }
-                Value value = ctv_analyser.get_value(bitfield);
+                Value value = ast.evalExpr(bitfield);
                 if (value.isZero()) {
                     if (name)
                         ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "zero width for bit-field '%s'", name);

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -16,7 +16,6 @@
 module module_analyser;
 
 import ast local;
-import ctv_analyser;
 import init_checker;
 import src_loc local;
 import scope;
@@ -330,7 +329,7 @@ fn bool Analyser.analyseCaseExpr(Analyser* ma,
                 ma.error(cond.getLoc(), "case condition is not compile-time constant");
                 return false;
             }
-            Value v = ctv_analyser.get_value(cond);
+            Value v = ast.evalExpr(cond);
             index = v.as_u32();
             *name_idxp = 0;
             if (loc) {

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -77,7 +77,7 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
                 ma.errorRange(initval.getLoc(), initval.getRange(), "initializer is not a compile-time value");
                 return;
             }
-            Value ctv = ctv_analyser.get_value(initval);
+            Value ctv = ast.evalExpr(initval);
             if (value.kind == ValueKind.Error) {
                 ma.errorRange(initval.getLoc(), initval.getRange(), "%s", ctv.error_msg);
                 return;
@@ -248,7 +248,7 @@ fn QualType Analyser.analyseTypeRef(Analyser* ma, TypeRef* ref) {
                 return QualType_Invalid;
             }
 
-            Value value = ctv_analyser.get_value(sizeExpr);
+            Value value = ast.evalExpr(sizeExpr);
             if (value.isNegative()) {
                 ma.errorRange(sizeExpr.getLoc(), sizeExpr.getRange(), "array size has negative value '%s'", value.str());
                 return QualType_Invalid;

--- a/generator/ir/basic_struct_layouter.c2
+++ b/generator/ir/basic_struct_layouter.c2
@@ -16,7 +16,6 @@
 module ir_generator;
 
 import ast;
-import ctv_analyser;
 
 type BasicStructLayouter struct {
     Generator* gen;
@@ -55,7 +54,7 @@ fn void BasicStructLayouter.add(BasicStructLayouter* l,
     if (ml.is_bitfield) {
         l.bitfield_base_size = ml.size;
         if (e.isCtv()) {
-            ast.Value value = ctv_analyser.get_value(e);
+            ast.Value value = ast.evalExpr(e);
             value.mask(ml.bitfield_width);
             value.left_shift2(ml.bitfield_offset);
             u64 v = value.as_u64();

--- a/generator/ir/field_struct_layouter.c2
+++ b/generator/ir/field_struct_layouter.c2
@@ -16,7 +16,6 @@
 module ir_generator;
 
 import ast;
-import ctv_analyser;
 import ir local;
 import ir_context;
 
@@ -132,7 +131,7 @@ field:
             //printf("BITFIELD(%d, %d) size %d\n", fi.info.bitfield_offset, fi.info.bitfield_width, bitfield_base_size);
 
             if (e.isCtv()) {
-                ast.Value value = ctv_analyser.get_value(e);
+                ast.Value value = ast.evalExpr(e);
                 value.mask(fi.info.bitfield_width);
                 value.left_shift2(fi.info.bitfield_offset);
                 u64 v = value.as_u64();
@@ -191,7 +190,7 @@ fn void FieldStructLayouter.finalizeExpr(FieldStructLayouter* l, const ast.Struc
                 ast.Expr* e = fi.expr;
                 Ref value_ref;
                 if (e.isCtv()) {
-                    ast.Value value = ctv_analyser.get_value(e);
+                    ast.Value value = ast.evalExpr(e);
                     value.mask(fi.info.bitfield_width);
                     if (fi.info.bitfield_offset) value.left_shift2(fi.info.bitfield_offset);
                     u64 v = value.as_u64();

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -21,7 +21,6 @@ import build_file;
 import component;
 import console;
 import constants;
-import ctv_analyser;
 import file_utils;
 import ir local;
 import ir_context local;
@@ -257,7 +256,7 @@ fn ir.Type Generator.type2irtype(Generator* gen, QualType qt) {
 
 fn void Generator.emitInit(Generator* gen, const Expr* e, u32 size) {
     if (e.isCtv()) {
-        Value v = ctv_analyser.get_value(e);
+        Value v = ast.evalExpr(e);
         switch (size) {
         case 1:
             gen.ctx.addInitValueU8(v.as_u8());
@@ -417,7 +416,7 @@ fn void Generator.emitArrayInit(Generator* gen, const Expr* e) {
             if (ie.isArrayDesignatedInit()) {
                 const ArrayDesignatedInitExpr* ad = (ArrayDesignatedInitExpr*)ie;
                 const Expr* desig = ad.getDesignator();
-                Value v = ctv_analyser.get_value(desig);
+                Value v = ast.evalExpr(desig);
                 sorter.addAt(v.as_u32(), ad.getInit());
             } else {
                 sorter.add(ie);

--- a/generator/ir/ir_generator_binop.c2
+++ b/generator/ir/ir_generator_binop.c2
@@ -19,7 +19,6 @@ import ast local;
 import bit_utils;
 import ir local;
 import ir_context;
-import ctv_analyser;
 
 fn void Generator.emitAssign(Generator* gen, ir.Ref* result, const Expr* lhs, const Expr* rhs) {
     // special case is needed because setting Bitfield is not a simple store
@@ -348,7 +347,7 @@ fn void Generator.emitBitfieldAssign(Generator* gen, ir.Ref* result, const Expr*
     const VarDecl* vd = (VarDecl*)d;
     const Expr* bitfield = vd.getBitfield();
     // TODO already convert to IntegerLiteral (if not already) in analyser?
-    Value val = ctv_analyser.get_value(bitfield);
+    Value val = ast.evalExpr(bitfield);
     u32 width = val.as_u32();
     u32 mask = bit_utils.get_mask32(width); // TEMP u32
     u32 bit_offset = 0; // TODO get bitfield-offset

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -19,11 +19,10 @@ import ast local;
 import ir local;
 import ir_context local;
 import ir_gen_locals local;
-import ctv_analyser;
 
 fn void Generator.emitExpr(Generator* gen, ir.Ref* result, const Expr* e) {
     if (e.isCtv()) {
-        Value v = ctv_analyser.get_value(e);
+        Value v = ast.evalExpr(e);
         // TEMP as u32 TODO
         *result = gen.ctx.addIntegerConstant(v.as_u32());
         return;
@@ -312,7 +311,7 @@ fn void Generator.emitCond(Generator* gen, const Expr* e, BlockId true_blk, Bloc
     ir_context.Context* c = gen.ctx;
 
     if (e.isCtv()) {
-        Value v = ctv_analyser.get_value(e);
+        Value v = ast.evalExpr(e);
         if (v.isZero()) {
             c.addJmpInstr(false_blk);
         } else {
@@ -509,7 +508,7 @@ fn void Generator.emitArraySubscript(Generator* gen, ir.Ref* result, const Expr*
         gen.emitExpr(&base_ref, base);
 
         // offset = value * base_size;
-        Value v = ctv_analyser.get_value(index);
+        Value v = ast.evalExpr(index);
         u32 offset = v.as_u32() * base_size;
         if (offset == 0) {
             *result = base_ref;

--- a/generator/ir/ir_generator_stmt.c2
+++ b/generator/ir/ir_generator_stmt.c2
@@ -127,7 +127,7 @@ fn void Generator.emitIfStmt(Generator* gen, const Stmt* s) {
     assert(cond.isExpr()); // TODO handle if (Decl* d = ..) ..
     Expr* e = (Expr*)cond;
     if (e.isCtv()) {
-        Value v = ctv_analyser.get_value(e);
+        Value v = ast.evalExpr(e);
         if (v.isZero()) {
             if (else_stmt) gen.emitStmt(else_stmt);
         } else {

--- a/generator/ir/ir_generator_switch.c2
+++ b/generator/ir/ir_generator_switch.c2
@@ -16,7 +16,6 @@
 module ir_generator;
 
 import ast local;
-import ctv_analyser;
 import ir local;
 import ir_context;
 
@@ -86,7 +85,7 @@ fn bool Generator.emitSwitchCase(Generator* gen,
             const RangeExpr* r = (RangeExpr*)case_cond;
             case_cond = r.getLHS();
         }
-        v = ctv_analyser.get_value(case_cond);
+        v = ast.evalExpr(case_cond);
     }
     // TEMP always take u32 for now
     BlockKind kind = sc.isDefault() ? BlockKind.SwitchDefault : BlockKind.SwitchCase;

--- a/recipe.txt
+++ b/recipe.txt
@@ -211,6 +211,7 @@ executable c2c
 
     analyser/conversion_checker.c2
     analyser/conversion_checker_expr.c2
+    analyser/ctv_analyser.c2
     analyser/incr_array_list.c2
     analyser/init_checker.c2
     analyser/module_analyser.c2
@@ -235,7 +236,6 @@ executable c2c
     analyser/struct_func_list.c2
     analyser/unused_checker.c2
 
-    analyser_utils/ctv_analyser.c2
     analyser_utils/printf_utils.c2
 
     compiler/c2recipe.c2


### PR DESCRIPTION
* rename `ctv_analyser.check` as `ctv_analyser.checkRange`
* call `ast.evalExpr()` instead of `ctv_analyser.get_value()`
* remove `ctv_analyser.get_value`
* move analyser_utils/ctv_analyser.c2 to analyser/ctv_analyser.c2