### PR TITLE
Analyser: construct new format strings in analyser

### DIFF
--- a/analyser/conversion_checker_expr.c2
+++ b/analyser/conversion_checker_expr.c2
@@ -103,6 +103,9 @@ fn ExprWidth getExprWidth(const Expr* e) {
     case NamedArgument:
         const NamedArgument* n = (NamedArgument*)e;
         return getExprWidth(n.getInner());
+    case Alternate:
+        const AlternateExpr* n = (AlternateExpr*)e;
+        return getExprWidth(n.getOriginal());
     }
 
     e.dump();

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -19,8 +19,10 @@ import ast local;
 import printf_utils;
 import scope;
 import src_loc local;
+import string_buffer;
 
 import stdio;
+import string;
 
 const char[] DiagTooManyArgs = "too many arguments to %sfunction call, expected %d, have %d";
 const char[] DiagTooFewArgs = "too few arguments to %sfunction call, expected %d, have %d";
@@ -163,7 +165,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
 
     //stdio.printf("CALL (%d | %d)\n", func_num_args, call_num_args);
     bool has_printf_format = false;
-    u32 printf_call_idx = 0;
+    u32 format_arg_idx = 0;
     while (1) {
         //stdio.printf("ARG [%d | %d]\n", func_arg_index, call_arg_index);
         if (func_arg_index >= func_num_args) break;
@@ -212,7 +214,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
 
         if (vd.hasPrintfFormat()) {
             has_printf_format = true;
-            printf_call_idx = call_arg_index;
+            format_arg_idx = call_arg_index;
         }
 
         func_arg_index++;
@@ -253,10 +255,10 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         }
 
         if (has_printf_format) {
-            u32 num_args = call_num_args - printf_call_idx - 1;
-            bool change_format = false;
-            ma.checkPrintArgs(call_args[printf_call_idx], num_args, &call_args[printf_call_idx+1], &change_format);
-            call.setPrintfFormat(printf_call_idx, change_format);
+            u32 num_args = call_num_args - format_arg_idx - 1;
+            call.setPrintfFormat(format_arg_idx);
+            if (!ma.checkPrintfArgs(&call_args[format_arg_idx], num_args, &call_args[format_arg_idx+1]))
+                return QualType_Invalid;
         }
     }
     return fd.getRType();
@@ -265,17 +267,54 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
 type FormatAnalyser struct {
     Analyser* ma;
     const char* format;
+    Expr** args;
     u32 num_args;
     u32 idx;
     SrcLoc loc;
-    bool change_format;
-    Expr** args;
+    u32 last_offset;
+    string_buffer.Buf* out;
+}
+
+const bool[] Format_needs_l_prefix = {
+    [BuiltinKind.Char] = false,
+    [BuiltinKind.Int8] = false,
+    [BuiltinKind.Int16] = false,
+    [BuiltinKind.Int32] = false,
+    [BuiltinKind.Int64] = true,
+    [BuiltinKind.UInt8] = false,
+    [BuiltinKind.UInt16] = false,
+    [BuiltinKind.UInt32] = false,
+    [BuiltinKind.UInt64] = true,
+    [BuiltinKind.Float32] = false,
+    [BuiltinKind.Float64] = true,
+    [BuiltinKind.ISize] = true,
+    [BuiltinKind.USize] = true,
+    [BuiltinKind.Bool] = false,
+}
+
+const bool[] Format_needs_u_prefix = {
+    [BuiltinKind.Char] = false,
+    [BuiltinKind.Int8] = false,
+    [BuiltinKind.Int16] = false,
+    [BuiltinKind.Int32] = false,
+    [BuiltinKind.Int64] = false,
+    [BuiltinKind.UInt8] = false,
+    [BuiltinKind.UInt16] = false,
+    [BuiltinKind.UInt32] = true,
+    [BuiltinKind.UInt64] = true,
+    [BuiltinKind.Float32] = false,
+    [BuiltinKind.Float64] = false,
+    [BuiltinKind.ISize] = false,
+    [BuiltinKind.USize] = true,
+    [BuiltinKind.Bool] = false,
 }
 
 fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, i32 stars, char c) {
     FormatAnalyser* fa = context;
     Analyser* ma = fa.ma;
     Expr** args = fa.args;
+
+    fa.out.add2(fa.format + fa.last_offset, offset - fa.last_offset);
 
     if (c == '\0') {
         ma.error(fa.loc + offset, "missing conversion specifier at end of format string");
@@ -313,7 +352,6 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         }
         break;
     case Integer:
-        fa.change_format = true;
         if (qt.isEnum()) {
             EnumType* et = qt.getEnumType();
             qt = et.getImplType();
@@ -321,10 +359,15 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         BuiltinType* bi = qt.getBuiltinTypeOrNil();
         if (!bi || !bi.isIntegerOrBool()) {
             ma.error(arg.getStartLoc(), "format '%%%c' expects an integer argument", c);
+            break;
         }
+        BuiltinKind kind = bi.getKind();
+        // TODO add ll prefix on LLP targets (64-bit long long and pointers, but 32-bit long)
+        if (Format_needs_l_prefix[kind]) fa.out.add1('l');
+        if (c == 'd' && Format_needs_u_prefix[kind]) c = 'u';
+        // Assume all supported formats are implemented in the target libc
         break;
     case FloatingPoint:
-        fa.change_format = true;
         BuiltinType* bi = qt.getBuiltinTypeOrNil();
         if (!bi || !bi.isFloatingPoint()) {
             ma.error(arg.getStartLoc(), "format '%%%c' expects a floating-point argument", c);
@@ -356,39 +399,47 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         }
         return false;
     }
+    fa.out.add1(c);
 
+    fa.last_offset = offset + 1;
     fa.idx++;
     return true;
 }
 
