### PR TITLE
Compiler: simplify attribute support

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -18,7 +18,7 @@ module module_analyser;
 import ast local;
 import ast_context;
 import ast_builder;
-import attr;
+import attr local;
 import conversion_checker as conv;
 import diagnostics;
 import file_utils;
@@ -557,7 +557,7 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
     }
 
     const AST* a = d.getAST();
-    const attr.Value* embed = a.getAttr(d, attr.AttrKind.Embed);
+    const Attr* embed = a.getAttr(d, Embed);
 
     if (canon.isArray() && !ref.isIncrArray()) {
         const ArrayType* at = canon.getArrayType();
@@ -589,7 +589,7 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
         }
 
         // open file, copy contents to StringPool and close
-        const char* filename = ma.astPool.idx2str(embed.text);
+        const char* filename = ma.astPool.idx2str(embed.value.text);
         file_utils.File reader.init("", filename);
         if (!reader.load()) {
             ma.error(embed.loc, "error opening embedded file '%s': %s", filename, reader.getError());
@@ -641,12 +641,12 @@ fn void Analyser.checkVarDeclAttributes(Analyser* ma, VarDecl* v) {
 
         const AST* a = d.getAST();
 
-        const attr.Value* section = a.getAttr(d, attr.AttrKind.Section);
+        const Attr* section = a.getAttr(d, Section);
         if (section) {
             ma.error(section.loc, "attribute 'section' cannot be applied to constants");
         }
 
-        const attr.Value* aligned = a.getAttr(d, attr.AttrKind.Aligned);
+        const Attr* aligned = a.getAttr(d, Aligned);
         if (aligned) {
             ma.error(aligned.loc, "attribute 'aligned' cannot be applied to constants");
         }

--- a/ast/ast.c2
+++ b/ast/ast.c2
@@ -15,7 +15,7 @@
 
 module ast;
 
-import attr;
+import attr local;
 import attr_table;
 import src_loc local;
 import string_buffer;
@@ -252,18 +252,13 @@ fn Decl* AST.findType(const AST* a, u32 name_idx) {
 }
 
 // note: these will be called sequentially for same decl
-public fn void AST.storeAttr(AST* a,
-                               Decl* d,
-                               attr.AttrKind kind,
-                               const attr.Value* value)
+public fn void AST.storeAttr(AST* a, Decl* d, const Attr* at)
 {
     if (!a.attrs) a.attrs = attr_table.create();
-    a.attrs.add(d, kind, value);
+    a.attrs.add(d, at);
 }
 
-public fn const attr.Value* AST.getAttr(const AST* a,
-                                          const Decl* d,
-                                          attr.AttrKind kind)
+public fn const Attr* AST.getAttr(const AST* a, const Decl* d, AttrKind kind)
 {
     if (a.attrs) return a.attrs.find(d, kind);
     return nil;

--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -16,7 +16,7 @@
 module ast;
 
 import src_loc local;
-import attr;
+import attr local;
 import string_buffer;
 import stdio;
 
@@ -291,8 +291,8 @@ public fn const char* Decl.getCName(const Decl* d) {
     if (!d.hasAttr()) return nil;
 
     const AST* a = d.getAST();
-    const attr.Value* cname = a.getAttr(d, attr.AttrKind.CName);
-    if (cname) return idx2name(cname.text);
+    const Attr* cname = a.getAttr(d, CName);
+    if (cname) return idx2name(cname.value.text);
     return nil;
 }
 
@@ -300,7 +300,7 @@ public fn bool Decl.hasCName(const Decl* d) {
     if (!d.hasAttr()) return false;
 
     const AST* a = d.getAST();
-    const attr.Value* cname = a.getAttr(d, attr.AttrKind.CName);
+    const Attr* cname = a.getAttr(d, CName);
     return cname;
 }
 
@@ -308,8 +308,8 @@ public fn const char* Decl.getCDef(const Decl* d) {
     if (!d.hasAttr()) return nil;
 
     const AST* a = d.getAST();
-    const attr.Value* cdef = a.getAttr(d, attr.AttrKind.CDef);
-    if (cdef) return idx2name(cdef.text);
+    const Attr* cdef = a.getAttr(d, CDef);
+    if (cdef) return idx2name(cdef.value.text);
     return nil;
 }
 
@@ -317,8 +317,8 @@ public fn const char* Decl.getSection(const Decl* d) {
     if (!d.hasAttr()) return nil;
 
     const AST* a = d.getAST();
-    const attr.Value* section = a.getAttr(d, attr.AttrKind.Section);
-    if (section) return idx2name(section.text);
+    const Attr* section = a.getAttr(d, Section);
+    if (section) return idx2name(section.value.text);
     return nil;
 }
 
@@ -432,25 +432,25 @@ fn void Decl.printAttrs(const Decl* d, string_buffer.Buf* out) {
 
     const AST* a = d.getAST();
     // Note: just request 4 here, ideally we should iterate over all
-    const attr.Value* cname = a.getAttr(d, attr.AttrKind.CName);
+    const Attr* cname = a.getAttr(d, CName);
     if (cname) {
         out.color(col_Attr);
-        out.print(" cname='%s'", idx2name(cname.text));
+        out.print(" cname='%s'", idx2name(cname.value.text));
     }
-    const attr.Value* cdef = a.getAttr(d, attr.AttrKind.CDef);
+    const Attr* cdef = a.getAttr(d, CDef);
     if (cdef) {
         out.color(col_Attr);
-        out.print(" cdef='%s'", idx2name(cdef.text));
+        out.print(" cdef='%s'", idx2name(cdef.value.text));
     }
-    const attr.Value* section = a.getAttr(d, attr.AttrKind.Section);
+    const Attr* section = a.getAttr(d, Section);
     if (section) {
         out.color(col_Attr);
-        out.print(" section='%s'", idx2name(section.text));
+        out.print(" section='%s'", idx2name(section.value.text));
     }
-    const attr.Value* embed = a.getAttr(d, attr.AttrKind.Embed);
+    const Attr* embed = a.getAttr(d, Embed);
     if (embed) {
         out.color(col_Attr);
-        out.print(" embed='%s'", idx2name(embed.text));
+        out.print(" embed='%s'", idx2name(embed.value.text));
     }
 }
 

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -15,7 +15,7 @@
 
 module ast;
 
-import attr;
+import attr local;
 import color local;
 import ast_context local;
 import string_buffer;
@@ -115,8 +115,6 @@ public type Globals struct @(opaque) {
     u32[elemsof(BuiltinKind)] builtinType_width;
     BuiltinKind[elemsof(BuiltinKind)] builtinType_baseTypes;
 
-    u32[elemsof(attr.AttrKind)] attr_name_indexes;
-
     string_buffer.Buf* dump_buf;
 #if AstStatistics
     Stats stats;
@@ -130,10 +128,7 @@ Globals* globals;
 public fn Globals* getGlobals() { return globals; }
 
 // only used by plugins
-public fn void setGlobals(Globals* g) @(unused){
-    globals = g;
-    attr.initialize(g.attr_name_indexes);
-}
+public fn void setGlobals(Globals* g) @(unused) { globals = g; }
 
 // wordsize in bytes, must NOT be called from Plugin!
 public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, bool use_color) {
@@ -180,9 +175,6 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
         globals.builtinType_baseTypes[BuiltinKind.ISize] = BuiltinKind.Int64;
         globals.builtinType_baseTypes[BuiltinKind.USize] = BuiltinKind.UInt64;
     }
-
-    attr.register(astPool, globals.attr_name_indexes);
-    attr.initialize(globals.attr_name_indexes);
 }
 
 public fn void deinit(bool print_stats) {
@@ -329,5 +321,5 @@ Color col_Error = Color.Red;
 Color col_Calc = Color.Yellow;    // all calculated value
 Color col_Normal = Color.Normal;
 
-public type AttrHandlerFn fn bool (void* arg, Decl* d, const attr.Attr* a);
+public type AttrHandlerFn fn bool (void* arg, Decl* d, const Attr* a);
 

--- a/ast_utils/attr.c2
+++ b/ast_utils/attr.c2
@@ -71,14 +71,14 @@ const char*[] attrKind_names = {
 
 static_assert(elemsof(AttrKind), elemsof(attrKind_names));
 
-public type ValueKind enum u8 {
+public type AttrValueKind enum u8 {
     None,
     Number,
     String,
 }
 
 // Note: Value itself does not need to know the kind
-public type Value struct {
+public type AttrValue struct {
     SrcLoc loc;
     union {
         u32 text;
@@ -87,40 +87,38 @@ public type Value struct {
 }
 
 public type Attr struct {
+    void* decl;
     u32 name;  // needed for unknown attributes
-    AttrKind kind;
-    ValueKind value_kind;
     SrcLoc loc;
-    Value value;
+    AttrKind kind;
+    AttrValueKind value_kind;
+    AttrValue value;
 }
+static_assert(32, sizeof(Attr));
 
 // Note: only meant for printing (since not allocated in StringPool)
-public fn const char* kind2name(AttrKind k) {
-    return attrKind_names[k];
+public fn const char* Attr.kind2name(const Attr* a) {
+    return attrKind_names[a.kind];
 }
 
-public fn void register(string_pool.Pool* pool, u32* indexes) {
+public type AttrRegistry struct {
+    u32[elemsof(AttrKind)] name_indexes;
+}
+
+public fn void AttrRegistry.init(AttrRegistry* ar, string_pool.Pool* pool) {
     // skip unknown attribute
-    indexes[0] = 0;
-    for (u32 i=1; i<elemsof(attrKind_names); i++) {
-        indexes[i] = pool.addStr(attrKind_names[i], true);
+    ar.name_indexes[0] = 0;
+    for (u32 i = 1; i < elemsof(AttrKind); i++) {
+        ar.name_indexes[i] = pool.addStr(attrKind_names[i], true);
     }
 }
 
-// Note: this is different per plugin!
-const u32* name_indexes;
-
-public fn void initialize(const u32* indexes) {
-    name_indexes = indexes;
-}
-
-public fn AttrKind find(u32 name_idx) {
+public fn AttrKind AttrRegistry.find(AttrRegistry* ar, u32 name_idx) {
     // skip unused
-    for (u32 i=1; i<elemsof(AttrKind); i++) {
-        if (name_idx == name_indexes[i]) return (AttrKind)i;
+    for (u32 i = 1; i < elemsof(AttrKind); i++) {
+        if (name_idx == ar.name_indexes[i]) return (AttrKind)i;
     }
-
-    return AttrKind.Unknown;
+    return Unknown;
 }
 
 const AttrReq[] Required_arg = {
@@ -162,30 +160,30 @@ fn bool isPowerOf2(u32 val) {
     return val && !(val & (val - 1));
 }
 
-public fn AttrReq check(const Attr* a) {
+public fn AttrReq Attr.checkArgument(const Attr* a) {
     switch (Required_arg[a.kind]) {
     case NoArg:
-        if (a.value_kind != ValueKind.None) return AttrReq.NoArg;
+        if (a.value_kind != None) return NoArg;
         break;
     case Number:
         switch (a.value_kind) {
         case None:
-            return AttrReq.Arg;
+            return Arg;
         case Number:
-            if (a.kind == AttrKind.Aligned) {
-                if (!isPowerOf2(a.value.number)) return AttrReq.Power2;
+            if (a.kind == Aligned) {
+                if (!isPowerOf2(a.value.number)) return Power2;
             }
             break;
         case String:
-            return AttrReq.Number;
+            return Number;
         }
         break;
     case String:
         switch (a.value_kind) {
         case None:
-            return AttrReq.Arg;
+            return Arg;
         case Number:
-            return AttrReq.String;
+            return String;
         case String:
             break;
         }
@@ -193,6 +191,6 @@ public fn AttrReq check(const Attr* a) {
     default:
         break;
     }
-    return AttrReq.Ok;
+    return Ok;
 }
 

--- a/ast_utils/attr_table.c2
+++ b/ast_utils/attr_table.c2
@@ -15,18 +15,10 @@
 
 module attr_table;
 
-import attr;
+import attr local;
 
 import stdlib;
 import string;
-
-type Attr struct {
-    void* decl;
-    attr.Value value;
-    attr.AttrKind kind;
-}
-
-static_assert(24, sizeof(Attr));
 
 public type Table struct @(opaque) {
     // use vector<Attr>
@@ -56,26 +48,21 @@ fn void Table.resize(Table* t, u32 capacity) {
     t.attrs = attrs2;
 }
 
-public fn void Table.add(Table* t,
-                         void* decl,
-                         attr.AttrKind kind,
-                         const attr.Value* value)
-{
+public fn void Table.add(Table* t, void* decl, const Attr* at) {
     // IDEA: TODO search for other Attrs that are the same for section?
 
     if (t.count == t.capacity) t.resize(t.capacity * 2);
 
     Attr* a = &t.attrs[t.count];
+    *a = *at;
     a.decl = decl;
-    a.value = *value;
-    a.kind = kind;
     t.count++;
 }
 
-public fn const attr.Value* Table.find(const Table* t, const void* decl, attr.AttrKind kind) {
+public fn const Attr* Table.find(const Table* t, const void* decl, AttrKind kind) {
     for (u32 i=0; i<t.count; i++) {
         const Attr* a = &t.attrs[i];
-        if (a.decl == decl && a.kind == kind) return &a.value;
+        if (a.decl == decl && a.kind == kind) return a;
     }
     return nil;
 }

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -26,9 +26,8 @@ import src_loc local;
 import string_pool;
 
 import stdlib local;
-import string;
 
-public type Builder struct  @(opaque) {
+public type Builder struct @(opaque) {
     Context* context;           // no ownership
     diagnostics.Diags* diags;   // no ownership
     string_pool.Pool* auxPool;  // no ownership
@@ -342,7 +341,7 @@ public fn VarDecl* Builder.actOnVarDecl(Builder* b,
 
 fn void Builder.storeAttr(Builder* b, Decl* d, const Attr* a) {
     d.setHasAttr();
-    b.ast.storeAttr(d, a.kind, &a.value);
+    b.ast.storeAttr(d, a);
 }
 
 public fn void Builder.actOnArrayValue(Builder* b,
@@ -352,21 +351,6 @@ public fn void Builder.actOnArrayValue(Builder* b,
 {
     ArrayValue* avd = ArrayValue.create(b.context, name, loc, initValue);
     b.ast.addArrayValue(avd);
-}
-
-fn bool Builder.checkAttr(Builder* b, const Attr* a) {
-    switch (a.kind) {
-    case CName:
-    case CDef:
-        if (!b.is_interface) {
-            b.diags.error(a.loc, "attribute 'cname' can only be used in interface files");
-            return false;
-        }
-        break;
-    default:
-        break;
-    }
-    return true;
 }
 
 fn void Builder.actOnFunctionAttr(Builder* b, Decl* d, const Attr* a) {
@@ -409,13 +393,13 @@ fn void Builder.actOnFunctionAttr(Builder* b, Decl* d, const Attr* a) {
         fd.setAttrPure();
         break;
     default:
-        b.diags.error(a.loc, "attribute '%s' is not applicable to functions", kind2name(a.kind));
+        b.diags.error(a.loc, "attribute '%s' is not applicable to functions", a.kind2name());
         break;
     }
 }
 
 fn void Builder.actOnStructAttr(Builder* b, Decl* d, const Attr* a) {
-    StructTypeDecl* std =(StructTypeDecl*)d;
+    StructTypeDecl* std = (StructTypeDecl*)d;
 
     switch (a.kind) {
     case Export:
@@ -429,7 +413,7 @@ fn void Builder.actOnStructAttr(Builder* b, Decl* d, const Attr* a) {
         break;
     case Section:
         b.diags.error(a.loc, "attribute '%s' cannot be applied to type declarations",
-                kind2name(a.kind));
+                      a.kind2name());
         break;
     case Aligned:
         std.setAttrAlignment(a.value.number);
@@ -448,12 +432,12 @@ fn void Builder.actOnStructAttr(Builder* b, Decl* d, const Attr* a) {
             std.setAttrNoTypeDef();
         } else {
             b.diags.error(a.loc, "attribute '%s' can only be used in interfaces",
-                kind2name(a.kind));
+                          a.kind2name());
         }
         break;
     default:
         b.diags.error(a.loc, "attribute '%s' is not applicable to structs",
-                kind2name(a.kind));
+                      a.kind2name());
         break;
     }
 }
@@ -465,21 +449,21 @@ fn bool Builder.actOnTypeAttr(Builder* b, Decl* d, const Attr* a) {
         break;
     case Packed:
         b.diags.error(a.loc, "attribute '%s' can only be applied to struct/union types",
-                kind2name(a.kind));
+                      a.kind2name());
         return false;
     case Unused:
         d.setAttrUnused();
         break;
     case Opaque:
         b.diags.error(a.loc, "attribute '%s' can only be applied to struct/union types",
-                kind2name(a.kind));
+                      a.kind2name());
         return false;
     case CName:
         b.storeAttr(d, a);
         break;
     default:
         b.diags.error(a.loc, "attribute '%s' is not applicable to Enum/Alias types",
-                kind2name(a.kind));
+                      a.kind2name());
         return false;
     }
     return true;
@@ -487,6 +471,11 @@ fn bool Builder.actOnTypeAttr(Builder* b, Decl* d, const Attr* a) {
 
 fn void Builder.actOnVarAttr(Builder* b, Decl* d, const Attr* a) {
     VarDecl* vd = (VarDecl*)d;
+
+    if (vd.getKind() == FunctionParam) {
+        b.actOnParamAttr(vd, a);
+        return;
+    }
 
     switch (a.kind) {
     case Export:
@@ -514,14 +503,14 @@ fn void Builder.actOnVarAttr(Builder* b, Decl* d, const Attr* a) {
         break;
     default:
         b.diags.error(a.loc, "attribute '%s' is not applicable to variables",
-                kind2name(a.kind));
+                      a.kind2name());
         break;
     }
 }
 
 public fn bool Builder.hasOpaqueAttr(Builder* b) {
     for (u32 i=0; i<b.num_attrs; i++) {
-        const attr.Attr* a = &b.attrs[i];
+        const Attr* a = &b.attrs[i];
         if (b.attrs[i].kind == Opaque) return true;
     }
     return false;
@@ -529,23 +518,14 @@ public fn bool Builder.hasOpaqueAttr(Builder* b) {
 
 public fn bool Builder.hasEmbedAttr(Builder* b) {
     for (u32 i=0; i<b.num_attrs; i++) {
-        const attr.Attr* a = &b.attrs[i];
+        const Attr* a = &b.attrs[i];
         if (b.attrs[i].kind == Embed) return true;
     }
     return false;
 }
 
-public fn bool Builder.actOnParamAttr(Builder* b,
-                                      VarDecl* d,
-                                      u32 name,
-                                      SrcLoc loc)
-{
-    AttrKind kind = attr.find(name);
-    switch (kind) {
-    case Unknown:
-        // TODO should be a warning
-        b.diags.error(loc, "unknown attribute '%s'", ast.idx2name(name));
-        return false;
+fn bool Builder.actOnParamAttr(Builder* b, VarDecl* d, const Attr* a) {
+    switch (a.kind) {
     case PrintfFormat:
         d.setPrintfFormat();
         return true;
@@ -562,41 +542,44 @@ public fn bool Builder.actOnParamAttr(Builder* b,
         d.setAttrAutoFunc();
         return true;
     default:
-        b.diags.error(loc, "attribute '%s' cannot be applied to function parameters",
-                      ast.idx2name(name));
+        b.diags.error(a.loc, "attribute '%s' cannot be applied to function parameters",
+                      ast.idx2name(a.name));
         return false;
     }
-    b.diags.error(loc, "invalid combination of attributes");
+    b.diags.error(a.loc, "invalid combination of attributes");
     return false;
 }
 
-public fn void Builder.actOnAttr(Builder* b, attr.Attr* a) {
-    a.kind = attr.find(a.name);
+public fn bool Builder.actOnAttr(Builder* b, const Attr* a) {
+    switch (a.kind) {
+    case CName:
+    case CDef:
+        if (!b.is_interface) {
+            b.diags.error(a.loc, "attribute '%s' can only be used in interface files", a.kind2name());
+            return false;
+        }
+        break;
+    default:
+        break;
+    }
 
-    if (!b.checkAttr(a)) return;
-
-    if (a.kind != AttrKind.Unknown) {
-        AttrReq req = attr.check(a);
-        switch (req) {
+    if (a.kind != Unknown) {
+        switch (a.checkArgument()) {
         case NoArg:
-            b.diags.error(a.loc, "attribute '%s' has no argument",
-                kind2name(a.kind));
-            return;
+            b.diags.error(a.loc, "attribute '%s' has no argument", a.kind2name());
+            return false;
         case Arg:
-            b.diags.error(a.loc, "attribute '%s' needs an argument",
-                kind2name(a.kind));
-            return;
+            b.diags.error(a.loc, "attribute '%s' needs an argument", a.kind2name());
+            return false;
         case Number:
-            b.diags.error(a.value.loc, "attribute '%s' needs a number argument",
-                kind2name(a.kind));
-            return;
+            b.diags.error(a.value.loc, "attribute '%s' needs a number argument", a.kind2name());
+            return false;
         case String:
-            b.diags.error(a.value.loc, "attribute '%s' needs a string argument",
-                kind2name(a.kind));
-            return;
+            b.diags.error(a.value.loc, "attribute '%s' needs a string argument", a.kind2name());
+            return false;
         case Power2:
             b.diags.error(a.value.loc, "requested alignment is not a power of 2");
-            return;
+            return false;
         case Ok:
             break;
         }
@@ -605,11 +588,12 @@ public fn void Builder.actOnAttr(Builder* b, attr.Attr* a) {
     // always store attribute and apply later in applyAttributes()
     if (b.num_attrs == elemsof(b.attrs)) {
         b.diags.error(a.loc, "too many attributes");
-        return;
+        return false;
     }
 
-    string.memcpy(&b.attrs[b.num_attrs], a , sizeof(Attr));
+    b.attrs[b.num_attrs] = *a;
     b.num_attrs++;
+    return true;
 }
 
 public fn void Builder.clearAttributes(Builder* b) {
@@ -648,18 +632,19 @@ fn void Builder.applyAttribute(Builder* b, Decl* d, const Attr* a) {
     }
 }
 
-public fn void Builder.applyAttributes(Builder* b, Decl* d) {
+public fn void Builder.applyAttributes(Builder* b, Decl* d, u32 count) {
     assert(d);
-    for (u32 i=0; i<b.num_attrs; i++) {
-        const attr.Attr* a = &b.attrs[i];
+    assert(count <= b.num_attrs);
+    for (u32 i = 0; i < count; i++) {
+        const Attr* a = &b.attrs[b.num_attrs - count + i];
 
-        if (a.kind == AttrKind.Unknown) {
-            b.attr_handler.handle(d, a);
+        if (a.kind == Unknown) {
+            if (!b.attr_handler.handle(d, a)) b.storeAttr(d, a);
         } else {
             b.applyAttribute(d, a);
         }
     }
-    b.num_attrs = 0;
+    b.num_attrs -= count;
 }
 
 public fn QualType Builder.actOnBuiltinType(Builder*, BuiltinKind kind) {

--- a/common/attr_handler.c2
+++ b/common/attr_handler.c2
@@ -16,8 +16,9 @@
 module attr_handler;
 
 import ast;
-import attr;
+import attr local;
 import diagnostics;
+import warning_flags;
 
 import stdlib;
 import string;
@@ -30,15 +31,18 @@ type Entry struct {
 
 public type Handler struct @(opaque) {
     diagnostics.Diags* diags;   // no ownership
+    const warning_flags.Flags* warnings;
 
     Entry* entries;
     u32 count;
     u32 capacity;
 }
 
-public fn Handler* create(diagnostics.Diags* diags) {
+public fn Handler* create(diagnostics.Diags* diags,
+                          const warning_flags.Flags* warnings) {
     Handler* h = stdlib.calloc(1, sizeof(Handler));
     h.diags = diags;
+    h.warnings = warnings;
     return h;
 }
 
@@ -68,13 +72,14 @@ public fn bool Handler.register(Handler* h, u32 name, ast.AttrHandlerFn func, vo
     return true;
 }
 
-public fn bool Handler.handle(Handler* h, ast.Decl* d, const attr.Attr* a) {
+public fn bool Handler.handle(Handler* h, ast.Decl* d, const Attr* a) {
     for (u32 i=0; i<h.count; i++) {
         Entry* e = &h.entries[i];
         if (e.name == a.name) return e.func(e.arg, d, a);
     }
-    // TODO give unknown attr error here
-    h.diags.error(a.loc, "unknown attribute '%s'", ast.idx2name(a.name));
+    if (!h.warnings.no_unknown_attribute) {
+        h.diags.warn(a.loc, "unknown attribute '%s'", ast.idx2name(a.name));
+    }
     return false;
 }
 

--- a/common/build_target.c2
+++ b/common/build_target.c2
@@ -196,6 +196,7 @@ public fn void Target.disableWarnings(Target* t) {
     t.warnings.no_unused_label = true;
     t.warnings.no_unused_enum_constant = true;
     t.warnings.no_unreachable_code = true;
+    t.warnings.no_unknown_attribute = true;
 }
 
 public fn void Target.enableWarnings(Target* t) {
@@ -210,6 +211,7 @@ public fn void Target.enableWarnings(Target* t) {
     t.warnings.no_unused_label = false;
     t.warnings.no_unused_enum_constant = false;
     t.warnings.no_unreachable_code = false;
+    t.warnings.no_unknown_attribute = false;
 }
 
 public fn const warning_flags.Flags* Target.getWarnings(const Target* t) {

--- a/common/warning_flags.c2
+++ b/common/warning_flags.c2
@@ -27,6 +27,7 @@ public type Flags struct {
     bool no_unused_label;
     bool no_unused_enum_constant;
     bool no_unreachable_code;
+    bool no_unknown_attribute;
     bool are_errors;
 }
 

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -580,6 +580,9 @@ fn void Parser.parseWarnings(Parser* p) {
         case "unreachable-code":
             warnings.no_unreachable_code = disable;
             break;
+        case "unknown-attribute":
+            warnings.no_unknown_attribute = disable;
+            break;
         case "promote-to-error":
             warnings.are_errors = !disable;
             break;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -197,7 +197,7 @@ fn void Compiler.build(Compiler* c,
 
     c.parse_queue.init(false, 64);
 
-    c.attr_handler = attr_handler.create(diags);
+    c.attr_handler = attr_handler.create(diags, target.getWarnings());
     c.builder = ast_builder.create(c.context,
                                    diags,
                                    c.auxPool,

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -17,7 +17,7 @@ module c2_parser;
 
 import ast_builder local;
 import ast local;
-import attr;
+import attr local;
 import c2_tokenizer;
 import color;
 import constants;
@@ -65,6 +65,8 @@ public type Parser struct @(opaque) {
     u32 varargs_idx;
     u32 stdarg_idx;
 
+    AttrRegistry attr_registry;
+
     stmt_list.List* stmt_lists;
     u32 stmt_list_count;
 
@@ -89,6 +91,7 @@ public fn Parser* create(SourceMgr* sm,
     p.va_list_idx = pool.addStr("va_list", true);
     p.varargs_idx = pool.addStr("varargs", true);
     p.stdarg_idx = pool.addStr("stdarg", true);
+    p.attr_registry.init(pool);
 
     // create a stack of stmt_lists to re-use (resize stack if needed)
     p.stmt_lists = malloc(NumStmtLists * sizeof(stmt_list.List));
@@ -373,30 +376,32 @@ fn void Parser.parseTopLevel(Parser* p) {
                   name=<number>
 */
 
-// returns if embed attribute was seen
-fn void Parser.parseOptionalAttributes(Parser* p) {
-    if (p.tok.kind != Kind.At) return;
+fn bool findName(const u32* names, u32 count, u32 name) {
+    for (u32 i = 0; i < count; i++) {
+        if (names[i] == name) return true;
+    }
+    return false;
+}
+
+// returns the number of attributes parsed and stored in Builder
+fn u32 Parser.parseOptionalAttributes(Parser* p) {
+    if (p.tok.kind != Kind.At) return 0;
     p.consumeToken();
 
     p.expectAndConsume(Kind.LParen);
 
-    u32[16] dups;
+    u32[elemsof(AttrKind)] dups;
     u32 num_attrs = 0;
+    u32 count = 0;
 
     while (1) {
         p.expectIdentifier();
-        attr.Attr a;
-        a.name = p.tok.name_idx;
-        a.loc = p.tok.loc;
-        a.value_kind = attr.ValueKind.None;
-
-        assert(num_attrs < elemsof(dups));
-
-        for (u32 i=0; i<num_attrs; i++) {
-            if (dups[i] == a.name) p.error("duplicate attribute");
+        Attr a = {
+            .name = p.tok.name_idx,
+            .kind = p.attr_registry.find(p.tok.name_idx),
+            .value_kind = None,
+            .loc = p.tok.loc,
         }
-        dups[num_attrs++] = a.name;
-
         p.consumeToken();
 
         if (p.tok.kind == Kind.Equal) {
@@ -404,58 +409,43 @@ fn void Parser.parseOptionalAttributes(Parser* p) {
             a.value.loc = p.tok.loc;
             switch (p.tok.kind) {
             case StringLiteral:
-                a.value_kind = attr.ValueKind.String;
+                a.value_kind = String;
                 a.value.text = p.tok.text_idx;
                 if (p.tok.text_len == 0) {
+                    // TODO: should be tested in Attr.checkArgument()
                     p.error("attribute argument cannot be an empty string");
                 }
                 p.consumeToken();
                 break;
             case IntegerLiteral:
-                a.value_kind = attr.ValueKind.Number;
+                a.value_kind = Number;
                 // TODO: either check overflow or make it 64-bit
                 a.value.number = (u32)p.tok.int_value;
                 p.consumeToken();
                 break;
             default:
                 p.error("expected attribute argument");
-                return;
+                break;
             }
         }
-
-        p.builder.actOnAttr(&a);
+        if (findName(dups, num_attrs, a.name)) {
+            p.diags.error(a.loc, "duplicate attribute");
+        } else {
+            if (num_attrs >= elemsof(dups)) p.error("too many attributes");
+            dups[num_attrs++] = a.name;
+            count += p.builder.actOnAttr(&a);
+        }
 
         if (p.tok.kind != Kind.Comma) break;
         p.consumeToken();
     }
 
     p.expectAndConsume(Kind.RParen);
+    return count;
 }
 
-fn void Parser.parseParamOptionalAttributes(Parser* p, VarDecl* d) {
-    if (p.tok.kind != Kind.At) return;
-    p.consumeToken();
-
-    p.expectAndConsume(Kind.LParen);
-
-    bool has_error = false;
-    while (1) {
-        p.expectIdentifier();
-        u32 attr_id = p.tok.name_idx;
-        SrcLoc loc = p.tok.loc;
-        p.consumeToken();
-
-        if (p.tok.kind == Kind.Equal) {
-            p.error("a parameter attribute cannot have a value");
-        }
-        if (!has_error) {
-            has_error = !p.builder.actOnParamAttr(d, attr_id, loc);
-        }
-        if (p.tok.kind != Kind.Comma) break;
-        p.consumeToken();
-    }
-
-    p.expectAndConsume(Kind.RParen);
+fn void Parser.applyAttributes(Parser* p, Decl* d, u32 count) {
+    if (count) p.builder.applyAttributes(d, count);
 }
 
 fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
@@ -525,8 +515,8 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
 
     params.free();
 
-    p.parseOptionalAttributes();
-    p.builder.applyAttributes((Decl*)f);
+    u32 num_attr = p.parseOptionalAttributes();
+    p.applyAttributes((Decl*)f, num_attr);
 
     if (p.is_interface) {
         if (p.tok.kind == Kind.Semicolon) {
@@ -601,7 +591,8 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public, bool accept_default
                                                is_variadic,
                                                DefKind.Param);
         // TODO attributes?
-        //p.parseOptionalAttributes();
+        //u32 num_attr = p.parseOptionalAttributes();
+        //p.applyAttributes((Decl*)fd, num_attr);
         params.free();
 
         ref.setFunction((Decl*)fd);
@@ -639,7 +630,8 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public, bool accept_default
 
     VarDecl* param = p.builder.actOnFunctionParam(name, loc, is_public, &ref, assignLoc, initValue);
 
-    p.parseParamOptionalAttributes(param);
+    u32 num_attr = p.parseOptionalAttributes();
+    p.applyAttributes((Decl*)param, num_attr);
 
     return param;
 }
@@ -707,7 +699,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
         Expr* initValue = nil;
         SrcLoc assignLoc = 0;
 
-        p.parseOptionalAttributes();
+        u32 num_attr = p.parseOptionalAttributes();
 
         switch (p.tok.kind) {
         case Equal:
@@ -728,7 +720,7 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
 
         bool has_embed = p.builder.hasEmbedAttr();
         Decl* d = p.builder.actOnGlobalVarDecl(name, loc, is_public, &ref, assignLoc, has_embed, initValue);
-        p.builder.applyAttributes(d);
+        p.applyAttributes(d, num_attr);
 
         if (p.tok.kind != Kind.Comma)
             break;

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -67,17 +67,17 @@ fn void Parser.parseFunctionType(Parser* p, u32 name, SrcLoc loc, bool is_public
                                                 (VarDecl**)params.getDecls(),
                                                 params.size(),
                                                 is_variadic);
-    p.parseOptionalAttributes();
+    u32 num_attr = p.parseOptionalAttributes();
     params.free();
 
     p.expectAndConsume(Kind.Semicolon);
-    p.builder.applyAttributes(ftd);
+    p.applyAttributes(ftd, num_attr);
 }
 
 fn void Parser.parseStructType(Parser* p, bool is_struct, u32 name, SrcLoc loc, bool is_public) {
     p.consumeToken();
 
-    p.parseOptionalAttributes();
+    u32 num_attr = p.parseOptionalAttributes();
 
     DeclList members.init();
 
@@ -97,8 +97,7 @@ fn void Parser.parseStructType(Parser* p, bool is_struct, u32 name, SrcLoc loc, 
                                                   members.size());
     members.free();
 
-    p.builder.applyAttributes((Decl*)d);
-
+    p.applyAttributes((Decl*)d, num_attr);
 }
 
 fn void Parser.checkMemberName(Parser* p) {
@@ -168,7 +167,8 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
                                                    is_variadic,
                                                    DefKind.StructMember);
             // TODO attributes?
-            //p.parseOptionalAttributes();
+            //u32 num_attr = p.parseOptionalAttributes();
+            //p.applyAttributes((Decl*)fd, num_attr);
             params.free();
 
             TypeRefHolder ref.init();
@@ -263,7 +263,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
     QualType implType = p.builder.actOnBuiltinType(tokKindToBuiltinKind(p.tok.kind));
     p.consumeToken();
 
-    p.parseOptionalAttributes();
+    u32 num_attr = p.parseOptionalAttributes();
 
     p.expectAndConsume(Kind.LBrace);
 
@@ -320,7 +320,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
 
     constants.free();
 
-    p.builder.applyAttributes(d);
+    p.applyAttributes(d, num_attr);
 }
 
 fn void Parser.parseAliasType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
@@ -328,8 +328,8 @@ fn void Parser.parseAliasType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
     p.parseTypeSpecifier(&ref);
 
     Decl* d = p.builder.actOnAliasType(name, loc, is_public, &ref);
-    p.parseOptionalAttributes();
+    u32 num_attr = p.parseOptionalAttributes();
     p.expectAndConsume(Kind.Semicolon);
-    p.builder.applyAttributes(d);
+    p.applyAttributes(d, num_attr);
 }
 

--- a/plugins/unit_test_plugin.c2
+++ b/plugins/unit_test_plugin.c2
@@ -16,7 +16,7 @@
 module plugin_main;
 
 import ast local;
-import attr;
+import attr local;
 import console;
 import plugin_info;
 import string_buffer;
@@ -91,9 +91,9 @@ fn void generate_types(Plugin *p) {
     p.info.addSource(p.info.fn_arg, "generated", out);
 }
 
-fn bool handle_attr(void* arg, Decl* d, const attr.Attr* a) {
+fn bool handle_attr(void* arg, Decl* d, const Attr* a) {
     Plugin* p = arg;
-    assert(a.name  == p.attr_name);
+    assert(a.name == p.attr_name);
 
     if (!d.isStructType()) {
         p.info.diags.error(a.loc, "attribute 'unittest' can only be applied to structs");

--- a/recipe.txt
+++ b/recipe.txt
@@ -393,6 +393,7 @@ executable c2cat
 	$warnings no-unused
 	$backend c
 
+    ast_utils/attr.c2
     ast_utils/color.c2
     ast_utils/constants.c2
     ast_utils/number_radix.c2

--- a/test/attr/function_param_other_attr.c2
+++ b/test/attr/function_param_other_attr.c2
@@ -3,3 +3,10 @@ module test;
 fn void run(i32 a @(unused)) { // @error{attribute 'unused' cannot be applied to function parameters}
 }
 
+fn void run2(i32 a @(weak),            // @error{attribute 'weak' cannot be applied to function parameters}
+             i32 b @(export),          // @error{attribute 'export' cannot be applied to function parameters}
+             i32 c @(embed="file.c2"), // @error{attribute 'embed' cannot be applied to function parameters}
+             i32 d @(packed),          // @error{attribute 'packed' cannot be applied to function parameters}
+             i32 e @(section="test"),  // @error{attribute 'section' cannot be applied to function parameters}
+             i32 f @(aligned=8),       // @error{attribute 'aligned' cannot be applied to function parameters}
+             i32 g @(cname="ggg")) {}  // @error{attribute 'cname' can only be used in interface files}

--- a/test/auto_args/auto_arg_both.c2
+++ b/test/auto_args/auto_arg_both.c2
@@ -8,8 +8,20 @@ fn void log1(u32 line @(auto_line, auto_file)) {    // @error{invalid combinatio
 fn void log2(const char* line @(auto_line, auto_file)) {    // @error{invalid combination of attributes}
 }
 
-fn void log3(const char* line @(auto_file, auto_func)) {    // @error{invalid combination of attributes}
+fn void log3(const char* file @(auto_file, auto_func)) {    // @error{invalid combination of attributes}
 }
 
-fn void log4(const char* line @(auto_file, auto_line, auto_func)) {    // @error{invalid combination of attributes}
+fn void log4(const char* line @(auto_file,
+                                auto_line,      // @error{invalid combination of attributes}
+                                auto_func)) {   // @error{invalid combination of attributes}
 }
+
+fn void logd1(u32 line @(auto_line, auto_line)) {    // @error{duplicate attribute}
+}
+
+fn void logd2(const char* file @(auto_file, auto_file)) {    // @error{duplicate attribute}
+}
+
+fn void logd3(const char* func @(auto_func, auto_func)) {    // @error{duplicate attribute}
+}
+

--- a/test/parser/attributes/cname_non_interface.c2
+++ b/test/parser/attributes/cname_non_interface.c2
@@ -6,3 +6,8 @@ public type Foo struct @(cname="foo")    // @error{attribute 'cname' can only be
     i32 a;
 }
 
+public type Foo2 struct @(cdef="foo")    // @error{attribute 'cdef' can only be used in interface files}
+{
+    i32 a;
+}
+

--- a/test/parser/attributes/unknown_attr.c2
+++ b/test/parser/attributes/unknown_attr.c2
@@ -1,6 +1,13 @@
 // @warnings{no-unused}
 module test;
 
-fn void f1() @(foobar) {}     // @error{unknown attribute 'foobar'}
+i32 var @(foobar);             // @warning{unknown attribute 'foobar'}
 
+type Enum enum u8 @(foobar) {  // @warning{unknown attribute 'foobar'}
+    None,
+}
+
+fn void f1() @(foobar) {}      // @warning{unknown attribute 'foobar'}
+
+fn void f2(i32 a @(foobar)) {} // @warning{unknown attribute 'foobar'}
 

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -16,6 +16,7 @@
 module c2cat_main;
 
 import c2_tokenizer;
+import attr local;
 import color local;
 import file_utils;
 import keywords;
@@ -53,38 +54,14 @@ type C2cat struct {
     string_pool.Pool* pool;
     string_buffer.Buf* out;
     c2_tokenizer.Tokenizer* tokenizer;
+    AttrRegistry attr_registry;
     const char* input;
     u32 offset;
     u32 in_attributes; // 0 no, 1 seen @, 2 (, ) -> 0
 }
 
-const char*[] attr_names = {
-    "export",
-    "packed",
-    "unused",
-    "unused_params",
-    "section",
-    "noreturn",
-    "inline",
-    "printf_format",
-    "aligned",
-    "weak",
-    "opaque",
-    "cname",
-    "no_typedef",
-    "constructor",
-    "destructor",
-    "pure",
-    "auto_file",
-    "auto_line",
-    "auto_func",
-}
-
-fn bool is_attribute(const char* str) {
-    for (u32 i=0; i<elemsof(attr_names); i++) {
-        if (strcmp(str, attr_names[i]) == 0) return true;
-    }
-    return false;
+fn bool C2cat.is_attribute(C2cat* ctx, u32 name_idx) {
+    return ctx.attr_registry.find(name_idx) != Unknown;
 }
 
 fn void C2cat.update_state(C2cat* ctx, const Token* tok) {
@@ -160,16 +137,13 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
     switch (tok.kind) {
     case Identifier:
         const char* str = ctx.pool.idx2str(tok.name_idx);
+        Color col = col_identifier;
 
-        if (ctx.in_attributes && is_attribute(str)) {
-            out.color(col_attr);
-            out.add(str);
-            out.color(col_normal);
-        } else {
-            out.color(col_identifier);
-            out.add(str);
-            out.color(col_normal);
-        }
+        if (ctx.in_attributes)
+            col = ctx.is_attribute(tok.name_idx) ? col_attr : col_invalid;
+        out.color(col);
+        out.add(str);
+        out.color(col_normal);
         ctx.offset = tok.loc + (u32)strlen(str);
         return;
     case IntegerLiteral:
@@ -290,6 +264,7 @@ public fn i32 c2cat(const char* filename, bool use_color)
     c2_tokenizer.Tokenizer tokenizer;
     tokenizer.init(ctx.pool, buf, ctx.input, 0, &kwinfo, &features, nil, nil, true);
     ctx.tokenizer = &tokenizer;
+    ctx.attr_registry.init(ctx.pool);
 
     Token tok;
     tok.init();


### PR DESCRIPTION
* simplfy attr module, remove `attr.name_indexes` global variable
* make `attr.kind2name` and `attr.check()` type functions
* rename types to avoid name clashes: `attr.Value` as `AttrValue`, `attr_table.Attr` as `DeclAttr`