### PR TITLE
Compiler: make void a separate typekind

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -38,24 +38,27 @@ import src_loc local;
 // 14 = Enum -> Enum
 // 15 = Builtin -> Func
 // 16 = Func -> Builtin
+// 17 = Anything -> Void
 const u8[elemsof(TypeKind)][elemsof(TypeKind)] Conversions = {
-    //  Builtin Pointer Array   Struct  Enum    Func   Alias    Module
+    //  Builtin Pointer Array   Struct  Enum    Func   Void     Alias    Module
     //  Builtin ->
-    {   2,      3,      1,      1,     13,     15,      0,      0   },
+    {   2,      3,      1,      1,     13,     15,     17,     0,      0   },
     //  Pointer ->
-    {   4,      5,      1,      1,      1,      6,      0,      0   },
+    {   4,      5,      1,      1,      1,      6,     17,     0,      0   },
     //  Array ->
-    {   1,      7,      8,      1,      1,      1,      0,      0   },
+    {   1,      7,      8,      1,      1,      1,     17,     0,      0   },
     //  Struct ->
-    {   1,      1,      1,      9,      1,      1,      0,      0   },
+    {   1,      1,      1,      9,      1,      1,     17,     0,      0   },
     //  Enum ->
-    {   10,     1,      1,      1,     14,      1,      0,      0   },
+    {   10,     1,      1,      1,     14,      1,     17,     0,      0   },
     //  Function ->
-    {   16,     11,     1,      1,      1,      12,     0,      0   },
+    {   16,     11,     1,      1,      1,      12,    17,     0,      0   },
+    //  Void += / -=
+    {   1,      1,      1,      1,      1,      1,     17,     0,      0   },
     //  Alias ->
-    {   0,      0,      0,      0,      0,      0,      0,      0   },
+    {   0,      0,      0,      0,      0,      0,      0,     0,      0   },
     //  Module ->
-    {   0,      0,      0,      0,      0,      0,      0,      0   },
+    {   0,      0,      0,      0,      0,      0,      0,     0,      0   },
 }
 
 //  0 = should not happen? (same)
@@ -68,38 +71,36 @@ const u8[elemsof(TypeKind)][elemsof(TypeKind)] Conversions = {
 //  7 = ok, no conversion needed (eg. char -> u8, isize -> i64, i32 -> bool)
 // No need to adjust for 32-bit as ISize and USize are converted before the lookup
 const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] BuiltinConversions = {
-    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32  Flt64  ISize  USize  Bool  Void
-    //  1      2      3      4      5      6      7      8      9      10     11     12     13     14    15
+    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32  Flt64  ISize  USize  Bool
+    //  1      2      3      4      5      6      7      8      9      10     11     12     13     14
     // Char ->
-    {   0,     3,     1,     1,     1,     7,     1,     1,     1,     1,     1,     1,     1,     7,    2  },
+    {   0,     3,     1,     1,     1,     7,     1,     1,     1,     1,     1,     1,     1,     7  },
     // Int8 ->
-    {   3,     0,     1,     1,     1,     3,     3,     3,     3,     1,     1,     1,     3,     7,    2  },
+    {   3,     0,     1,     1,     1,     3,     3,     3,     3,     1,     1,     1,     3,     7  },
     // Int16 ->
-    {   4,     4,     0,     1,     1,     4,     3,     3,     3,     1,     1,     1,     3,     7,    2  },
+    {   4,     4,     0,     1,     1,     4,     3,     3,     3,     1,     1,     1,     3,     7  },
     // Int32 ->
-    {   4,     4,     4,     7,     1,     4,     4,     3,     3,     1,     1,     1,     3,     7,    2  },
+    {   4,     4,     4,     7,     1,     4,     4,     3,     3,     1,     1,     1,     3,     7  },
     // Int64 ->
-    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     7,     3,     7,    2  },
+    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     7,     3,     7  },
     // UInt8 ->
-    {   1,     3,     1,     1,     1,     0,     1,     1,     1,     1,     1,     3,     1,     7,    2  },
+    {   1,     3,     1,     1,     1,     0,     1,     1,     1,     1,     1,     3,     1,     7  },
     // UInt16 ->
-    {   4,     4,     3,     1,     1,     4,     0,     1,     1,     1,     1,     3,     1,     7,    2  },
+    {   4,     4,     3,     1,     1,     4,     0,     1,     1,     1,     1,     3,     1,     7  },
     // UInt32 ->
-    {   4,     4,     4,     3,     1,     4,     4,     7,     1,     1,     1,     3,     1,     7,    2  },
+    {   4,     4,     4,     3,     1,     4,     4,     7,     1,     1,     1,     3,     1,     7  },
     // UInt64 ->
-    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     7,     7,    2  },
+    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     7,     7  },
     // Flt32 ->
-    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     0,     1,     5,     5,     2,    2  },
+    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     0,     1,     5,     5,     2  },
     // Flt64 ->
-    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     6,     0,     5,     5,     2,    2  },
+    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     6,     0,     5,     5,     2  },
     // ISize ->
-    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     0,     3,     7,    2  },
+    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     0,     3,     7  },
     // USize ->
-    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     0,     7,    2  },
+    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     0,     7  },
     // Bool ->