-fn void Analyser.checkPrintArgs(Analyser* ma, Expr* format, u32 num_args, Expr** args, bool* change_format) {
-    // if format is StringLiteral or vardecl of type char[], it will wrapped in ArrayToPointerDecay
-    // otherwise it's a VarDecl of type (const) char* we cannot check and report this as an error
-    if (!format.isImplicitCast()) goto not_constant;
-    ImplicitCastExpr* ic = (ImplicitCastExpr*)format;
-    if (!ic.isArrayToPointerDecay()) goto not_constant;
-    format = ic.getInner();
-
-    SrcLoc format_loc;
+fn bool Analyser.checkPrintfArgs(Analyser* ma, Expr** format_ptr, u32 num_args, Expr** args) {
+    Expr* format = *format_ptr;
+    SrcLoc format_loc = format.getLoc();
     const char* format_text = printf_utils.get_format(format, &format_loc);
-    if (!format_text) goto not_constant;
+    if (!format_text) {
+        ma.error(format_loc, "format argument is not a constant string");
+        return false;
+    }
 
-    FormatAnalyser fa = { ma, format_text, num_args, 0, format_loc, false, args }
+    string_buffer.Buf* out = string_buffer.create(256, false, 0);
+    FormatAnalyser fa = { ma, format_text, args, num_args, 0, format_loc, 0, out }
+
     if (!printf_utils.parseFormat(format_text, on_format_specifier, &fa)) {
         // error already reported
-        return;
+        out.free();
+        return false;
     }
-    *change_format = fa.change_format;
+    out.add(format_text + fa.last_offset);
 
     if (fa.idx < num_args) {
         ma.error(args[fa.idx].getLoc(), "too many arguments for format");
-        return;
+        out.free();
+        return false;
     }
-    return;
-
-not_constant:
-    ma.error(format.getLoc(), "format argument is not a constant string");
-    return;
+    const char* new_format_text = out.data();
+    if (string.strcmp(format_text, new_format_text)) {
+        u32 len = out.size();
+        Expr* new_format = ma.builder.actOnStringLiteral(0, len, ma.astPool.add(new_format_text, len, true), len);
+        QualType qt = getPointerFromArray(ma.builder, new_format.getType());
+        ma.builder.insertImplicitCast(ArrayToPointerDecay, &new_format, qt);
+        *format_ptr = ma.builder.actOnAlternate(*format_ptr, new_format);
+    }
+    out.free();
+    return true;
 }
 
 fn void create_template_name(char* name, const char* orig, u16 idx) {

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -111,6 +111,19 @@ fn QualType Analyser.analyseExprInner(Analyser* ma, Expr** e_ptr, u32 side) {
         e.copyConstantFlags(inner);
         e.copyValType(inner);
         return qt;
+    case Alternate:
+#if 0
+        AlternateExpr* p = (AlternateExpr*)e;
+        QualType qt = ma.analyseExpr(p.getOriginal2(), false, side);
+        ma.analyseExpr(p.getGenerated2(), false, side);
+        Expr* original = p.getOriginal();
+        e.copyConstantFlags(original);
+        e.copyValType(original);
+        return qt;
+#else
+        // Alternate nodes are only created by the analyser
+        break;
+#endif
     }
     return QualType_Invalid;
 }

--- a/analyser/module_analyser_unaryop.c2
+++ b/analyser/module_analyser_unaryop.c2
@@ -268,6 +268,9 @@ fn IdentifierKind getInnerExprAddressOf(const Expr* e) {
     case NamedArgument:
         NamedArgument* n = (NamedArgument*)e;
         return getInnerExprAddressOf(n.getInner());
+    case Alternate:
+        AlternateExpr* n = (AlternateExpr*)e;
+        return getInnerExprAddressOf(n.getOriginal());
     }
 
     return IdentifierKind.Unresolved;

--- a/analyser/printf_utils.c2
+++ b/analyser/printf_utils.c2
@@ -20,50 +20,58 @@ import ctype;
 import src_loc local;
 
 public fn const char* get_format(Expr* format, SrcLoc* format_loc) {
-    const char* format_text = nil;
-    switch (format.getKind()) {
-    case StringLiteral:
-        StringLiteral* s = (StringLiteral*)format;
-        format_text = s.getText();
-        // set location to first character of string literal
-        // this works for simple strings only: multi-strings, raw strings,
-        // strings with escape sequences may show an incorrect position for
-        // format specifier errors.
-        *format_loc = format.getLoc() + 1;
-        break;
-    case Identifier:
-        QualType qt = format.getType();
-        assert(qt.isArray());
-        ArrayType* at = qt.getArrayType();
-        qt = at.getElemType();
-        if (!qt.isConst()) return nil;
+    // if format is StringLiteral or vardecl of type char[], it will wrapped in ArrayToPointerDecay
+    // otherwise it's a VarDecl of type (const) char* we cannot check and report this as an error
 
-        IdentifierExpr* id = (IdentifierExpr*)format;
-        Decl* decl = id.getDecl();
-        assert(decl.isVariable());
-        VarDecl* vd = (VarDecl*)decl;
-        Expr* initExpr = vd.getInit();
-        assert(initExpr);
-        return get_format(initExpr, format_loc);
-    case Member:
-        QualType qt = format.getType();
-        assert(qt.isArray());
-        ArrayType* at = qt.getArrayType();
-        qt = at.getElemType();
-        if (!qt.isConst()) return nil;
+    if (!format.isImplicitCast()) return nil;
+    ImplicitCastExpr* ic = (ImplicitCastExpr*)format;
+    if (!ic.isArrayToPointerDecay()) return nil;
+    format = ic.getInner();
+    *format_loc = format.getLoc();
 
-        MemberExpr* m = (MemberExpr*)format;
-        Decl* decl = m.getFullDecl();
-        assert (decl.isVariable());
-        VarDecl* vd = (VarDecl*)decl;
-        Expr* initExpr = vd.getInit();
-        assert(initExpr);
-        return get_format(initExpr, format_loc);
-    default:
-        assert(0);
-        break;
+    for (;;) {
+        switch (format.getKind()) {
+        case StringLiteral:
+            // set location to first character of string literal
+            // this works for simple strings only: multi-strings, raw strings,
+            // strings with escape sequences may show an incorrect position for
+            // format specifier errors.
+            *format_loc = format.getLoc() + 1;
+            StringLiteral* s = (StringLiteral*)format;
+            return s.getText();
+        case Identifier:
+            QualType qt = format.getType();
+            assert(qt.isArray());
+            ArrayType* at = qt.getArrayType();
+            qt = at.getElemType();
+            if (!qt.isConst()) return nil;
+
+            IdentifierExpr* id = (IdentifierExpr*)format;
+            Decl* decl = id.getDecl();
+            assert(decl.isVariable());
+            VarDecl* vd = (VarDecl*)decl;
+            format = vd.getInit();
+            assert(format);
+            continue;
+        case Member:
+            QualType qt = format.getType();
+            assert(qt.isArray());
+            ArrayType* at = qt.getArrayType();
+            qt = at.getElemType();
+            if (!qt.isConst()) return nil;
+
+            MemberExpr* m = (MemberExpr*)format;
+            Decl* decl = m.getFullDecl();
+            assert (decl.isVariable());
+            VarDecl* vd = (VarDecl*)decl;
+            format = vd.getInit();
+            assert(format);
+            continue;
+        default:
+            assert(0);
+            return nil;
+        }
     }
-    return format_text;
 }
 
 public type Specifier enum u8 {

--- a/ast/alternate_expr.c2
+++ b/ast/alternate_expr.c2
@@ -1,0 +1,74 @@
+/* Copyright 2022-2025 Bas van den Berg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+import ast_context;
+import string_buffer;
+import src_loc local;
+
+public type AlternateExpr struct @(opaque) {
+    Expr base;
+    Expr* original;
+    Expr* generated;
+}
+
+public fn AlternateExpr* AlternateExpr.create(ast_context.Context* c, Expr* original, Expr* generated) @(unused) {
+    AlternateExpr* e = c.alloc(sizeof(AlternateExpr));
+    e.base.init(ExprKind.Alternate, original.getLoc(), 0, 0, 0, ValType.NValue);
+    e.original = original;
+    e.generated = generated;
+    e.base.setType(original.getType());
+#if AstStatistics
+    Stats.addExpr(ExprKind.Alternate, sizeof(AlternateExpr));
+#endif
+    return e;
+}
+
+fn Expr* AlternateExpr.instantiate(AlternateExpr* e, Instantiator* inst) {
+    return (Expr*)AlternateExpr.create(inst.c, e.original.instantiate(inst), e.generated.instantiate(inst));
+}
+
+public fn Expr* AlternateExpr.getOriginal(const AlternateExpr* e) { return e.original; }
+
+//public fn Expr** AlternateExpr.getOriginal2(AlternateExpr* e) { return &e.original; }
+
+public fn Expr* AlternateExpr.getGenerated(const AlternateExpr* e) { return e.generated; }
+
+//public fn Expr** AlternateExpr.getGenerated2(AlternateExpr* e) { return &e.generated; }
+
+fn void AlternateExpr.print(const AlternateExpr* e, string_buffer.Buf* out, u32 indent) {
+    e.base.printKind(out, indent);
+    e.base.printTypeBits(out);
+    out.newline();
+
+    e.original.print(out, indent + 1);
+    e.generated.print(out, indent + 1);
+}
+
+fn SrcLoc AlternateExpr.getStartLoc(const AlternateExpr* e) {
+    return e.original.getStartLoc();
+}
+
+fn SrcLoc AlternateExpr.getEndLoc(const AlternateExpr* e) {
+    return e.original.getEndLoc();
+}
+
+fn void AlternateExpr.printLiteral(const AlternateExpr* e, string_buffer.Buf* out) {
+    out.lparen();
+    e.original.printLiteral(out);
+    out.rparen();
+}
+

--- a/ast/ast_evaluator.c2
+++ b/ast/ast_evaluator.c2
@@ -118,6 +118,9 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
     case NamedArgument:
         const NamedArgument* n = (NamedArgument*)e;
         return eval.get_value(n.getInner());
+    case Alternate:
+        const AlternateExpr* n = (AlternateExpr*)e;
+        return eval.get_value(n.getOriginal());
     }
     return Value.error("expression is not constant");
 }

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -90,10 +90,6 @@ const bool[] BuiltinType_signed = {
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_signed));
 
-public fn bool builtinKind2Signed(BuiltinKind kind) {
-    return BuiltinType_signed[kind];
-}
-
 const bool[] BuiltinType_unsigned = {
     [BuiltinKind.Char] = true,
     [BuiltinKind.Int8] = false,

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -26,7 +26,6 @@ type CallExprBits struct {
     u32 calls_static_sf : 1;
     u32 is_template_call : 1;
     u32 printf_format : 4;  // 1-based, 0 means no printf-format
-    u32 change_format : 1;   // if c-generator needs to re-write format
     u32 has_auto_args : 1;   // if c-generator needs to insert extra arguments (file, line)
     u32 is_noreturn : 1;
     u32 num_args : 8;
@@ -156,22 +155,17 @@ public fn bool CallExpr.isNoreturn(const CallExpr* e) {
     return e.base.base.callExprBits.is_noreturn;
 }
 
-// note: both idx are 0-based
-public fn void CallExpr.setPrintfFormat(CallExpr* e, u32 format_idx, bool change_format) {
+// note: format_idx is 0-based
+public fn void CallExpr.setPrintfFormat(CallExpr* e, u32 format_idx) {
     e.base.base.callExprBits.printf_format = format_idx + 1;
-    e.base.base.callExprBits.change_format = change_format;
 }
 
 fn bool CallExpr.isPrintfCall(const CallExpr* e) {
     return e.base.base.callExprBits.printf_format != 0;
 }
 
-public fn u32 CallExpr.getPrintfFormat(const CallExpr* e) {
+fn u32 CallExpr.getPrintfFormat(const CallExpr* e) {
     return e.base.base.callExprBits.printf_format - 1;
-}
-
-public fn bool CallExpr.needFormatChange(const CallExpr* e) {
-    return e.base.base.callExprBits.change_format;
 }
 
 public fn void CallExpr.setHasAutoArgs(CallExpr* e) {
@@ -218,7 +212,7 @@ fn void CallExpr.print(const CallExpr* e, string_buffer.Buf* out, u32 indent) {
     if (e.base.base.callExprBits.calls_static_sf) out.add(" STF");
     if (e.base.base.callExprBits.is_noreturn) out.add(" noreturn");
     if (e.isPrintfCall()) {
-        out.print(" printf=%d|%d", e.getPrintfFormat(), e.needFormatChange());
+        out.print(" printf=%d", e.getPrintfFormat());
     }
     if (e.hasAutoArgs()) out.add(" auto-args");
     out.newline();

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -43,6 +43,7 @@ public type ExprKind enum u8 {
     ImplicitCast,
     Range,
     NamedArgument,
+    Alternate,
 }
 
 const char*[] exprKind_names = {
@@ -70,6 +71,7 @@ const char*[] exprKind_names = {
     "ImplicitCast",
     "RangeExpr",
     "NamedArgument",
+    "Alternate",
 }
 static_assert(elemsof(ExprKind), elemsof(exprKind_names));
 
@@ -185,6 +187,8 @@ fn Expr* Expr.instantiate(Expr* e, Instantiator* inst) {
         return RangeExpr.instantiate((RangeExpr*)e, inst);
     case NamedArgument:
         return NamedArgument.instantiate((NamedArgument*)e, inst);
+    case Alternate:
+        return AlternateExpr.instantiate((AlternateExpr*)e, inst);
     }
     e.dump();
     assert(0);
@@ -391,6 +395,8 @@ public fn SrcLoc Expr.getStartLoc(const Expr* e) {
         return ((RangeExpr*)e).getStartLoc();
     case NamedArgument:
         return ((NamedArgument*)e).getStartLoc();
+    case Alternate:
+        return ((AlternateExpr*)e).getStartLoc();
     }
     return e.base.loc;
 }
@@ -445,6 +451,8 @@ public fn SrcLoc Expr.getEndLoc(const Expr* e) {
         return ((RangeExpr*)e).getEndLoc();
     case NamedArgument:
         return ((NamedArgument*)e).getEndLoc();
+    case Alternate:
+        return ((AlternateExpr*)e).getEndLoc();
     }
     return e.base.loc;
 }
@@ -494,6 +502,9 @@ public fn bool Expr.needsSemi(const Expr* e) {
     case NamedArgument:
         const NamedArgument* n = (NamedArgument*)e;
         return n.getInner().needsSemi();
+    case Alternate:
+        const AlternateExpr* n = (AlternateExpr*)e;
+        return n.getOriginal().needsSemi();
     }
     return true;
 }
@@ -578,6 +589,9 @@ fn void Expr.print(const Expr* e, string_buffer.Buf* out, u32 indent) {
     case NamedArgument:
         NamedArgument.print((NamedArgument*)e, out, indent);
         break;
+    case Alternate:
+        AlternateExpr.print((AlternateExpr*)e, out, indent);
+        break;
     }
 }
 
@@ -655,7 +669,10 @@ public fn void Expr.printLiteral(const Expr* e, string_buffer.Buf* out) {
         return;
     case NamedArgument:
         NamedArgument.printLiteral((NamedArgument*)e, out);
-        break;
+        return;
+    case Alternate:
+        AlternateExpr.printLiteral((AlternateExpr*)e, out);
+        return;
     }
     out.print("<<kind=%d>>", e.getKind());
 }

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -1093,3 +1093,7 @@ public fn Expr* Builder.actOnNamedArgument(Builder* b, SrcLoc loc, u32 name, Exp
     return (Expr*)NamedArgument.create(b.context, loc, name, inner);
 }
 
+public fn Expr* Builder.actOnAlternate(Builder* b, Expr* original, Expr* generated) {
+    return (Expr*)AlternateExpr.create(b.context, original, generated);
+}
+

--- a/generator/ast_visitor_expr.c2
+++ b/generator/ast_visitor_expr.c2
@@ -22,15 +22,10 @@ fn void Visitor.handleExpr(Visitor* v, Expr* e) {
 
     switch (e.getKind()) {
     case IntegerLiteral:
-        return;
     case FloatLiteral:
-        return;
     case BooleanLiteral:
-        return;
     case CharLiteral:
-        return;
     case StringLiteral:
-        return;
     case Nil:
         return;
     case Identifier:
@@ -118,6 +113,10 @@ fn void Visitor.handleExpr(Visitor* v, Expr* e) {
     case NamedArgument:
         NamedArgument* n = (NamedArgument*)e;
         v.handleExpr(n.getInner());
+        break;
+    case Alternate:
+        AlternateExpr* n = (AlternateExpr*)e;
+        v.handleExpr(n.getOriginal());
         break;
     }
 }

--- a/generator/c/c_generator_call.c2
+++ b/generator/c/c_generator_call.c2
@@ -16,11 +16,8 @@
 module c_generator;
 
 import ast local;
-import printf_utils;
 import source_mgr;
-import src_loc local;
 import string_buffer;
-import string;
 
 fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
     CallExpr* call = (CallExpr*)e;
@@ -116,7 +113,6 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
     FunctionDecl* fd = get_function(dest);
     u32 func_num_args = fd.getNumParams();
     VarDecl** func_args = fd.getParams();
-    u32 format_idx = call.needFormatChange() ? call.getPrintfFormat() : 1000;
 
     u32 call_index = 0;
     u32 func_index = 0;
@@ -145,46 +141,28 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
                 continue;
             }
 
-            if (call_index == format_idx) {
-                SrcLoc format_loc;
-                Expr* format = args[call_index++];
-                assert(format.isImplicitCast());
-                ImplicitCastExpr* ic = (ImplicitCastExpr*)format;
-                if (!ic.isArrayToPointerDecay()) return;
-                format = ic.getInner();
-                const char* format_text = printf_utils.get_format(format, &format_loc);
-                assert(format_text);
+            Expr* arg;
+            Decl* d = vd.asDecl();
 
-                FormatChanger fc = { format_text, &args[call_index], 0, 0, out }
-                out.add1('"');
-                printf_utils.parseFormat(format_text, on_format_specifier, &fc);
-                out.encodeBytes(format_text + fc.last_offset,
-                                (u32)(string.strlen(format_text + fc.last_offset)), '"');
-                out.add1('"');
-            } else {
-                Expr* arg;
-                Decl* d = vd.asDecl();
-
-                if (call_index < call_num_args) {
-                    arg = args[call_index++];
-                    if (arg.isNamedArgument()) {
-                        NamedArgument* n = (NamedArgument*)arg;
-                        u32 arg_name_idx = n.getNameIdx();
-                        if (d.getNameIdx() == arg_name_idx) {
-                            arg = n.getInner();
-                        } else {
-                            call_index--;
-                            arg = vd.getInit();
-                        }
+            if (call_index < call_num_args) {
+                arg = args[call_index++];
+                if (arg.isNamedArgument()) {
+                    NamedArgument* n = (NamedArgument*)arg;
+                    u32 arg_name_idx = n.getNameIdx();
+                    if (d.getNameIdx() == arg_name_idx) {
+                        arg = n.getInner();
+                    } else {
+                        call_index--;
+                        arg = vd.getInit();
                     }
-                } else {
-                    arg = vd.getInit();
                 }
-                if (arg.isInitList()) {
-                    gen.emitCast(out, d.getType(), true);
-                }
-                gen.emitExpr(out, arg);
+            } else {
+                arg = vd.getInit();
             }
+            if (arg.isInitList()) {
+                gen.emitCast(out, d.getType(), true);
+            }
+            gen.emitExpr(out, arg);
             needs_comma = true;
             func_index++;
         } else {

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -17,7 +17,6 @@ module c_generator;
 
 import ast local;
 import c_prec local;
-import printf_utils;
 import string_buffer;
 
 fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
@@ -177,6 +176,10 @@ fn void Generator.emitExpr2(Generator* gen, string_buffer.Buf* out, Expr* e, C_P
     case NamedArgument:
         NamedArgument* n = (NamedArgument*)e;
         gen.emitExpr(out, n.getInner());
+        break;
+    case Alternate:
+        const AlternateExpr* n = (AlternateExpr*)e;
+        gen.emitExpr(out, n.getGenerated());
         break;
     }
 }
@@ -388,84 +391,6 @@ fn void Generator.emitArrayDesigExpr(Generator* gen, string_buffer.Buf* out, Exp
     gen.emitExpr(out, ad.getDesignator());
     out.add("] = ");
     gen.emitExpr(out, ad.getInit());
-}
-
-type FormatChanger struct {
-    const char* format;
-    Expr** args;
-    u32 idx;
-    u32 last_offset;
-    string_buffer.Buf* out;
-}
-
-const bool[] Size_prefix = {
-    [BuiltinKind.Char] = false,
-    [BuiltinKind.Int8] = false,
-    [BuiltinKind.Int16] = false,
-    [BuiltinKind.Int32] = false,
-    [BuiltinKind.Int64] = true,
-    [BuiltinKind.UInt8] = false,
-    [BuiltinKind.UInt16] = false,
-    [BuiltinKind.UInt32] = false,
-    [BuiltinKind.UInt64] = true,
-    [BuiltinKind.Float32] = false,
-    [BuiltinKind.Float64] = true,
-    [BuiltinKind.ISize] = true,
-    [BuiltinKind.USize] = true,
-    [BuiltinKind.Bool] = false,
-}
-
-fn void emitNumberFormat(BuiltinKind kind, char letter, string_buffer.Buf* out) {
-    // TODO: use proper prefix depending on target
-#if 0
-    if (kind == BuiltinKind.ISize) {
-        return;
-    }
-    if (kind == BuiltinKind.USize) {
-        return;
-    }
-#endif
-    if (Size_prefix[kind]) out.add1('l');
-    if (letter == 'd' && !builtinKind2Signed(kind))
-        letter = 'u';
-    // Assume all supported formats are implemented in the target libc
-    out.add1(letter);
-}
-
-// TODO: move to generator/c_generator_call.c2
-fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, i32 stars, char c) {
-    FormatChanger* fc = context;
-
-    /* copy optional flags, width and precision */
-    fc.out.encodeBytes(fc.format + fc.last_offset, offset - fc.last_offset, '"');
-
-    fc.idx += stars;
-    QualType qt = fc.args[fc.idx].getType();
-    qt = qt.getCanonicalType();
-    switch (specifier) {
-    case Integer:
-        if (qt.isEnum()) {
-            EnumType* et = qt.getEnumType();
-            qt = et.getImplType();
-        }
-        fallthrough;
-    case FloatingPoint:
-        BuiltinType* bt = qt.getBuiltinTypeOrNil();
-        if (!bt) {
-            fc.args[fc.idx].dump();
-        }
-        assert(bt);
-        emitNumberFormat(bt.getKind(), c, fc.out);
-        break;
-    default:
-        fc.out.add1(c);
-        // no need to change
-        break;
-    }
-
-    fc.last_offset = offset + 1;
-    fc.idx++;
-    return true;
 }
 
 fn void Generator.emitBuiltinExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {

--- a/generator/c/dep_finder.c2
+++ b/generator/c/dep_finder.c2
@@ -145,15 +145,10 @@ fn void Finder.handleVarDecl(Finder* s, VarDecl* d) {
 fn void Finder.handleExpr(Finder* s, Expr* e) {
     switch (e.getKind()) {
     case IntegerLiteral:
-        break;
     case FloatLiteral:
-        break;
     case BooleanLiteral:
-        break;
     case CharLiteral:
-        break;
     case StringLiteral:
-        break;
     case Nil:
         break;
     case Identifier:
@@ -229,6 +224,11 @@ fn void Finder.handleExpr(Finder* s, Expr* e) {
     case NamedArgument:
         NamedArgument* n = (NamedArgument*)e;
         s.handleExpr(n.getInner());
+        break;
+    case Alternate:
+        AlternateExpr* n = (AlternateExpr*)e;
+        s.handleExpr(n.getOriginal());
+        //s.handleExpr(n.getGenerated());
         break;
     }
 }

--- a/generator/c2i/c2i_generator_expr.c2
+++ b/generator/c2i/c2i_generator_expr.c2
@@ -150,6 +150,10 @@ fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, const Expr* e
     case NamedArgument:
         NamedArgument.printLiteral((NamedArgument*)e, out);
         break;
+    case Alternate:
+        const AlternateExpr* n = (AlternateExpr*)e;
+        gen.emitExpr(out, n.getOriginal());
+        break;
     }
 }
 

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -357,6 +357,10 @@ fn void Generator.emitInit(Generator* gen, const Expr* e, u32 size) {
         NamedArgument* n = (NamedArgument*)e;
         gen.emitInit(n.getInner(), size);
         break;
+    case Alternate:
+        AlternateExpr* n = (AlternateExpr*)e;
+        gen.emitInit(n.getGenerated(), size);
+        break;
     }
 }
 

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -128,6 +128,10 @@ fn void Generator.emitExpr(Generator* gen, ir.Ref* result, const Expr* e) {
         NamedArgument* n = (NamedArgument*)e;
         gen.emitExpr(result, n.getInner());
         break;
+    case Alternate:
+        AlternateExpr* n = (AlternateExpr*)e;
+        gen.emitExpr(result, n.getGenerated());
+        break;
     }
 }
 
@@ -374,6 +378,10 @@ fn void Generator.emitCond(Generator* gen, const Expr* e, BlockId true_blk, Bloc
     case NamedArgument:
         NamedArgument* n = (NamedArgument*)e;
         gen.emitCond(n.getInner(), true_blk, false_blk, start_blk);
+        break;
+    case Alternate:
+        AlternateExpr* n = (AlternateExpr*)e;
+        gen.emitCond(n.getGenerated(), true_blk, false_blk, start_blk);
         break;
     }
     gen.emitExpr(&ref, e);

--- a/recipe.txt
+++ b/recipe.txt
@@ -72,6 +72,7 @@ set ast
 
     # ast expressions
     ast/expr.c2
+    ast/alternate_expr.c2
     ast/array_designated_init_expr.c2
     ast/array_subscript_expr.c2
     ast/binary_operator.c2
@@ -232,12 +233,11 @@ executable c2c
     analyser/struct_field_init_checker.c2
     analyser/name_vector.c2
     analyser/label_vector.c2
+    analyser/printf_utils.c2
     analyser/scope.c2
     analyser/size_analyser.c2
     analyser/struct_func_list.c2
     analyser/unused_checker.c2
-
-    analyser_utils/printf_utils.c2
 
     compiler/c2recipe.c2
     compiler/c2recipe_parser.c2

--- a/test/expr/assign_enum.c2t
+++ b/test/expr/assign_enum.c2t
@@ -27,7 +27,7 @@ int32_t main(void)
 {
     test_State s1 = test_State_ON;
     if (s1 > test_State_OFF && s1 >= test_State_ON && s1 <= test_State_ON && s1 < test_State_OTHER && s1 == test_State_ON && s1 != test_State_OFF) s1 = test_State_OFF;
-    printf("State s0 is %u\n", test_s0);
-    printf("State s1 is %u\n", s1);
+    printf("State s0 is %d\n", test_s0);
+    printf("State s1 is %d\n", s1);
     return 0;
 }

--- a/test/functions/named_arg.c2t
+++ b/test/functions/named_arg.c2t
@@ -90,10 +90,10 @@ static void test_foo3(const char* s)
 
 static void test_test1(const char* s)
 {
-   printf("check_case(\"%s\", true) -> %u\n", s, test_check_case(s, true));
-   printf("check_case(\"%s\", false) -> %u\n", s, test_check_case(s, false));
-   printf("check_case(\"%s\", is_upper: true) -> %u\n", s, test_check_case(s, true));
-   printf("check_case(\"%s\", is_upper: false) -> %u\n", s, test_check_case(s, false));
+   printf("check_case(\"%s\", true) -> %d\n", s, test_check_case(s, true));
+   printf("check_case(\"%s\", false) -> %d\n", s, test_check_case(s, false));
+   printf("check_case(\"%s\", is_upper: true) -> %d\n", s, test_check_case(s, true));
+   printf("check_case(\"%s\", is_upper: false) -> %d\n", s, test_check_case(s, false));
 }
 
 int32_t main(int32_t argc, char** argv)


### PR DESCRIPTION
* add `AlternateExpr` nodes
* compute modified format string in analyser and store via `Alternate` node
* move analyser_utils/printf_utils.c2 to analyser/printf_utils.c2
* remove unused code
* fix floating point formats: `%lf` is not required for `printf`