### PR TITLE
Analyser: fix conversion errors on ambiguous cases

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -342,13 +342,15 @@ fn bool Checker.checkIntConversion(Checker* c, const BuiltinType* bi) {
     ExprWidth w = getExprWidth(e);
     //stdio.printf("INT CONVERSION signed|width: %d %d -> %d %d\n", w.is_signed, w.width, bi.isSigned(), w.width);
 
+    if (w.width > wl) return false;
+
     if (w.is_signed != bi.isSigned()) {
-        // dont allow signed -> unsigned: fully defined but requires explicit cast in c2
-        if (w.is_signed) return false;
         // allow unsigned -> signed only if value is preserved (eg. u16 fits in i32)
-        return w.width < wl;
+        if (!w.is_signed) return w.width < wl;
+        // only allow signed -> unsigned if positive: fully defined but requires explicit cast in c2
+        if (!e.isPositiveOrUB()) return false;
     }
-    return w.width <= wl;
+    return true;
 }
 
 // Note: try to fix array type that has been decayed to a pointer

--- a/analyser/conversion_checker_expr.c2
+++ b/analyser/conversion_checker_expr.c2
@@ -216,7 +216,13 @@ fn ExprWidth getTypeWidth(QualType qt) {
     qt = qt.getCanonicalType();
     if (qt.isEnum()) {
         EnumType* et = qt.getEnumType();
-        qt = et.getImplType();
+        //qt = et.getImplType();
+        EnumTypeDecl* etd = et.getDecl();
+        u32 num = etd.getNumConstants();
+        EnumConstantDecl** constants = etd.getConstants();
+        Value vmax = constants[num - 1].getValue();
+        ExprWidth result = { .width = vmax.getWidth() }
+        return result;
     }
     if (qt.isBuiltin()) {
         const BuiltinType* bi = qt.getBuiltin();

--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -675,7 +675,8 @@ fn QualType Analyser.analyseBinaryOperator(Analyser* ma, Expr** e_ptr) {
     if (opcode == BinaryOpcode.Assign) {
         if (!ma.analyseInitExpr(b.getRHS2(), ltype, e.getLoc(), false, false))
             return QualType_Invalid;
-        rtype = b.getRHS().getType();
+        //rtype = b.getRHS().getType();
+        return ltype;
     } else {
         rtype = ma.analyseExpr(b.getRHS2(), true, RHS);
     }

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -352,6 +352,87 @@ public fn bool Expr.isBitfield(const Expr* e) {
     return m.isBitfield();
 }
 
+public fn bool Expr.isPositiveOrUB(const Expr* e) {
+    switch (e.getKind()) {
+    case IntegerLiteral:
+    case FloatLiteral:
+    case BooleanLiteral:
+    case CharLiteral:
+        return true;
+    case StringLiteral:
+    case Nil:
+    case Identifier:
+    case Type:
+    case Call:
+    case InitList:
+    case FieldDesignatedInit:
+    case ArrayDesignatedInit:
+        break;
+    case BinaryOperator:
+        BinaryOperator* b = (BinaryOperator*)e;
+        switch (b.getOpcode()) {
+        case Multiply:
+        case Divide:
+        case Remainder:
+        case Add:
+        case Subtract:
+            return b.getLHS().isPositiveOrUB() && b.getRHS().isPositiveOrUB();
+        case ShiftLeft:
+        case ShiftRight:
+        case LessThan:
+        case GreaterThan:
+        case LessEqual:
+        case GreaterEqual:
+        case Equal:
+        case NotEqual:
+        case And:
+        case Xor:
+        case Or:
+        case LAnd:
+        case LOr:
+            return true;
+        default:
+            break;
+        }
+        break;
+    case UnaryOperator:
+        UnaryOperator* u = (UnaryOperator*)e;
+        switch (u.getOpcode()) {
+        case Plus:
+            return u.getInner().isPositiveOrUB();
+        case Minus:
+            return false;
+        case Not:
+        case LNot:
+            return true;
+        default:
+            break;
+        }
+        break;
+    case ConditionalOperator:
+        ConditionalOperator* c = (ConditionalOperator*)e;
+        return c.getLHS().isPositiveOrUB() && c.getRHS().isPositiveOrUB();
+    case Builtin:
+        return true;
+    case ArraySubscript:
+    case Member:
+        break;
+    case Paren:
+        return ((ParenExpr*)e).getInner().isPositiveOrUB();
+    case BitOffset:
+        break;
+    case ExplicitCast:
+    case ImplicitCast:
+        return ((ImplicitCastExpr*)e).getInner().isPositiveOrUB();
+    case Range:
+    case NamedArgument:
+        break;
+    case Alternate:
+        return ((AlternateExpr*)e).getOriginal().isPositiveOrUB();
+    }
+    return false;
+}
+
 public fn SrcLoc Expr.getLoc(const Expr* e) { return e.base.loc; }
 
 public fn SrcLoc Expr.getStartLoc(const Expr* e) {

--- a/test/types/conversion/shift_convert.c2
+++ b/test/types/conversion/shift_convert.c2
@@ -4,6 +4,10 @@ module test;
 type Enum enum u8 { A, B }
 
 fn void test1(Enum e) {
-    u32 v = e << 30;   // @error{implicit conversion changes signedness: 'i32' to 'u32'}
+    u32 v = e << 30;
+}
+
+fn u32 test2(Enum e) {
+    return e << 30;
 }
 


### PR DESCRIPTION
* improve `getTypeWidth()` on enums: use width of max value
* simplify `analyseBinaryOperator()` for simple assignments
* add `Expr.isPositiveOrUB()` to refine sign conversion checking
* refine checkIntConversion() for ambiguous sign conversions

Fixes #410