-    {   1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     0,    2  },
-    // Void ->
-    {   2,     2,     2,     2,     2,     2,     2,     2,     2,     2,     2,     2,     2,     2,    0  },
+    {   1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     0  },
 }
 
 public type Checker struct {
@@ -210,6 +211,8 @@ fn bool Checker.checkTypes(Checker* c, const Type* lcanon, const Type* rcanon) {
         return c.conversionError("invalid type conversion from");
     case 16: // Function -> Builtin
         return c.checkFunc2Builtin(lcanon, rcanon, false);
+    case 17: // Anything -> Void
+        return true;
     default:
         c.diags.note(c.loc, "TODO CONVERSION  %d)", res);
         return false;
@@ -622,38 +625,36 @@ fn bool Checker.checkPointer2BuiltinCast(Checker* c, const Type* lcanon, const T
 // Just takes smallest type, dont promote both sides to i32
 // No need to adjust for 32-bit as ISize and USize are converted before the lookup
 const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] ConditionalOperatorResult = {
-    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool  Void
-    //  0      1      2      3      4      5      6      7      8      9     10     11     12     13     14
+    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool
+    //  0      1      2      3      4      5      6      7      8      9     10     11     12     13
     // Char ->
-    {   0,     2,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     0,    14  },
+    {   0,     2,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     0  },
     // Int8 ->
-    {   2,     1,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     1,    14  },
+    {   2,     1,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     1  },
     // Int16 ->
-    {   2,     2,     2,     3,     4,     2,     6,     7,     8,     9,    10,    11,    12,     2,    14  },
+    {   2,     2,     2,     3,     4,     2,     6,     7,     8,     9,    10,    11,    12,     2  },
     // Int32 ->
-    {   3,     3,     3,     3,     4,     3,     3,     7,     8,     9,    10,    11,    12,     3,    14  },
+    {   3,     3,     3,     3,     4,     3,     3,     7,     8,     9,    10,    11,    12,     3  },
     // Int64 ->
-    {   4,     4,     4,     4,     4,     4,     4,     4,     8,     9,    10,    11,    12,     4,    14  },
+    {   4,     4,     4,     4,     4,     4,     4,     4,     8,     9,    10,    11,    12,     4  },
     // UInt8 ->
-    {   5,     5,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     5,    14  },
+    {   5,     5,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     5  },
     // UInt16 ->
-    {   6,     6,     6,     3,     4,     6,     6,     7,     8,     9,    10,    11,    12,     6,    14  },
+    {   6,     6,     6,     3,     4,     6,     6,     7,     8,     9,    10,    11,    12,     6  },
     // UInt32 ->
-    {   7,     7,     7,     7,     7,     7,     7,     7,     8,     9,    10,    11,    12,     7,    14  },
+    {   7,     7,     7,     7,     7,     7,     7,     7,     8,     9,    10,    11,    12,     7  },
     // UInt64 ->
-    {   8,     8,     8,     8,     8,     8,     8,     8,     8,     9,    10,    11,    12,     8,    14  },
+    {   8,     8,     8,     8,     8,     8,     8,     8,     8,     9,    10,    11,    12,     8  },
     // Flt32 ->
-    {   9,     9,     9,     9,     9,     9,     9,     9,     9,     9,    10,     9,     9,     9,    14  },
+    {   9,     9,     9,     9,     9,     9,     9,     9,     9,     9,    10,     9,     9,     9  },
     // Flt64 ->
-    {  10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    14  },
+    {  10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10  },
     // ISize ->
-    {  11,    11,    11,    11,    11,    11,    11,    11,     8,     9,    10,    11,    12,    11,    14  },
+    {  11,    11,    11,    11,    11,    11,    11,    11,     8,     9,    10,    11,    12,    11  },
     // USize ->
-    {  12,    12,    12,    12,    12,    12,    12,    12,     8,     9,    10,    12,    12,    12,    14  },
+    {  12,    12,    12,    12,    12,    12,    12,    12,     8,     9,    10,    12,    12,    12  },
     // Bool ->
-    {   0,     1,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,    13,    14  },
-    // Void ->
-    {  14,    14,    14,    14,    14,    14,    14,    14,    14,    14,    14,    14,    14,    14,    14  },
+    {   0,     1,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,    13  },
 }
 public fn QualType get_common_arithmetic_type(BuiltinType* bi1, BuiltinType* bi2) {
     BuiltinKind kind = (BuiltinKind)ConditionalOperatorResult[bi2.getBaseKind()][bi1.getBaseKind()];
@@ -673,38 +674,36 @@ public fn QualType get_common_arithmetic_type(BuiltinType* bi1, BuiltinType* bi2
 // See ISO/IEC 9899:201x 6.3.1
 // No need to adjust for 32-bit as ISize and USize are converted before the lookup
 const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] UsualArithmeticConversions = {
-    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool  Void
-    //  0      1      2      3      4      5      6      7      8      9     10     11     12     13     14
+    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool
+    //  0      1      2      3      4      5      6      7      8      9     10     11     12     13
     // Char ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
     // Int8 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
     // Int16 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
     // Int32 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
     // Int64 ->
-    {   2,     2,     2,     3,     2,     2,     2,     2,     3,     4,     5,     6,     6,     2,     6  },
+    {   2,     2,     2,     3,     2,     2,     2,     2,     3,     4,     5,     6,     6,     2  },
     // UInt8 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
     // UInt16 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
     // UInt32 ->
-    {   1,     1,     1,     1,     3,     1,     1,     1,     3,     4,     5,     6,     6,     1,     6  },
+    {   1,     1,     1,     1,     3,     1,     1,     1,     3,     4,     5,     6,     6,     1  },
     // UInt64 ->
-    {   3,     3,     3,     3,     3,     3,     3,     3,     3,     4,     5,     6,     6,     3,     6  },
+    {   3,     3,     3,     3,     3,     3,     3,     3,     3,     4,     5,     6,     6,     3  },
     // Flt32 ->
-    {   4,     4,     4,     4,     4,     4,     4,     4,     4,     4,     5,     4,     4,     4,     6  },
+    {   4,     4,     4,     4,     4,     4,     4,     4,     4,     4,     5,     4,     4,     4  },
     // Flt64 ->
-    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     6  },
+    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5  },
     // ISize ->
-    {   6,     6,     6,     6,     6,     6,     6,     6,     3,     4,     5,     6,     6,     6,     6  },
+    {   6,     6,     6,     6,     6,     6,     6,     6,     3,     4,     5,     6,     6,     6  },
     // USize ->
-    {   6,     6,     6,     6,     6,     6,     6,     6,     6,     4,     5,     6,     6,     6,     6  },
+    {   6,     6,     6,     6,     6,     6,     6,     6,     6,     4,     5,     6,     6,     6  },
     // Bool ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0,     6  },
-    // Void ->
-    {   6,     6,     6,     6,     6,     6,     6,     6,     6,     6,     6,     6,     6,     6,     6  },
+    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
 }
 
 public fn QualType usual_arithmetic_conversion(const BuiltinType* b1, const BuiltinType* b2) {

--- a/analyser/ctv_analyser.c2
+++ b/analyser/ctv_analyser.c2
@@ -75,7 +75,7 @@ public fn bool checkTypeRange(diagnostics.Diags* diags, QualType qt, Value* valu
 
     BuiltinType* bi = canon.getBuiltin();
     // TODO: check float32 range
-    if (bi.getKind() == BuiltinKind.Float32 || bi.getKind() == BuiltinKind.Float64) return true;
+    if (bi.isFloatingPoint()) return true;
 
     Limit limit.init(bi.getWidth(), bi.isSigned());
 

--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -25,7 +25,6 @@ fn bool validArithType(QualType t) {
     t = t.getCanonicalType();
     switch (t.getKind()) {
     case Builtin:
-        return !t.isVoid();
     case Enum:
         return true;
     default:
@@ -37,7 +36,7 @@ fn bool validIntegerType(QualType t) {
     t = t.getCanonicalType();
     switch (t.getKind()) {
     case Builtin:
-        return !t.isVoid() && !t.isFloat();
+        return !t.isFloat();
     case Enum:
         return true;
     default:
@@ -50,7 +49,6 @@ fn bool validTestType(QualType t) {
     if (!t.isValid()) return false;
     switch (t.getKind()) {
     case Builtin:
-        return !t.isVoid();
     case Pointer:
     case Enum:
     case Function:
@@ -282,19 +280,21 @@ fn QualType Analyser.checkBinopLogical(Analyser* ma, BinaryOperator* b, QualType
 // 7  enum -= builtin
 // 8  enum -= enum -> int (CTV)
 const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvAddSubAss = {
-    //  Builtin Pointer Array   Struct  Enum    Func   Alias  Module
+    //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin += / -=
-    {   4,      2,      0,      2,      5,      2,     0,     0  },
+    {   4,      2,      0,      2,      5,      2,     2,     0,     0  },
     //  Pointer += / -=
-    {   6,      3,      0,      2,      6,      2,     0,     0  },
+    {   6,      3,      0,      2,      6,      2,     2,     0,     0  },
     //  Array += / -=
-    {   0,      0,      0,      0,      0,      0,     0,     0  },
+    {   0,      0,      0,      0,      0,      0,     0,     0,     0  },
     //  Struct += / -=
-    {   1,      1,      0,      3,      1,      3,     0,     0  },
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
     //  Enum += / -=
-    {   7,      1,      0,      2,      8,      2,     0,     0  },
+    {   7,      1,      0,      2,      8,      2,     2,     0,     0  },
     //  Function += / -=
-    {   1,      3,      0,      3,      1,      3,     0,     0  },
+    {   1,      3,      0,      3,      1,      3,     3,     0,     0  },
+    //  Void += / -=
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
     // Alias + Module are zero
 }
 fn QualType Analyser.checkBinopAddSubAssign(Analyser* ma, BinaryOperator* b, QualType lhs, QualType rhs) {
@@ -309,14 +309,11 @@ fn QualType Analyser.checkBinopAddSubAssign(Analyser* ma, BinaryOperator* b, Qua
         break;
     case 1: // invalid lhs
     invalid_lhs:
-        if (rcanon.isVoid()) goto invalid;
         return ma.invalidBinOp1(b, b.getLHS(), lhs);
     case 2: // invalid rhs
     invalid_rhs:
-        if (lcanon.isVoid()) goto invalid;
         return ma.invalidBinOp1(b, b.getRHS(), rhs);
     case 3: // invalid operands
-    invalid:
         return ma.invalidBinOp2(b, lhs, rhs);
     case 4: // builtin - builtin
     case 5: // builtin - enum -> int
@@ -347,19 +344,21 @@ fn QualType Analyser.checkBinopAddSubAssign(Analyser* ma, BinaryOperator* b, Qua
 // TODO remove Alias/Module (+Array, need to move) since already checked
 // TODO need to fix C2C.c++ (asserts of elemsof(..) -2), then table can be 5x5
 const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvAdd = {
-    //  Builtin Pointer Array   Struct  Enum    Func   Alias  Module
+    //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin +
-    {   4,      7,      0,      2,      5,      2,     0,     0  },
+    {   4,      7,      0,      2,      5,      2,     2,     0,     0  },
     //  Pointer +
-    {   8,      3,      0,      2,      8,      3,     0,     0  },
+    {   8,      3,      0,      2,      8,      3,     2,     0,     0  },
     //  Array +
-    {   0,      0,      0,      0,      0,      0,     0,     0  },
+    {   0,      0,      0,      0,      0,      0,     0,     0,     0  },
     //  Struct +
-    {   1,      1,      0,      3,      1,      3,     0,     0  },
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
     //  Enum +
-    {   6,      7,      0,      2,      3,      2,     0,     0  },
+    {   6,      7,      0,      2,      3,      2,     2,     0,     0  },
     //  Function +
-    {   1,      3,      0,      3,      1,      3,     0,     0  },
+    {   1,      3,      0,      3,      1,      3,     3,     0,     0  },
+    //  Void +
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
     // Alias + Module are zero
 }
 fn QualType Analyser.checkBinopAddArgs(Analyser* ma, BinaryOperator* b, QualType lhs, QualType rhs) {
@@ -374,12 +373,10 @@ fn QualType Analyser.checkBinopAddArgs(Analyser* ma, BinaryOperator* b, QualType
         break;
     case 1: // invalid lhs
     invalid_lhs:
-        if (rcanon.isVoid()) goto invalid;
         if (rcanon.isVoidPtr())  goto invalid;
         return ma.invalidBinOp1(b, b.getLHS(), lhs);
     case 2: // invalid rhs
     invalid_rhs:
-        if (lcanon.isVoid()) goto invalid;
         if (lcanon.isVoidPtr())  goto invalid;
         return ma.invalidBinOp1(b, b.getRHS(), rhs);
     case 3: // invalid operands
@@ -391,11 +388,7 @@ fn QualType Analyser.checkBinopAddArgs(Analyser* ma, BinaryOperator* b, QualType
         BuiltinType* br = rcanon.getBuiltin();
         // TODO move somewhere else (used at many places)
         QualType optype = conversion_checker.usual_arithmetic_conversion(bl, br);
-        if (!optype.isValid()) {
-            if (!lcanon.isVoid()) goto invalid_rhs;
-            if (!rcanon.isVoid()) goto invalid_lhs;
-            goto invalid;
-        }
+        if (!optype.isValid()) goto invalid;
         BuiltinType* bi = optype.getBuiltin();
         if (bl != bi) {
             ma.builder.insertImplicitCast(IntegralCast, b.getLHS2(), optype);
@@ -434,19 +427,21 @@ fn QualType Analyser.checkBinopAddArgs(Analyser* ma, BinaryOperator* b, QualType
 // 8  pointer - builtin/enum
 // 9  pointer - pointer -> isize
 const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvSub = {
-    //  Builtin Pointer Array   Struct  Enum    Func   Alias  Module
+    //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin -
-    {   4,      3,      0,      2,      5,      2,     0,     0  },
+    {   4,      3,      0,      2,      5,      2,     2,     0,     0  },
     //  Pointer -
-    {   8,      9,      0,      1,      8,      2,     0,     0  },
+    {   8,      9,      0,      1,      8,      2,     2,     0,     0  },
     //  Array -
-    {   0,      0,      0,      0,      0,      0,     0,     0  },
+    {   0,      0,      0,      0,      0,      0,     0,     0,     0  },
     //  Struct -
-    {   1,      1,      0,      3,      1,      3,     0,     0  },
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
     //  Enum -
-    {   6,      3,      0,      2,      7,      2,     0,     0  },
+    {   6,      3,      0,      2,      7,      2,     2,     0,     0  },
     //  Function -
-    {   1,      1,      0,      3,      1,      3,     0,     0  },
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
+    //  Void += / -=
+    {   1,      1,      0,      3,      1,      3,     3,     0,     0  },
     // Alias + Module are zero
 }
 fn QualType Analyser.checkBinopSubArgs(Analyser* ma, BinaryOperator* b, QualType lhs, QualType rhs) {
@@ -461,11 +456,9 @@ fn QualType Analyser.checkBinopSubArgs(Analyser* ma, BinaryOperator* b, QualType
         break;
     case 1: // invalid lhs
     invalid_lhs:
-        if (rcanon.isVoid()) goto invalid;
         return ma.invalidBinOp1(b, b.getLHS(), lhs);
     case 2: // invalid rhs
     invalid_rhs:
-        if (lcanon.isVoid()) goto invalid;
         return ma.invalidBinOp1(b, b.getRHS(), rhs);
     case 3: // invalid operands
     invalid:
@@ -476,11 +469,7 @@ fn QualType Analyser.checkBinopSubArgs(Analyser* ma, BinaryOperator* b, QualType
         BuiltinType* br = rcanon.getBuiltin();
         // TODO move somewhere else (used at many places)
         QualType optype = conversion_checker.usual_arithmetic_conversion(bl, br);
-        if (!optype.isValid()) {
-            if (!lcanon.isVoid()) goto invalid_rhs;
-            if (!rcanon.isVoid()) goto invalid_lhs;
-            goto invalid;
-        }
+        if (!optype.isValid()) goto invalid;
         BuiltinType* bi = optype.getBuiltin();
         if (bl != bi) {
             ma.builder.insertImplicitCast(IntegralCast, b.getLHS2(), optype);
@@ -533,19 +522,21 @@ fn QualType Analyser.checkBinopSubArgs(Analyser* ma, BinaryOperator* b, QualType
 // 11  invalid rhs
 // TODO: accept pointer/function : 0 and 0 : pointer/function
 const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvComparison = {
-    //  Builtin Pointer Array   Struct  Enum    Func   Alias  Module
+    //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin :
-    {   2,      1,      0,     11,      3,      0,     0,     0  },
+    {   2,      1,      0,     11,      3,      0,    11,     0,     0  },
     //  Pointer :
-    {   1,      4,      0,     11,      1,      7,     0,     0  },
+    {   1,      4,      0,     11,      1,      7,    11,     0,     0  },
     //  Array :
-    {   0,      0,      0,      0,      0,      0,     0,     0  },
+    {   0,      0,      0,      0,      0,      0,     0,     0,     0  },
     //  Struct :
-    {  10,     10,      0,      1,     10,     10,     0,     0  },
+    {  10,     10,      0,      1,     10,     10,     1,     0,     0  },
     //  Enum :
-    {   5,      1,      0,     11,      6,      1,     0,     0  },
+    {   5,      1,      0,     11,      6,      1,    11,     0,     0  },
     //  Function :
-    {   1,      8,      0,     11,      1,      9,     0,     0  },
+    {   1,      8,      0,     11,      1,      9,     1,     0,     0  },
+    //  Void += / -=
+    {  10,     10,      0,      1,     10,      1,     1,     0,     0  },
     // Alias + Module are zero
 }
 fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualType lhs, QualType rhs, bool is_relative) {
@@ -567,11 +558,7 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
         BuiltinType* br = rcanon.getBuiltin();
         // TODO move somewhere else (used at many places)
         QualType optype = conversion_checker.usual_arithmetic_conversion(bl, br);
-        if (!optype.isValid()) {
-            if (!lcanon.isVoid()) goto invalid_rhs;
-            if (!rcanon.isVoid()) goto invalid_lhs;
-            goto invalid;
-        }
+        if (!optype.isValid()) goto invalid;
         BuiltinType* bi = optype.getBuiltin();
         if (bl != bi) {
             ma.builder.insertImplicitCast(IntegralCast, b.getLHS2(), optype);
@@ -622,12 +609,8 @@ fn QualType Analyser.checkBinopComparison(Analyser* ma, BinaryOperator* b, QualT
         if (is_relative) return ma.invalidFuncCompare(b);
         return builtins[BuiltinKind.Bool];
     case 10: // invalid lhs
-    invalid_lhs:
-        if (rcanon.isVoid()) goto invalid;
         return ma.invalidBinOp1(b, b.getLHS(), lhs);
     case 11: // invalid rhs
-    invalid_rhs:
-        if (lcanon.isVoid()) goto invalid;
         return ma.invalidBinOp1(b, b.getRHS(), rhs);
     }
     ma.error(e.getLoc(), "TODO BINOP %d", res);

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -308,8 +308,7 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
         }
         break;
     case Char:
-        // TODO check can be more efficient
-        if (!qt.isChar() && !qt.isInt8() && !qt.isUInt8()) {
+        if (!qt.isCharCompatible()) {
             ma.error(arg.getStartLoc(), "format '%%c' expects a character argument");
         }
         break;

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -243,21 +243,24 @@ fn IdentifierKind Analyser.setExprFlags(Analyser* ma, Expr** e_ptr, Decl* d) {
 // 8  function : pointer
 // 9  function : function
 // 10  struct : struct
+// 11  void : void
 // TODO: accept pointer/function : 0 and 0 : pointer/function
 const u8[elemsof(TypeKind)][elemsof(TypeKind)] CondOpTable = {
-    //  Builtin Pointer Array   Struct  Enum    Func   Alias  Module
+    //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin :
-    {   2,      1,      0,      1,      3,      0,     0,     0  },
+    {   2,      1,      0,      1,      3,      0,     1,     0,     0  },
     //  Pointer :
-    {   1,      4,      0,      1,      1,      7,     0,     0  },
+    {   1,      4,      0,      1,      1,      7,     1,     0,     0  },
     //  Array :
-    {   0,      0,      0,      0,      0,      0,     0,     0  },
+    {   0,      0,      0,      0,      0,      0,     0,     0,     0  },
     //  Struct :
-    {   1,      1,      0,     10,      1,      1,     0,     0  },
+    {   1,      1,      0,     10,      1,      1,     1,     0,     0  },
     //  Enum :
-    {   5,      1,      0,      1,      6,      1,     0,     0  },
+    {   5,      1,      0,      1,      6,      1,     1,     0,     0  },
     //  Function :
-    {   1,      8,      0,      1,      1,      9,     0,     0  },
+    {   1,      8,      0,      1,      1,      9,     1,     0,     0  },
+    //  Void:
+    {   1,      1,      0,      1,      1,      1,    11,     0,     0  },
     // Alias + Module are zero
 }
 fn QualType Analyser.analyseConditionalOperator(Analyser* ma, Expr** e_ptr) {
@@ -296,7 +299,7 @@ fn QualType Analyser.analyseConditionalOperator(Analyser* ma, Expr** e_ptr) {
         BuiltinType* br = rcanon.getBuiltin();
         // Use modified version of usual_arithmetic_conversion
         QualType optype = conversion_checker.get_common_arithmetic_type(bl, br);
-        if (!optype.isValid() || optype.isVoid()) goto invalid;
+        if (!optype.isValid()) goto invalid;
         BuiltinType* bi = optype.getBuiltin();
         if (bl != bi) {
             ma.builder.insertImplicitCast(IntegralCast, cond.getLHS2(), optype);
@@ -342,6 +345,8 @@ fn QualType Analyser.analyseConditionalOperator(Analyser* ma, Expr** e_ptr) {
             ma.error(e.getLoc(), "ternary operands are structs or unions of different types ('%s' and '%s')", lhs.diagName(), rhs.diagName());
             return QualType_Invalid;
         }
+        return lhs;
+    case 11: // void : void
         return lhs;
     }
     e.dump();
@@ -403,14 +408,9 @@ fn QualType usualUnaryConversions(Expr* e) {
     QualType qt = e.getType();
     QualType canon = qt.getCanonicalType();
 
-    if (canon.isBuiltin()) {
-        BuiltinType* bi = canon.getBuiltin();
-        if (bi.isPromotableIntegerType()) return ast.builtins[BuiltinKind.Int32];
-    } else if (canon.isPointer()) {
-        // TODO depend on arch width
-        return ast.builtins[BuiltinKind.UInt64];
-    }
-
+    if (!canon.isBuiltin()) return QualType_Invalid;
+    BuiltinType* bi = canon.getBuiltin();
+    if (bi.isPromotableIntegerType()) return ast.builtins[BuiltinKind.Int32];
     return qt;
 }
 

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -37,9 +37,7 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
             if (at) {
                 // check that element type is char/i8/u8
                 QualType elem = at.getElemType();
-                if (elem.getTypeOrNil() != builtins[BuiltinKind.Char].getTypeOrNil()
-                &&  elem.getTypeOrNil() != builtins[BuiltinKind.Int8].getTypeOrNil()
-                &&  elem.getTypeOrNil() != builtins[BuiltinKind.UInt8].getTypeOrNil()) {
+                if (!elem.isCharCompatible()) {
                     ma.errorRange(assignLoc, e.getRange(), "cannot initialize array of '%s' with a string literal", elem.diagName());
                     return false;
                 }

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -187,6 +187,10 @@ fn QualType Analyser.analyseTypeRef(Analyser* ma, TypeRef* ref) {
         base = ma.builder.actOnBuiltinType(kind);
         assert(base.isValid());
         break;
+    case Void:
+        base = ma.builder.actOnVoidType();
+        assert(base.isValid());
+        break;
     case User:
         base = ma.analyseUserTypeRef(ref);
         if (base.isInvalid()) return base;
@@ -290,14 +294,20 @@ fn QualType Analyser.analyseTypeRef(Analyser* ma, TypeRef* ref) {
 fn QualType Analyser.analyseIncrTypeRef(Analyser* ma, TypeRef* ref, u32 size) {
     // TODO refactor common code with analyseTypeRef
     QualType base;
-    if (ref.isUser()) {
-        base = ma.analyseUserTypeRef(ref);
-        if (base.isInvalid()) return base;
-        assert(base.hasCanonicalType());
-    } else {
+    switch (ref.getKind()) {
+    case Builtin:
         BuiltinKind kind = ref.getBuiltinKind();
         base = ma.builder.actOnBuiltinType(kind);
         assert(base.isValid());
+        break;
+    case User:
+        base = ma.analyseUserTypeRef(ref);
+        if (base.isInvalid()) return base;
+        assert(base.hasCanonicalType());
+        break;
+    default:
+        assert(0);
+        break;
     }
 
     if (ref.isConst()) base.setConst();

--- a/analyser/module_analyser_unaryop.c2
+++ b/analyser/module_analyser_unaryop.c2
@@ -69,8 +69,8 @@ fn QualType Analyser.analyseUnaryOperator(Analyser* ma, Expr** e_ptr, u32 side) 
     e = *e_ptr; // re-read in case of ImplicitCast insertions
     Expr* inner = u.getInner();
 
-    if (t.isVoid()) goto invalid_type;
     QualType canon = t.getCanonicalType();
+    if (canon.isVoid()) goto invalid_type;
 
     switch (u.getOpcode()) {
     case PostInc:
@@ -122,7 +122,12 @@ fn QualType Analyser.analyseUnaryOperator(Analyser* ma, Expr** e_ptr, u32 side) 
             t = t.getCanonicalType();
             const PointerType* p = t.getPointerType();
             // TODO copy flags from inner
-            return p.getInner();
+            t = p.getInner();
+            if (t.isVoid()) {
+                ma.error(e.getLoc(), "cannot dereference a void pointer");
+                return QualType_Invalid;
+            }
+            break;
         } else {
             ma.error(e.getLoc(), "indirection requires pointer operand ('%s' invalid)", t.diagName());
             return QualType_Invalid;
@@ -144,6 +149,7 @@ fn QualType Analyser.analyseUnaryOperator(Analyser* ma, Expr** e_ptr, u32 side) 
         t = usualUnaryConversions(inner);
         break;
     case LNot:
+        if (!canon.isScalar()) goto invalid_type;
         e.copyConstantFlags(inner);
         return builtins[BuiltinKind.Bool];
     }
@@ -159,7 +165,7 @@ fn bool Analyser.checkIncrDecr(Analyser* ma, Expr* inner, QualType t, bool is_in
     if (!ma.checkAssignment(inner, t, operand, loc)) return false;
 
     t = t.getCanonicalType();
-    if (!t.isBuiltin() && !t.isPointer() && !t.isEnum()) {
+    if (!t.isBuiltin() && !t.isEnum() && (!t.isPointer() || t.isVoidPtr())) {
         ma.error(loc, "cannot %s value of type '%s'", is_incr ? "increment" : "decrement", t.diagName());
         return false;
     }
@@ -291,8 +297,6 @@ fn QualType getMinusType(QualType qt) {
         return qt;
     case USize:
         return builtins[BuiltinKind.ISize];
-    case Void:
-        break;
     }
     return QualType_Invalid;
 }

--- a/analyser/size_analyser.c2
+++ b/analyser/size_analyser.c2
@@ -223,6 +223,11 @@ public fn TypeSize sizeOfType(QualType qt) {
         result.size = pointerSize;
         result.align = pointerSize;
         break;
+    case Void:
+        result.size = 0;
+        result.align = 0;
+        result.is_signed = false;
+        break;
     case Alias:
         assert(0);  // cannot occur here
         break;

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -34,7 +34,6 @@ public type BuiltinKind enum u8 {
     ISize,
     USize,
     Bool,
-    Void,
 }
 
 const char*[] builtinType_names = {
@@ -52,7 +51,6 @@ const char*[] builtinType_names = {
     [BuiltinKind.ISize] = "isize",
     [BuiltinKind.USize] = "usize",
     [BuiltinKind.Bool] = "bool",
-    [BuiltinKind.Void] = "void",
 }
 static_assert(elemsof(BuiltinKind), elemsof(builtinType_names));
 
@@ -71,7 +69,6 @@ const bool[] BuiltinType_promotable = {
     [BuiltinKind.ISize] = false,
     [BuiltinKind.USize] = false,
     [BuiltinKind.Bool] = true,
-    [BuiltinKind.Void] = false,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_promotable));
 
@@ -90,7 +87,6 @@ const bool[] BuiltinType_signed = {
     [BuiltinKind.ISize] = true,
     [BuiltinKind.USize] = false,
     [BuiltinKind.Bool] = false,
-    [BuiltinKind.Void] = false,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_signed));
 
@@ -113,7 +109,6 @@ const bool[] BuiltinType_unsigned = {
     [BuiltinKind.ISize] = false,
     [BuiltinKind.USize] = true,
     [BuiltinKind.Bool] = false,
-    [BuiltinKind.Void] = false,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_unsigned));
 
@@ -132,7 +127,6 @@ const bool[] BuiltinType_integer = {
     [BuiltinKind.ISize] = true,
     [BuiltinKind.USize] = true,
     [BuiltinKind.Bool] = false,
-    [BuiltinKind.Void] = false,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_integer));
 
@@ -152,7 +146,6 @@ const u32[] BuiltinType_default_sizes = {
     [BuiltinKind.ISize] = 8,       // adjusted in global
     [BuiltinKind.USize] = 8,       // adjusted in global
     [BuiltinKind.Bool] = 1,
-    [BuiltinKind.Void] = 0,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_sizes));
 
@@ -172,7 +165,6 @@ const u32[] BuiltinType_default_widths = {
     [BuiltinKind.ISize] = 64,       // adjusted in global
     [BuiltinKind.USize] = 64,       // adjusted in global
     [BuiltinKind.Bool] = 1,
-    [BuiltinKind.Void] = 0,
 }
 static_assert(elemsof(BuiltinKind), elemsof(BuiltinType_default_widths));
 
@@ -209,30 +201,12 @@ public fn BuiltinKind BuiltinType.getBaseKind(const BuiltinType* b) {
     return globals.builtinType_baseTypes[b.getKind()];
 }
 
-fn bool BuiltinType.isChar(const BuiltinType* b) {
-    return b.base.builtinTypeBits.kind == BuiltinKind.Char;
-}
-
-fn bool BuiltinType.isInt8(const BuiltinType* b) {
-    return b.base.builtinTypeBits.kind == BuiltinKind.Int8;
-}
-
-fn bool BuiltinType.isUInt8(const BuiltinType* b) {
-    return b.base.builtinTypeBits.kind == BuiltinKind.UInt8;
-}
-
 public fn bool BuiltinType.isInt32(const BuiltinType* b) {
     return b.base.builtinTypeBits.kind == BuiltinKind.Int32;
 }
 
-/*
-public fn bool BuiltinType.isBool(const BuiltinType* b) {
+fn bool BuiltinType.isBool(const BuiltinType* b) {
     return b.base.builtinTypeBits.kind == BuiltinKind.Bool;
-}
-*/
-
-fn bool BuiltinType.isVoid(const BuiltinType* b) {
-    return b.base.builtinTypeBits.kind == BuiltinKind.Void;
 }
 
 public fn const char* BuiltinType.kind2str(const BuiltinType* b) {
@@ -248,11 +222,11 @@ public fn bool BuiltinType.isInteger(const BuiltinType* b) {
 }
 
 public fn bool BuiltinType.isIntegerOrBool(const BuiltinType* b) {
-    return b.isInteger() || b.getKind() == BuiltinKind.Bool;
+    return b.isInteger() || b.getKind() == Bool;
 }
 
 public fn bool BuiltinType.isFloatingPoint(const BuiltinType* b) {
-    return (b.getKind() == BuiltinKind.Float32 || b.getKind() == BuiltinKind.Float64);
+    return (b.getKind() == Float32 || b.getKind() == Float64);
 }
 
 public fn bool BuiltinType.isSigned(const BuiltinType* b) {

--- a/ast/float_literal.c2
+++ b/ast/float_literal.c2
@@ -73,6 +73,6 @@ public fn void FloatLiteral.printLiteral(const FloatLiteral* e, string_buffer.Bu
         break;
     }
     QualType qt = e.base.getType();
-    if (qt.getBuiltinKind() == Float32) out.add1('F');
+    if (qt.isFloat32()) out.add1('F');
 }
 

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -109,9 +109,8 @@ public fn bool QualType.isScalar(const QualType qt) {
     QualType canon = qt.getCanonicalType();
     const Type* t = canon.getTypeOrNil();
     if (t.isBuiltinType()) {
-        BuiltinType* bi = (BuiltinType*)t;
         // bool and arithmetic types are allowed
-        return !bi.isVoid();
+        return true;
     }
     if (canon.isPointer()) return true;
     if (canon.isFunction()) return true;
@@ -199,7 +198,8 @@ public fn u32 QualType.getSize(const QualType qt, bool deref_ptr) {
 }
 
 public fn bool QualType.isBool(const QualType qt) {
-    return qt.getTypeOrNil() == builtins[BuiltinKind.Bool].getTypeOrNil();
+    const BuiltinType* bi = qt.getBuiltinTypeOrNil();
+    return (bi && bi.isBool());
 }
 
 public fn bool QualType.isBuiltin(const QualType qt) {
@@ -215,23 +215,23 @@ public fn bool QualType.isStruct(const QualType qt) {
 }
 
 public fn bool QualType.isInteger(const QualType qt) {
-    const Type* t = qt.getTypeOrNil();
-    if (!t.isBuiltinType()) return false;
-    const BuiltinType* bi = (BuiltinType*)t;
-    return bi.isInteger();
+    const BuiltinType* bi = qt.getBuiltinTypeOrNil();
+    return (bi && bi.isInteger());
 }
 
 public fn bool QualType.isFloat(const QualType qt) {
-    const Type* t = qt.getTypeOrNil();
-    if (!t.isBuiltinType()) return false;
-    const BuiltinType* bi = (BuiltinType*)t;
-    return bi.isFloatingPoint();
+    const BuiltinType* bi = qt.getBuiltinTypeOrNil();
+    return (bi && bi.isFloatingPoint());
 }
 
-public fn BuiltinKind QualType.getBuiltinKind(const QualType* qt) {
-    const Type* t = qt.getTypeOrNil();
-    if (!t || !t.isBuiltinType()) return Void;
-    const BuiltinType* bi = (BuiltinType*)t;
+public fn bool QualType.isFloat32(const QualType qt) {
+    const BuiltinType* bi = qt.getBuiltinTypeOrNil();
+    return (bi && bi.getKind() == Float32);
+}
+
+fn BuiltinKind QualType.getBuiltinKind(const QualType* qt) {
+    const BuiltinType* bi = qt.getBuiltinTypeOrNil();
+    assert(bi);
     return bi.getKind();
 }
 
@@ -367,32 +367,34 @@ public fn EnumType* QualType.getEnumTypeOrNil(const QualType qt) {
     return nil;
 }
 
+public fn bool QualType.isCharCompatible(const QualType qt) {
+    QualType canon = qt.getCanonicalType();
+    const Type* t = canon.getTypeOrNil();
+    if (t.getKind() != TypeKind.Builtin) return false;
+    const BuiltinType* bi = (BuiltinType*)t;
+    BuiltinKind kind = bi.getKind();
+    return kind == Char || kind == Int8 || kind == UInt8;
+}
+
 public fn bool QualType.isChar(const QualType qt) {
     const Type* t = qt.getTypeOrNil();
     if (t.getKind() != TypeKind.Builtin) return false;
     const BuiltinType* bi = (BuiltinType*)t;
-    return bi.isChar();
-}
-
-public fn bool QualType.isInt8(const QualType qt) {
-    const Type* t = qt.getTypeOrNil();
-    if (t.getKind() != TypeKind.Builtin) return false;
-    const BuiltinType* bi = (BuiltinType*)t;
-    return bi.isInt8();
+    return bi.getKind() == Char;
 }
 
 public fn bool QualType.isUInt8(const QualType qt) {
     const Type* t = qt.getTypeOrNil();
     if (t.getKind() != TypeKind.Builtin) return false;
     const BuiltinType* bi = (BuiltinType*)t;
-    return bi.isUInt8();
+    return bi.getKind() == UInt8;
 }
 
 public fn bool QualType.promotesToInt32(const QualType qt) {
     const Type* t = qt.getTypeOrNil();
     if (t.getKind() != TypeKind.Builtin) return false;
     const BuiltinType* bi = (BuiltinType*)t;
-    return bi.getKind() == BuiltinKind.Int32 || bi.isPromotableIntegerType();
+    return bi.getKind() == Int32 || bi.isPromotableIntegerType();
 }
 
 public fn bool QualType.needsCtvInit(const QualType qt) {
@@ -413,6 +415,7 @@ public fn bool QualType.needsCtvInit(const QualType qt) {
     case Struct:    return true;
     case Enum:      return true;
     case Function:  return false;
+    case Void:      return true;
     case Alias:     return false;   // is never a canonical type
     case Module:    return false;
     }

--- a/ast/type.c2
+++ b/ast/type.c2
@@ -24,6 +24,7 @@ public type TypeKind enum u8 {
     Struct,
     Enum,
     Function,
+    Void,
     Alias,
     Module,
 }
@@ -35,6 +36,7 @@ const char*[] typeKind_names = {
     "Struct",
     "Enum",
     "Function",
+    "Void",
     "Alias",
     "Module",
 }
@@ -103,7 +105,7 @@ fn bool Type.isEnumType(const Type* t) {
 }
 
 public fn bool Type.isVoidType(const Type* t) {
-    return t == builtins[BuiltinKind.Void].getTypeOrNil();
+    return (t.getKind() == TypeKind.Void);
 }
 
 public fn void Type.dump(const Type* t) @(unused) {
@@ -135,6 +137,8 @@ fn u32 Type.getAlignment(const Type* t) {
         return it.getTypeOrNil().getAlignment();
     case Function:
         break;
+    case Void:
+        return 0;
     case Alias:
         QualType canon = t.getCanonicalType();
         return canon.getAlignment();
@@ -172,6 +176,8 @@ fn u32 Type.getSize(const Type* t, bool deref_ptr) {
         return it.getTypeOrNil().getSize(false);
     case Function:
         break;
+    case Void:
+        return 0;
     case Alias:
         QualType canon = t.getCanonicalType();
         return canon.getAlignment();
@@ -203,6 +209,9 @@ fn void Type.print(const Type* t, string_buffer.Buf* out) {
     case Function:
         FunctionType.print((FunctionType*)t, out);
         break;
+    case Void:
+        VoidType.print((VoidType*)t, out);
+        break;
     case Alias:
         AliasType.print((AliasType*)t, out);
         break;
@@ -231,6 +240,9 @@ fn void Type.fullPrint(const Type* t, string_buffer.Buf* out, u32 indent) {
         break;
     case Function:
         FunctionType.fullPrint((FunctionType*)t, out, indent);
+        break;
+    case Void:
+        VoidType.fullPrint((VoidType*)t, out, indent);
         break;
     case Alias:
         AliasType.fullPrint((AliasType*)t, out, indent);

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -22,6 +22,7 @@ import string;
 
 public type TypeRefKind enum u8 {
     Builtin,
+    Void,
     User,
     Function,
 }
@@ -29,6 +30,7 @@ public type TypeRefKind enum u8 {
 fn const char* TypeRefKind.str(TypeRefKind k) {
     switch (k) {
     case Builtin:   return "builtin";
+    case Void:      return "void";
     case User:      return "user";
     case Function:  return "function";
     }
@@ -159,6 +161,12 @@ public fn void TypeRefHolder.setBuiltin(TypeRefHolder* h, BuiltinKind kind, SrcL
     r.loc = loc;
 }
 
+public fn void TypeRefHolder.setVoid(TypeRefHolder* h, SrcLoc loc) {
+    TypeRef* r = (TypeRef*)&h.ref;
+    r.flags.kind = TypeRefKind.Void;
+    r.loc = loc;
+}
+
 public fn void TypeRefHolder.setUser(TypeRefHolder* h, SrcLoc loc, u32 name_idx) {
     TypeRef* r = (TypeRef*)&h.ref;
     r.flags.kind = TypeRefKind.User;
@@ -207,6 +215,7 @@ fn void TypeRef.init(TypeRef* dest, const TypeRefHolder* h) {
     // copy for tail-allocated info
     switch (r.getKind()) {
     case Builtin:
+    case Void:
         break;
     case User:
         dest.refs[0] = h.user;
@@ -301,7 +310,7 @@ public fn bool TypeRef.isFunction(const TypeRef* r) {
 }
 
 public fn bool TypeRef.isVoid(const TypeRef* r) {
-    return r.isBuiltin() && r.flags.num_ptrs == 0 && r.getBuiltinKind() == BuiltinKind.Void;
+    return r.flags.kind == TypeRefKind.Void;
 }
 
 public fn bool TypeRef.isConstCharPtr(const TypeRef* r) {
@@ -337,6 +346,7 @@ public fn TypeRefKind TypeRef.getKind(const TypeRef* r) {
 public fn SrcLoc TypeRef.getLoc(const TypeRef* r) {
     switch (r.getKind()) {
     case Builtin:
+    case Void:
         break;
     case User:
         if (r.hasPrefix()) return r.refs[1].loc;
@@ -415,6 +425,9 @@ fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool prin
     case Builtin:
         out.add(builtinType_names[r.flags.builtin_kind]);
         break;
+    case Void:
+        out.add("void");
+        break;
     case User:
         Decl* d = r.refs[0].decl;
         assert(d);
@@ -453,6 +466,9 @@ fn void TypeRef.print(const TypeRef* r, string_buffer.Buf* out, bool filled) {
     switch ((TypeRefKind)r.flags.kind) {
     case Builtin:
         out.add(builtinType_names[r.flags.builtin_kind]);
+        break;
+    case Void:
+        out.add("void");
         break;
     case User:
         if (r.flags.has_prefix) {

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -112,6 +112,8 @@ public type Globals struct @(opaque) {
     BuiltinKind[elemsof(BuiltinKind)] builtinType_baseTypes;
 
     u32[elemsof(attr.AttrKind)] attr_name_indexes;
+    QualType void_type;
+    QualType void_ptr_type;
 
     string_buffer.Buf* dump_buf;
 #if AstStatistics
@@ -150,15 +152,16 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
 #endif
 
     // create all Qualtypes for builtin-types, 1 extra for void-ptr
-    builtins = stdlib.malloc((elemsof(BuiltinKind) + 1) * sizeof(QualType));
+    builtins = stdlib.malloc(elemsof(BuiltinKind) * sizeof(QualType));
     for (u32 i=0; i<elemsof(BuiltinKind); i++) {
         builtins[i].set((Type*)BuiltinType.create(c, (BuiltinKind)i));
     }
 
+    globals.void_type.set((Type*)VoidType.create(c));
     // create void* Type so its easy to check if a type is a void*
-    Type* void_ptr = ast.getPointerType(builtins[BuiltinKind.Void]);
-    builtins[elemsof(BuiltinKind)].set(void_ptr);
-    void_ptr.setCanonicalType(builtins[elemsof(BuiltinKind)]);
+    Type* void_ptr = ast.getPointerType(globals.void_type);
+    globals.void_ptr_type.set(void_ptr);
+    void_ptr.setCanonicalType(globals.void_ptr_type);
 
     string.memcpy(globals.builtinType_sizes, BuiltinType_default_sizes, sizeof(BuiltinType_default_sizes));
     globals.builtinType_sizes[BuiltinKind.ISize] = wordsize;
@@ -217,11 +220,15 @@ public fn const char* idx2name(u32 idx) {
 }
 
 fn QualType getVoidPtr() {
-    return builtins[elemsof(BuiltinKind)];
+    return globals.void_ptr_type;
 }
 
 public fn Type* getPointerType(QualType inner) {
     return globals.pointers.getPointer(inner);
+}
+
+public fn QualType getVoidQT() {
+    return globals.void_type;
 }
 
 fn u32 addAST(AST* ast_) {
@@ -272,6 +279,7 @@ public fn void setTypePublicUsed(QualType qt) {
     Decl* d = nil;
     switch (t.getKind()) {
     case Builtin:
+    case Void:
         return;
     case Pointer:
         PointerType* pt = (PointerType*)t;

--- a/ast/void_type.c2
+++ b/ast/void_type.c2
@@ -1,0 +1,42 @@
+/* Copyright 2022-2025 Bas van den Berg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+import ast_context;
+import string_buffer;
+
+type VoidType struct {
+    Type base;
+}
+
+fn VoidType* VoidType.create(ast_context.Context* c) {
+    VoidType* b = c.alloc(sizeof(VoidType));
+    b.base.init(TypeKind.Void);
+    b.base.setCanonicalType(QualType.create(&b.base));
+#if AstStatistics
+    Stats.addType(TypeKind.Void, sizeof(VoidType));
+#endif
+    return b;
+}
+
+fn void VoidType.print(const VoidType* b, string_buffer.Buf* out) {
+    out.add("void");
+}
+
+fn void VoidType.fullPrint(const VoidType* t, string_buffer.Buf* out, u32 indent) {
+    out.indent(indent);
+    out.print("VoidType [%p] void\n", t);
+}

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -666,6 +666,10 @@ public fn QualType Builder.actOnBuiltinType(Builder*, BuiltinKind kind) {
     return builtins[kind];
 }
 
+public fn QualType Builder.actOnVoidType(Builder*) {
+    return getVoidQT();
+}
+
 public fn QualType Builder.actOnPointerType(Builder*, QualType inner) {
     QualType ptr = QualType.create(ast.getPointerType(inner));
 

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -252,9 +252,7 @@ const char*[] builtinType_cnames = {
     "ssize_t",
     "size_t",
     "_Bool",
-    "void",
 }
-
 static_assert(elemsof(BuiltinKind), elemsof(builtinType_cnames));
 
 fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType qt) {
@@ -295,6 +293,9 @@ fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType q
         FunctionDecl* fd = ft.getDecl();
         decl = (Decl*)fd;
         break;
+    case Void:
+        out.add("void");
+        return;
     case Alias:
         AliasType* at = (AliasType*)qt.getType();
         decl = (Decl*)at.getDecl();
@@ -333,6 +334,7 @@ fn void Generator.genTypeIfNeeded(Generator* gen, QualType qt, bool full) {
 
     switch (qt.getKind()) {
     case Builtin:
+    case Void:
         return;
     case Pointer:
         PointerType* pt = (PointerType*)qt.getType();

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -156,7 +156,7 @@ fn void Generator.emitExpr2(Generator* gen, string_buffer.Buf* out, Expr* e, C_P
         ImplicitCastExpr* i = (ImplicitCastExpr*)e;
         if (i.getKind() == IntegralCast) {
             QualType qt = e.getType();
-            if (qt.getBuiltinKind() == Float32) {
+            if (qt.isFloat32()) {
                 if (prec > Prefix) out.lparen();
                 gen.emitCast(out, qt, false);
                 gen.emitExpr2(out, i.getInner(), Prefix);
@@ -413,7 +413,6 @@ const bool[] Size_prefix = {
     [BuiltinKind.ISize] = true,
     [BuiltinKind.USize] = true,
     [BuiltinKind.Bool] = false,
-    [BuiltinKind.Void] = false,
 }
 
 fn void emitNumberFormat(BuiltinKind kind, char letter, string_buffer.Buf* out) {

--- a/generator/c2i/c2i_generator_decl.c2
+++ b/generator/c2i/c2i_generator_decl.c2
@@ -140,6 +140,9 @@ fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType q
         BuiltinType* bt = (BuiltinType*)qt.getType();
         out.add(bt.kind2str());
         return;
+    case Void:
+        out.add("void");
+        return;
     case Pointer:
         PointerType* pt = (PointerType*)qt.getType();
         gen.emitTypePre(out, pt.getInner());

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -204,7 +204,6 @@ const ir.Type[elemsof(BuiltinKind)] Ast_type2ir_type = {
     [BuiltinKind.ISize]   = I64,  // TODO 32-bit
     [BuiltinKind.USize]   = U64,  // TODO 32-bit
     [BuiltinKind.Bool]    = I8,    // TODO ir.Type.I1?
-    [BuiltinKind.Void]    = None,
 }
 
 fn ir.Type builtin2irtype(BuiltinKind k) {
@@ -217,6 +216,8 @@ fn ir.Type Generator.type2irtype(Generator* gen, QualType qt) {
     case Builtin:
         BuiltinType* bi = canon.getBuiltin();
         return builtin2irtype(bi.getKind());
+    case Void:
+        return None;
     case Pointer:
         // TODO 32-bits
         return ir.Type.I64;

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -268,7 +268,7 @@ fn void Parser.errorAt(Parser* p, SrcLoc loc, const char* format @(printf_format
 fn void Parser.parseModule(Parser* p, bool is_interface, bool is_generated) {
     p.expectAndConsume(Kind.KW_module);
     // accept builtin types as module names
-    if (!p.tok.kind.isBuiltinType())
+    if (!p.tok.kind.isBuiltinTypeOrVoid())
         p.expectIdentifier();
 
     const char*modname = p.pool.idx2str(p.tok.name_idx);
@@ -789,7 +789,6 @@ const BuiltinKind[] Tok2builtin = {
     USize,      // KW_usize
     Float32,    // KW_f32
     Float64,    // KW_f64
-    Void,       // KW_void
 }
 
 fn BuiltinKind tokKindToBuiltinKind(token.Kind kind) {
@@ -805,6 +804,9 @@ fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref) {
     if (kind.isBuiltinType()) {
         ref.setBuiltin(tokKindToBuiltinKind(p.tok.kind), p.tok.loc);
         if (kind >= Kind.KW_reg8 && kind <= Kind.KW_reg64) ref.setVolatile();
+        p.consumeToken();
+    } else if (kind == KW_void) {
+        ref.setVoid(p.tok.loc);
         p.consumeToken();
     } else if (kind == Kind.Identifier) {
         p.parseFullTypeIdentifier(ref);

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -574,7 +574,7 @@ fn bool Parser.isTemplateFunctionCall(Parser* p) {
     Kind kind = p.peekToken(1);
     if (kind != Kind.Identifier) {
         if (kind.isQualifier()) return true;
-        return kind.isBuiltinType() && (p.peekToken(2) != Kind.Dot);
+        return kind.isBuiltinTypeOrVoid() && (p.peekToken(2) != Kind.Dot);
     }
 
     u32 stars = 0;
@@ -829,7 +829,7 @@ fn bool Parser.parseAsType(Parser* p) {
     Kind kind = p.tok.kind;
     if (kind != Kind.Identifier) {
         if (kind.isQualifier()) return true;
-        return kind.isBuiltinType() && (p.peekToken(1) != Kind.Dot);
+        return kind.isBuiltinTypeOrVoid() && (p.peekToken(1) != Kind.Dot);
     }
     Token t2 = p.tok;
     // parse potential member expression
@@ -887,7 +887,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
         if (ahead) p.peekToken2(ahead, &t2);
         ahead++;
         Kind kind = t2.kind;
-        if (kind.isBuiltinType()) {
+        if (kind.isBuiltinTypeOrVoid()) {
             // builtin type, non ambiguous
             ambiguous = false;
             break;

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -639,7 +639,7 @@ fn Stmt* Parser.parseGotoStmt(Parser* p) {
 fn bool Parser.isDeclaration(Parser* p) {
     const Kind kind = p.tok.kind;
     if (kind == Kind.Identifier) return p.isTypeSpec();
-    if (kind.isBuiltinType()) return true;
+    if (kind.isBuiltinTypeOrVoid()) return true;
     if (kind == Kind.KW_local) return true;
     if (kind.isQualifier()) return true;
     return false;

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -159,6 +159,10 @@ public fn bool Kind.isQualifier(Kind kind) {
 }
 
 public fn bool Kind.isBuiltinType(Kind kind) {
+    return kind >= Kind.KW_bool && kind < Kind.KW_void;
+}
+
+public fn bool Kind.isBuiltinTypeOrVoid(Kind kind) {
     return kind >= Kind.KW_bool && kind <= Kind.KW_void;
 }
 

--- a/recipe.txt
+++ b/recipe.txt
@@ -109,6 +109,7 @@ set ast
     ast/qualtype.c2
     ast/struct_type.c2
     ast/type_ref.c2
+    ast/void_type.c2
 
     # ast utility function
 	ast/array_value_list.c2

--- a/test/expr/binary/invalid_operands.c2
+++ b/test/expr/binary/invalid_operands.c2
@@ -943,7 +943,7 @@ fn void fun2() {
         f1() >>= d,    // @error{lvalue required as left operand of assignment}
 
         f1() + p,      // @error{invalid operand type 'void' for binary expression '+'}
-        f1() - p,      // @error{invalid operands to binary expression ('void' and 'char*')}
+        f1() - p,      // @error{invalid operand type 'void' for binary expression '-'}
         f1() * p,      // @error{invalid operands to binary expression ('void' and 'char*')}
         f1() / p,      // @error{invalid operands to binary expression ('void' and 'char*')}
         f1() % p,      // @error{invalid operands to binary expression ('void' and 'char*')}
@@ -952,12 +952,12 @@ fn void fun2() {
         f1() ^ p,      // @error{invalid operands to binary expression ('void' and 'char*')}
         f1() << p,     // @error{invalid operands to binary expression ('void' and 'char*')}
         f1() >> p,     // @error{invalid operands to binary expression ('void' and 'char*')}
-        f1() <= p,     // @error{invalid operands to binary expression ('void' and 'char*')}
-        f1() < p,      // @error{invalid operands to binary expression ('void' and 'char*')}
-        f1() == p,     // @error{invalid operands to binary expression ('void' and 'char*')}
-        f1() != p,     // @error{invalid operands to binary expression ('void' and 'char*')}
-        f1() >= p,     // @error{invalid operands to binary expression ('void' and 'char*')}
-        f1() > p,      // @error{invalid operands to binary expression ('void' and 'char*')}
+        f1() <= p,     // @error{invalid operand type 'void' for binary expression '<='}
+        f1() < p,      // @error{invalid operand type 'void' for binary expression '<'}
+        f1() == p,     // @error{invalid operand type 'void' for binary expression '=='}
+        f1() != p,     // @error{invalid operand type 'void' for binary expression '!='}
+        f1() >= p,     // @error{invalid operand type 'void' for binary expression '>='}
+        f1() > p,      // @error{invalid operand type 'void' for binary expression '>'}
         f1() += p,     // @error{lvalue required as left operand of assignment}
         f1() -= p,     // @error{lvalue required as left operand of assignment}
         f1() *= p,     // @error{lvalue required as left operand of assignment}
@@ -970,7 +970,7 @@ fn void fun2() {
         f1() >>= p,    // @error{lvalue required as left operand of assignment}
 
         f1() + vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() - vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
+        f1() - vp,     // @error{invalid operand type 'void' for binary expression '-'}
         f1() * vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() / vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() % vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
@@ -979,12 +979,12 @@ fn void fun2() {
         f1() ^ vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() << vp,    // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() >> vp,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() <= vp,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() < vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() == vp,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() != vp,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() >= vp,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() > vp,     // @error{invalid operands to binary expression ('void' and 'void*')}
+        f1() <= vp,    // @error{invalid operand type 'void' for binary expression '<='}
+        f1() < vp,     // @error{invalid operand type 'void' for binary expression '<'}
+        f1() == vp,    // @error{invalid operand type 'void' for binary expression '=='}
+        f1() != vp,    // @error{invalid operand type 'void' for binary expression '!='}
+        f1() >= vp,    // @error{invalid operand type 'void' for binary expression '>='}
+        f1() > vp,     // @error{invalid operand type 'void' for binary expression '>'}
         f1() += vp,    // @error{lvalue required as left operand of assignment}
         f1() -= vp,    // @error{lvalue required as left operand of assignment}
         f1() *= vp,    // @error{lvalue required as left operand of assignment}
@@ -1132,7 +1132,7 @@ fn void fun2() {
         f1() >>= 1.0,  // @error{lvalue required as left operand of assignment}
 
         f1() + nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() - nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
+        f1() - nil,    // @error{invalid operand type 'void' for binary expression '-'}
         f1() * nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() / nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() % nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
@@ -1141,12 +1141,12 @@ fn void fun2() {
         f1() ^ nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() << nil,   // @error{invalid operands to binary expression ('void' and 'void*')}
         f1() >> nil,   // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() <= nil,   // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() < nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() == nil,   // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() != nil,   // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() >= nil,   // @error{invalid operands to binary expression ('void' and 'void*')}
-        f1() > nil,    // @error{invalid operands to binary expression ('void' and 'void*')}
+        f1() <= nil,   // @error{invalid operand type 'void' for binary expression '<='}
+        f1() < nil,    // @error{invalid operand type 'void' for binary expression '<'}
+        f1() == nil,   // @error{invalid operand type 'void' for binary expression '=='}
+        f1() != nil,   // @error{invalid operand type 'void' for binary expression '!='}
+        f1() >= nil,   // @error{invalid operand type 'void' for binary expression '>='}
+        f1() > nil,    // @error{invalid operand type 'void' for binary expression '>'}
         f1() += nil,   // @error{lvalue required as left operand of assignment}
         f1() -= nil,   // @error{lvalue required as left operand of assignment}
         f1() *= nil,   // @error{lvalue required as left operand of assignment}

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -125,7 +125,7 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         ctx.offset = tok.loc + (u32)strlen(str);
         return;
     }
-    if (tok.kind.isBuiltinType()) {
+    if (tok.kind.isBuiltinTypeOrVoid()) {
         const char* str = tok.kind.str();
         out.color(col_type);
         out.add(str);


### PR DESCRIPTION
* remove `BuiltinType.isChar()`, `BuiltinType.isInt8()`, `BuiltinType.isUInt8()`, `QualType.isInt8()`
* add `QualType.isCharCompatible()`
* remove `Void` builtin type, add `Void` `TypeKind` and `TypeRefKind`
* simplify binary operation dispatch
* fix unary type checking, detect more type errors