### PR TITLE
Compiler: remove builtins global variable

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -302,7 +302,7 @@ fn bool Checker.checkPointer2Builtin(Checker* c, const Type* lcanon, const Type*
 
     BuiltinKind kind = bi.getKind();
     if (kind == BuiltinKind.Bool) {
-        c.builder.insertImplicitCast(PointerToBoolean, c.expr_ptr, builtins[BuiltinKind.Bool]);
+        c.builder.insertImplicitCast(PointerToBoolean, c.expr_ptr, getBuiltinQT(Bool));
         return true;
     }
 
@@ -321,7 +321,7 @@ fn bool Checker.checkPointer2Builtin(Checker* c, const Type* lcanon, const Type*
         }
     }
 
-    c.builder.insertImplicitCast(PointerToInteger, c.expr_ptr, builtins[BuiltinKind.USize]);
+    c.builder.insertImplicitCast(PointerToInteger, c.expr_ptr, getBuiltinQT(USize));
     return true;
 }
 
@@ -658,7 +658,7 @@ const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] ConditionalOperatorResult =
 }
 public fn QualType get_common_arithmetic_type(BuiltinType* bi1, BuiltinType* bi2) {
     BuiltinKind kind = (BuiltinKind)ConditionalOperatorResult[bi2.getBaseKind()][bi1.getBaseKind()];
-    return ast.builtins[kind];
+    return getBuiltinQT(kind);
 }
 
 /*
@@ -712,17 +712,17 @@ public fn QualType usual_arithmetic_conversion(const BuiltinType* b1, const Buil
 
     switch(UsualArithmeticConversions[k2][k1]) {
     case 0:
-        return ast.builtins[BuiltinKind.Int32];
+        return getBuiltinQT(Int32);
     case 1:
-        return ast.builtins[BuiltinKind.UInt32];
+        return getBuiltinQT(UInt32);
     case 2:
-        return ast.builtins[BuiltinKind.Int64];
+        return getBuiltinQT(Int64);
     case 3:
-        return ast.builtins[BuiltinKind.UInt64];
+        return getBuiltinQT(UInt64);
     case 4:
-        return ast.builtins[BuiltinKind.Float32];
+        return getBuiltinQT(Float32);
     case 5:
-        return ast.builtins[BuiltinKind.Float64];
+        return getBuiltinQT(Float64);
     case 6:
         break;
     }

--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -225,12 +225,12 @@ fn QualType Analyser.checkBinopShiftArgs(Analyser* ma, BinaryOperator* b, QualTy
 
     // perform integer promotion on both arguments
     if (bl.isPromotableIntegerType()) {
-        lcanon = ast.builtins[BuiltinKind.Int32];
+        lcanon = getBuiltinQT(Int32);
         width = 32;
         if (!assign) ma.builder.insertImplicitCast(IntegralCast, b.getLHS2(), lcanon);
     }
     if (br.isPromotableIntegerType()) {
-        rcanon = ast.builtins[BuiltinKind.Int32];
+        rcanon = getBuiltinQT(Int32);
         ma.builder.insertImplicitCast(IntegralCast, b.getRHS2(), rcanon);
     }
     Expr* lhs = b.getLHS();
@@ -267,7 +267,7 @@ fn QualType Analyser.checkBinopLogical(Analyser* ma, BinaryOperator* b, QualType
     }
     if (!validTestType(rhs)) return ma.invalidBinOp1(b, b.getRHS(), rhs);
 
-    return builtins[BuiltinKind.Bool];
+    return getBuiltinQT(Bool);
 }
 
 // 0  cannot happen
@@ -503,7 +503,7 @@ fn QualType Analyser.checkBinopSubArgs(Analyser* ma, BinaryOperator* b, QualType
         QualType t1 = pt1.getInner();
         QualType t2 = pt2.getInner();
         if (t1.getTypeOrNil() != t2.getTypeOrNil() || t1.isVoid() || t2.isVoid()) goto invalid;
-        return builtins[BuiltinKind.ISize];
+        return getBuiltinQT(ISize);
     }
     return ma.invalidBinOp2(b, lhs, rhs);
 }
@@ -569,7 +569,7 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
         // TODO should detect comparison between i32/u32 and i32/u32
         // TODO i32 < u32 is not the same as i32 = u32! dont use checker
         //if (ma.checker.check(lhs, rhs, &e, e.getLoc())) return QualType_Invalid;
-        return builtins[BuiltinKind.Bool];
+        return getBuiltinQT(Bool);
     case 3: // builtin : enum
         rcanon = rcanon.getImplType();
         goto builtin;
@@ -585,7 +585,7 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
             ma.error(e.getLoc(), "comparing pointers to different types ('%s' and '%s')", lhs.diagName(), rhs.diagName());
             return QualType_Invalid;
         }
-        return builtins[BuiltinKind.Bool];
+        return getBuiltinQT(Bool);
     case 5: // enum : builtin
         lcanon = lcanon.getImplType();
         goto builtin;
@@ -594,7 +594,7 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
             ma.error(e.getLoc(), "comparing enums of different types ('%s' and '%s')", lhs.diagName(), rhs.diagName());
             return QualType_Invalid;
         }
-        return builtins[BuiltinKind.Bool];
+        return getBuiltinQT(Bool);
     case 7: // pointer : function
         if (is_relative) return ma.invalidFuncCompare(b);
         // TODO accept 0 == f, (void*)0 == f and (void*)nil == f
@@ -607,7 +607,7 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
         return ma.checkFuncTest(lcanon.getFunctionType(), e.getLoc());
     case 9: // function : function
         if (is_relative) return ma.invalidFuncCompare(b);
-        return builtins[BuiltinKind.Bool];
+        return getBuiltinQT(Bool);
     case 10: // invalid lhs
         return ma.invalidBinOp1(b, b.getLHS(), lhs);
     case 11: // invalid rhs
@@ -621,7 +621,7 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
 fn QualType Analyser.checkFuncTest(Analyser* ma, FunctionType* ft, SrcLoc loc) {
     // only allow nil vs weak-function or function pointer
     FunctionDecl* fd = ft.getDecl();
-    if (fd.isType() || fd.hasAttrWeak()) return builtins[BuiltinKind.Bool]; // Variable with Function type (eg callback)
+    if (fd.isType() || fd.hasAttrWeak()) return getBuiltinQT(Bool); // Variable with Function type (eg callback)
     ma.error(loc, "comparison of function '%s' will always be true", fd.asDecl().getFullName());
     return QualType_Invalid;
 }
@@ -669,7 +669,7 @@ fn QualType Analyser.analyseBinaryOperator(Analyser* ma, Expr** e_ptr) {
     if (opcode.isComparison()) {
         // special case for enum comparison without prefix (eg kind >= KW_void)
         if (ma.checkEnumArg(b.getRHS2(), ltype))
-            return builtins[BuiltinKind.Bool];
+            return getBuiltinQT(Bool);
     }
     QualType rtype;
     if (opcode == BinaryOpcode.Assign) {

--- a/analyser/module_analyser_builtin.c2
+++ b/analyser/module_analyser_builtin.c2
@@ -87,7 +87,7 @@ fn QualType Analyser.analyseSizeof(Analyser* ma, BuiltinExpr* e) {
 
     size_analyser.TypeSize info = size_analyser.sizeOfType(qt);
     e.setUValue(info.size);
-    return builtins[BuiltinKind.UInt32];
+    return getBuiltinQT(UInt32);
 }
 
 fn QualType Analyser.analyseElemsof(Analyser* ma, BuiltinExpr* b) {
@@ -107,13 +107,13 @@ fn QualType Analyser.analyseElemsof(Analyser* ma, BuiltinExpr* b) {
             return QualType_Invalid;
         }
         b.setUValue(at.getSize());
-        return builtins[BuiltinKind.UInt32];
+        return getBuiltinQT(UInt32);
     }
     const EnumType* et = qt.getEnumTypeOrNil();
     if (et) {
         const EnumTypeDecl* etd = et.getDecl();
         b.setUValue(etd.getNumConstants());
-        return builtins[BuiltinKind.UInt32];
+        return getBuiltinQT(UInt32);
     }
     ma.error(inner.getLoc(), "elemsof can only be used on arrays/enums");
     return QualType_Invalid;
@@ -149,7 +149,7 @@ fn QualType Analyser.analyseOffsetOf(Analyser* ma, BuiltinExpr* b) {
     QualType qt = ma.analyseExpr(&inner, false, RHS);
     if (qt.isInvalid()) return QualType_Invalid;
 
-    e.setType(builtins[BuiltinKind.UInt32]);
+    e.setType(getBuiltinQT(UInt32));
 
     StructType* st = qt.getStructTypeOrNil();
     if (!st) {

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -423,7 +423,7 @@ fn QualType usualUnaryConversions(Expr* e) {
 
     if (!canon.isBuiltin()) return QualType_Invalid;
     BuiltinType* bi = canon.getBuiltin();
-    if (bi.isPromotableIntegerType()) return ast.builtins[BuiltinKind.Int32];
+    if (bi.isPromotableIntegerType()) return getBuiltinQT(Int32);
     return qt;
 }
 
@@ -554,13 +554,13 @@ fn QualType Analyser.analyseBitOffsetExpr(Analyser* ma, QualType ltype, Expr* ba
         Value width = lval.minus(&rval);
         u64 w = width.as_u64() + 1;
         if (w <= 8) {
-            ltype = ast.builtins[BuiltinKind.UInt8];
+            ltype = getBuiltinQT(UInt8);
         } else if (w <= 16) {
-            ltype = ast.builtins[BuiltinKind.UInt16];
+            ltype = getBuiltinQT(UInt16);
         } else if (w <= 32) {
-            ltype = builtins[BuiltinKind.UInt32];
+            ltype = getBuiltinQT(UInt32);
         } else {
-            ltype = ast.builtins[BuiltinKind.UInt64];
+            ltype = getBuiltinQT(UInt64);
         }
 
         bo.setWidth((u8)w);

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -215,7 +215,7 @@ fn QualType Analyser.analyseCondition(Analyser* ma, Stmt** s_ptr, bool check_ass
     assert(s.isExpr());
     QualType qt = ma.analyseExpr((Expr**)s_ptr, true, RHS);
     Expr* e = (Expr*)*s_ptr;
-    if (qt.isValid()) ma.checker.check(builtins[BuiltinKind.Bool], qt, (Expr**)s_ptr, e.getLoc());
+    if (qt.isValid()) ma.checker.check(getBuiltinQT(Bool), qt, (Expr**)s_ptr, e.getLoc());
     e = (Expr*)*s_ptr;    // re-read in case of ImplicitCast insertions
 
     if (check_assign && e.isAssignment()) {
@@ -266,7 +266,7 @@ fn FlowBits Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
     if (cond) {
         QualType qt = ma.analyseExpr(cond, true, RHS);
         if (qt.isInvalid()) goto done;
-        ma.checker.check(builtins[BuiltinKind.Bool], qt, cond, (*cond).getLoc());
+        ma.checker.check(getBuiltinQT(Bool), qt, cond, (*cond).getLoc());
         if ((*cond).isCtv()) {
             Value v = ast.evalExpr((*cond));
             if (v.isZero()) {
@@ -435,7 +435,7 @@ fn void Analyser.analyseAssertStmt(Analyser* ma, Stmt* s) {
     if (qt.isInvalid()) return;
 
     Expr* inner = a.getInner();
-    ma.checker.check(builtins[BuiltinKind.Bool], qt, a.getInner2(), inner.getLoc());
+    ma.checker.check(getBuiltinQT(Bool), qt, a.getInner2(), inner.getLoc());
 }
 
 fn void Analyser.analyseReturnStmt(Analyser* ma, Stmt* s) {

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -316,7 +316,7 @@ fn QualType Analyser.analyseIncrTypeRef(Analyser* ma, TypeRef* ref, u32 size) {
     QualType resolved = base;
     u32 num_ptrs = ref.getNumPointers();
     for (u32 i=0; i<num_ptrs; i++) {
-        resolved = ma.builder.actOnPointerType(resolved) ;
+        resolved = ma.builder.actOnPointerType(resolved);
     }
 
     if (resolved.isVoid()) {

--- a/analyser/module_analyser_unaryop.c2
+++ b/analyser/module_analyser_unaryop.c2
@@ -151,7 +151,7 @@ fn QualType Analyser.analyseUnaryOperator(Analyser* ma, Expr** e_ptr, u32 side) 
     case LNot:
         if (!canon.isScalar()) goto invalid_type;
         e.copyConstantFlags(inner);
-        return builtins[BuiltinKind.Bool];
+        return getBuiltinQT(Bool);
     }
     return t;
 
@@ -284,22 +284,22 @@ fn QualType getMinusType(QualType qt) {
     case Int8:
     case Int16:
     case Bool:
-        return ast.builtins[BuiltinKind.Int32];
+        return getBuiltinQT(Int32);
     case Int32:
     case Int64:
         return qt;
     case UInt8:
     case UInt16:
     case UInt32:
-        return ast.builtins[BuiltinKind.Int32];
+        return getBuiltinQT(Int32);
     case UInt64:
-        return ast.builtins[BuiltinKind.Int64];
+        return getBuiltinQT(Int64);
     case Float32:
     case Float64:
     case ISize:
         return qt;
     case USize:
-        return builtins[BuiltinKind.ISize];
+        return getBuiltinQT(ISize);
     }
     return QualType_Invalid;
 }

--- a/ast/boolean_literal.c2
+++ b/ast/boolean_literal.c2
@@ -32,7 +32,7 @@ public fn BooleanLiteral* BooleanLiteral.create(ast_context.Context* c, SrcLoc l
     BooleanLiteral* e = c.alloc(sizeof(BooleanLiteral));
     e.base.init(ExprKind.BooleanLiteral, loc, 1, 1, 0, ValType.RValue);
     e.base.base.booleanLiteralBits.value = val;
-    e.base.setType(ast.builtins[BuiltinKind.Bool]);
+    e.base.setType(getBuiltinQT(Bool));
 #if AstStatistics
     Stats.addExpr(ExprKind.BooleanLiteral, sizeof(BooleanLiteral));
 #endif

--- a/ast/char_literal.c2
+++ b/ast/char_literal.c2
@@ -40,7 +40,7 @@ public fn CharLiteral* CharLiteral.create(ast_context.Context* c, SrcLoc loc, u3
 #if AstStatistics
     Stats.addExpr(ExprKind.CharLiteral, sizeof(CharLiteral));
 #endif
-    e.base.setType(builtins[BuiltinKind.Char]);
+    e.base.setType(getBuiltinQT(Char));
     return e;
 }
 

--- a/ast/float_literal.c2
+++ b/ast/float_literal.c2
@@ -40,7 +40,7 @@ public fn FloatLiteral* FloatLiteral.create(ast_context.Context* c, SrcLoc loc, 
 #if AstStatistics
     Stats.addExpr(ExprKind.FloatLiteral, sizeof(FloatLiteral));
 #endif
-    i.base.setType(ast.builtins[kind]);
+    i.base.setType(getBuiltinQT(kind));
 
     return i;
 }

--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -40,7 +40,7 @@ public fn IntegerLiteral* IntegerLiteral.create(ast_context.Context* c, SrcLoc l
 #if AstStatistics
     Stats.addExpr(ExprKind.IntegerLiteral, sizeof(IntegerLiteral));
 #endif
-    i.base.setType(builtins[kind]);
+    i.base.setType(getBuiltinQT(kind));
 
     return i;
 }

--- a/ast/string_type_pool.c2
+++ b/ast/string_type_pool.c2
@@ -78,7 +78,7 @@ fn QualType StringTypePool.get(StringTypePool* p, u32 len) {
     }
     if (p.count == p.capacity) p.resize(p.capacity * 2);
 
-    Type* t = (Type*)ArrayType.create(p.context, builtins[BuiltinKind.Char], true, len, false, QualType_Invalid);
+    Type* t = (Type*)ArrayType.create(p.context, getBuiltinQT(Char), true, len, false, QualType_Invalid);
     u32 idx = p.count;
     p.slots[idx].len = len;
     p.slots[idx].type_ = t;

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -97,6 +97,10 @@ static_assert(8, sizeof(TypeRef));
 public const QualType QualType_Invalid = { }
 
 public type Globals struct @(opaque) {
+    QualType[elemsof(BuiltinKind)] builtins;
+    QualType void_type;
+    QualType void_ptr_type;
+
     string_pool.Pool* names_pool;
     PointerPool pointers;
     StringTypePool string_types;
@@ -112,8 +116,6 @@ public type Globals struct @(opaque) {
     BuiltinKind[elemsof(BuiltinKind)] builtinType_baseTypes;
 
     u32[elemsof(attr.AttrKind)] attr_name_indexes;
-    QualType void_type;
-    QualType void_ptr_type;
 
     string_buffer.Buf* dump_buf;
 #if AstStatistics
@@ -123,7 +125,6 @@ public type Globals struct @(opaque) {
 
 // The only globals for AST are here, since they must be set explicitly for plugins!!
 Globals* globals;
-public QualType* builtins;
 
 // for plugins
 public fn Globals* getGlobals() { return globals; }
@@ -133,7 +134,6 @@ public fn void setGlobals(Globals* g) @(unused){
     globals = g;
     attr.initialize(g.attr_name_indexes);
 }
-
 
 // wordsize in bytes, must NOT be called from Plugin!
 public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, bool use_color) {
@@ -152,9 +152,8 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
 #endif
 
     // create all Qualtypes for builtin-types, 1 extra for void-ptr
-    builtins = stdlib.malloc(elemsof(BuiltinKind) * sizeof(QualType));
     for (u32 i=0; i<elemsof(BuiltinKind); i++) {
-        builtins[i].set((Type*)BuiltinType.create(c, (BuiltinKind)i));
+        globals.builtins[i].set((Type*)BuiltinType.create(c, (BuiltinKind)i));
     }
 
     globals.void_type.set((Type*)VoidType.create(c));
@@ -198,7 +197,6 @@ public fn void deinit(bool print_stats) {
     globals.pointers.clear();
     globals.string_types.clear();
     stdlib.free(globals);
-    stdlib.free(builtins);
     globals.dump_buf.free();
 }
 
@@ -229,6 +227,10 @@ public fn Type* getPointerType(QualType inner) {
 
 public fn QualType getVoidQT() {
     return globals.void_type;
+}
+
+public fn QualType getBuiltinQT(BuiltinKind kind) {
+    return globals.builtins[kind];
 }
 
 fn u32 addAST(AST* ast_) {

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -663,7 +663,7 @@ public fn void Builder.applyAttributes(Builder* b, Decl* d) {
 }
 
 public fn QualType Builder.actOnBuiltinType(Builder*, BuiltinKind kind) {
-    return builtins[kind];
+    return getBuiltinQT(kind);
 }
 
 public fn QualType Builder.actOnVoidType(Builder*) {

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -314,7 +314,6 @@ fn void Compiler.build(Compiler* c,
     info.target = target;
     info.components = &c.components;
     info.ast_globals = ast.getGlobals();
-    info.ast_builtins = ast.builtins;
     info.astPool = c.astPool;
     info.auxPool = c.auxPool;
     info.context = c.context;

--- a/plugins/deps_generator_plugin.c2
+++ b/plugins/deps_generator_plugin.c2
@@ -53,7 +53,6 @@ fn void init(void* arg, plugin_info.Info* info) {
     Plugin* p = arg;
     p.info = info;
     ast.setGlobals(info.ast_globals);
-    ast.builtins = info.ast_builtins;
 }
 
 fn void post_analysis(void* arg) {

--- a/plugins/git_version_plugin.c2
+++ b/plugins/git_version_plugin.c2
@@ -69,7 +69,6 @@ fn void init(void* arg, plugin_info.Info* info) {
 fn void generate_module(void* arg) {
     Plugin* p = arg;
     ast.setGlobals(p.info.ast_globals);
-    ast.builtins = p.info.ast_builtins;
 
     // create module git_version
     u32 mod_name = p.info.astPool.addStr("git_version", true);

--- a/plugins/plugin_info.c2
+++ b/plugins/plugin_info.c2
@@ -41,7 +41,7 @@ public type Info struct {
     ast_context.Context* context;
     ast_builder.Builder* builder;
     ast.Globals* ast_globals;
-    ast.QualType* ast_builtins;
+    void* ast_builtins__;  // part of ast_globals now
 
     AddSourceFn addSource;
     RegisterAttrFn register_attr;

--- a/plugins/refs_generator_plugin.c2
+++ b/plugins/refs_generator_plugin.c2
@@ -54,7 +54,6 @@ fn void init(void* arg, plugin_info.Info* info) {
     Plugin* p = arg;
     p.info = info;
     ast.setGlobals(info.ast_globals);
-    ast.builtins = info.ast_builtins;
 }
 
 fn void post_analysis(void* arg) {

--- a/plugins/shell_cmd_plugin.c2
+++ b/plugins/shell_cmd_plugin.c2
@@ -72,7 +72,6 @@ fn void init(void* arg, plugin_info.Info* info) {
     Plugin* p = arg;
     p.info = info;
     ast.setGlobals(info.ast_globals);
-    ast.builtins = info.ast_builtins;
 
     console.debug("shell_cmd: loading %s", p.config_file);
     file_utils.File file.init("", p.config_file);

--- a/plugins/unit_test_plugin.c2
+++ b/plugins/unit_test_plugin.c2
@@ -71,7 +71,6 @@ fn void plugin_init(void* arg, plugin_info.Info* info) {
     p.info = info;
     p.decls.clear();
     ast.setGlobals(info.ast_globals);
-    ast.builtins = info.ast_builtins;
 
     p.attr_name = info.astPool.addStr("unittest", true);
     info.registerAttr(p.attr_name, handle_attr, p);


### PR DESCRIPTION
* move the allocated array `builtins` to the `ast.globals` structure
* add `getBuiltinQT()` to retrieve `QualType` values for builtin types
* remove `ast_builtins` in `plugin_into.Info` structure
* remove `BuiltinType.isInt8()`, `BuiltinType.isChar()`, `BuiltinType.isUInt8()`, `QualType.isInt8()`
* add `QualType.isCharCompatible()`