### PR TITLE
Analyser: handle scanf format strings

### DIFF
--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -16,7 +16,7 @@
 module module_analyser;
 
 import ast local;
-import printf_utils;
+import printf_utils local;
 import scope;
 import src_loc local;
 import string_buffer;
@@ -164,8 +164,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
     }
 
     //stdio.printf("CALL (%d | %d)\n", func_num_args, call_num_args);
-    bool has_printf_format = false;
-    u32 format_arg_idx = 0;
+    u8 format_arg_idx = 0;
+    FormatAttr format_attr = fd.getFormatAttr(&format_arg_idx);
     while (1) {
         //stdio.printf("ARG [%d | %d]\n", func_arg_index, call_arg_index);
         if (func_arg_index >= func_num_args) break;
@@ -212,11 +212,6 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         if (!ma.analyseInitExpr(&call_args[call_arg_index], d.getType(), arg.getLoc(), false, false))
             return QualType_Invalid;
 
-        if (vd.hasPrintfFormat()) {
-            has_printf_format = true;
-            format_arg_idx = call_arg_index;
-        }
-
         func_arg_index++;
         call_arg_index++;
     }
@@ -254,10 +249,11 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
             call_arg_index++;
         }
 
-        if (has_printf_format) {
+        if (format_attr) {
+            format_arg_idx -= num_auto_args + isTypeFuncCall;
             u32 num_args = call_num_args - format_arg_idx - 1;
-            call.setPrintfFormat(format_arg_idx);
-            if (!ma.checkPrintfArgs(&call_args[format_arg_idx], num_args, &call_args[format_arg_idx+1]))
+            call.setFormatAttr(format_attr);
+            if (!ma.checkFormatArgs(&call_args[format_arg_idx], num_args, &call_args[format_arg_idx+1], format_attr))
                 return QualType_Invalid;
         }
     }
@@ -273,58 +269,54 @@ type FormatAnalyser struct {
     SrcLoc loc;
     u32 last_offset;
     string_buffer.Buf* out;
+    FormatAttr format_attr;
 }
 
-const bool[] Format_needs_l_prefix = {
-    [BuiltinKind.Char] = false,
-    [BuiltinKind.Int8] = false,
-    [BuiltinKind.Int16] = false,
-    [BuiltinKind.Int32] = false,
-    [BuiltinKind.Int64] = true,
-    [BuiltinKind.UInt8] = false,
-    [BuiltinKind.UInt16] = false,
-    [BuiltinKind.UInt32] = false,
-    [BuiltinKind.UInt64] = true,
-    [BuiltinKind.Float32] = false,
-    [BuiltinKind.Float64] = true,
-    [BuiltinKind.ISize] = true,
-    [BuiltinKind.USize] = true,
-    [BuiltinKind.Bool] = false,
-}
+fn bool on_printf_specifier(void* context, u32 offset, PrintfSpecifier specifier, PrintfConversion* conv) {
+    if (specifier == Percent) return true;
 
-const bool[] Format_needs_u_prefix = {
-    [BuiltinKind.Char] = false,
-    [BuiltinKind.Int8] = false,
-    [BuiltinKind.Int16] = false,
-    [BuiltinKind.Int32] = false,
-    [BuiltinKind.Int64] = false,
-    [BuiltinKind.UInt8] = false,
-    [BuiltinKind.UInt16] = false,
-    [BuiltinKind.UInt32] = true,
-    [BuiltinKind.UInt64] = true,
-    [BuiltinKind.Float32] = false,
-    [BuiltinKind.Float64] = false,
-    [BuiltinKind.ISize] = false,
-    [BuiltinKind.USize] = true,
-    [BuiltinKind.Bool] = false,
-}
-
-fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32 offset, i32 stars, char c) {
     FormatAnalyser* fa = context;
     Analyser* ma = fa.ma;
     Expr** args = fa.args;
 
+    offset += conv.len;
     fa.out.add2(fa.format + fa.last_offset, offset - fa.last_offset);
 
-    if (c == '\0') {
-        ma.error(fa.loc + offset, "missing conversion specifier at end of format string");
+    char c = conv.c;
+    if (specifier == Invalid) {
+        SrcLoc loc = fa.loc + offset;  // approximate location of offending letter
+        switch (c) {
+        case '\0':
+            ma.error(loc, "missing conversion specifier at end of format string");
+            break;
+        case '%':
+            ma.error(loc, "invalid '%%%%' conversion specifier");
+            break;
+        case 'h':
+        case 'j':
+        case 'l':
+        case 't':
+        case 'w':
+        case 'z':
+        case 'L':
+            ma.error(loc, "format length modifier '%c' should be omitted", c);
+            break;
+        case 'i':
+        case 'u':
+            ma.error(loc, "invalid format specifier '%%%c', should use '%%d'", c);
+            break;
+        default:
+            ma.error(loc, "invalid format specifier '%%%c'", c);
+            break;
+        }
         return false;
     }
+    u32 stars = conv.has_width_star + conv.has_prec_star;
     if (fa.idx + stars >= fa.num_args) {
         ma.error(fa.loc + offset, "too many format specifiers or not enough arguments");
         return false;
     }
-    for (i32 i = 0; i < stars; i++) {
+    for (u32 i = 0; i < stars; i++) {
         Expr* arg = args[fa.idx];
         QualType qt = arg.getType();
         qt = qt.getCanonicalType();
@@ -339,7 +331,7 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
     qt = qt.getCanonicalType();
 
     switch (specifier) {
-    case Other:
+    case Invalid:
         break;
     case String:
         if (!qt.isCharPointer()) {
@@ -361,11 +353,11 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
             ma.error(arg.getStartLoc(), "format '%%%c' expects an integer argument", c);
             break;
         }
-        BuiltinKind kind = bi.getKind();
         // TODO add ll prefix on LLP targets (64-bit long long and pointers, but 32-bit long)
-        if (Format_needs_l_prefix[kind]) fa.out.add1('l');
-        if (c == 'd' && Format_needs_u_prefix[kind]) c = 'u';
-        // Assume all supported formats are implemented in the target libc
+        u32 width = bi.getWidth();
+        if (width > 32) fa.out.add1('l');
+        if (c == 'd' && width >= 32 && bi.isUnsigned()) c = 'u';
+        // Assume target libc supports %b
         break;
     case FloatingPoint:
         BuiltinType* bi = qt.getBuiltinTypeOrNil();
@@ -378,26 +370,24 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
             ma.error(arg.getStartLoc(), "format '%%p' expects a pointer argument");
         }
         break;
-    case Invalid:
-        switch (c) {
-        case 'h':
-        case 'j':
-        case 'l':
-        case 't':
-        case 'w':
-        case 'z':
-        case 'L':
-            ma.error(fa.loc + offset, "format length modifier '%c' should be omitted", c);
-            break;
-        case 'i':
-        case 'u':
-            ma.error(fa.loc + offset, "invalid format specifier '%%%c', should use '%%d'", c);
-            break;
-        default:
-            ma.error(fa.loc + offset, "invalid format specifier '%%%c'", c);
-            break;
+    case Offset:
+        if (qt.isPointer()) {
+            const PointerType* p = qt.getPointerType();
+            QualType t = p.getInner();
+            BuiltinType* bi = t.getBuiltinTypeOrNil();
+            if (bi && bi.isInteger()) {
+                u32 width = bi.getWidth();
+                // TODO add ll prefix on LLP targets (64-bit long long and pointers, but 32-bit long)
+                if (width < 16) fa.out.add1('h');
+                if (width < 32) fa.out.add1('h');
+                if (width > 32) fa.out.add1('l');
+                break;
+            }
         }
-        return false;
+        ma.error(arg.getStartLoc(), "format '%%n' expects an integer pointer argument");
+        break;
+    case Percent:
+        break;
     }
     fa.out.add1(c);
 
@@ -406,22 +396,194 @@ fn bool on_format_specifier(void* context, printf_utils.Specifier specifier, u32
     return true;
 }
 
-fn bool Analyser.checkPrintfArgs(Analyser* ma, Expr** format_ptr, u32 num_args, Expr** args) {
+fn bool on_scanf_specifier(void* context, u32 offset, ScanfSpecifier specifier, ScanfConversion* conv) {
+    FormatAnalyser* fa = context;
+    Analyser* ma = fa.ma;
+    Expr** args = fa.args;
+
+    offset += conv.len;
+    fa.out.add2(fa.format + fa.last_offset, offset - fa.last_offset);
+
+    char c = conv.c;
+    if (specifier == Invalid) {
+        SrcLoc loc = fa.loc + offset;  // approximate location of offending letter
+        switch (c) {
+        case '\0':
+            ma.error(loc, "missing conversion specifier at end of format string");
+            break;
+        case '%':
+            ma.error(loc, "invalid '%%%%' conversion specifier");
+            break;
+        case 'h':
+        case 'j':
+        case 'l':
+        case 't':
+        case 'w':
+        case 'z':
+        case 'L':
+            ma.error(loc, "conversion length modifier '%c' should be omitted", c);
+            break;
+        case 'i':
+        case 'u':
+            ma.error(loc, "invalid conversion specifier '%%%c', should use '%%d'", c);
+            break;
+        default:
+            ma.error(loc, "invalid conversion specifier '%%%c'", c);
+            break;
+        }
+        return false;
+    }
+    if (!conv.has_star) {
+        if (fa.idx >= fa.num_args) {
+            ma.error(fa.loc + offset, "too many conversion specifiers or not enough arguments");
+            return false;
+        }
+        Expr* arg = args[fa.idx++];
+        QualType qt = arg.getType();
+        qt = qt.getCanonicalType();
+        QualType tt = QualType_Invalid;
+        BuiltinType* bi = nil;
+        if (qt.isPointer()) {
+            const PointerType* p = qt.getPointerType();
+            tt = p.getInner();
+            tt = tt.getImplType();
+            bi = tt.getBuiltinTypeOrNil();
+        }
+        switch (specifier) {
+        case Invalid:
+            break;
+        case String:
+        case Scanset:
+            if (!qt.isCharPointer()) {
+                ma.error(arg.getStartLoc(), "conversion '%%s' expects a string argument");
+            }
+            // TODO: check array length and specify it if missing
+            break;
+        case Char:
+            if (!bi || !tt.isCharCompatible()) {
+                ma.error(arg.getStartLoc(), "conversion '%%c' expects a character pointer argument");
+            }
+            // TODO: check array length if field width is present
+            break;
+        case Integer:
+        case Offset:
+            if (!bi || !bi.isIntegerOrBool()) {
+                ma.error(arg.getStartLoc(), "conversion '%%%c' expects an integer pointer argument", c);
+                break;
+            }
+            u32 width = bi.getWidth();
+            // TODO add ll prefix on LLP targets (64-bit long long and pointers, but 32-bit long)
+            if (width < 16) fa.out.add1('h');
+            if (width < 32) fa.out.add1('h');
+            if (width > 32) fa.out.add1('l');
+            if (c == 'd' && bi.isUnsigned()) c = 'u';
+            // Assuming target libc supports %b
+            break;
+        case FloatingPoint:
+            if (!bi || !bi.isFloatingPoint()) {
+                ma.error(arg.getStartLoc(), "conversion '%%%c' expects a floating-point pointer argument", c);
+            }
+            if (bi.getWidth() > 32) fa.out.add1('l');
+            break;
+        case Pointer:
+            if (!bi || (!tt.isPointer() && !tt.isFunction())) {
+                ma.error(arg.getStartLoc(), "conversion '%%p' expects a pointer to a pointer argument");
+            }
+            break;
+        case Percent:
+            break;
+        }
+    }
+    fa.out.add1(c);
+    if (conv.len2) fa.out.add2(fa.format + offset + 1, conv.len2);
+    fa.last_offset = offset + 1 + conv.len2;
+    return true;
+}
+
+fn const char* get_format(Expr* format, SrcLoc* format_loc) {
+    // if format is StringLiteral or vardecl of type char[], it will wrapped in ArrayToPointerDecay
+    // otherwise it's a VarDecl of type (const) char* we cannot check and report this as an error
+
+    if (!format.isImplicitCast()) return nil;
+    ImplicitCastExpr* ic = (ImplicitCastExpr*)format;
+    if (!ic.isArrayToPointerDecay()) return nil;
+    format = ic.getInner();
+    *format_loc = format.getLoc();
+
+    for (;;) {
+        switch (format.getKind()) {
+        case StringLiteral:
+            // set location to first character of string literal
+            // this works for simple strings only: multi-strings, raw strings,
+            // strings with escape sequences may show an incorrect position for
+            // format specifier errors.
+            *format_loc = format.getLoc() + 1;
+            StringLiteral* s = (StringLiteral*)format;
+            return s.getText();
+        case Identifier:
+            QualType qt = format.getType();
+            assert(qt.isArray());
+            ArrayType* at = qt.getArrayType();
+            qt = at.getElemType();
+            if (!qt.isConst()) return nil;
+
+            IdentifierExpr* id = (IdentifierExpr*)format;
+            Decl* decl = id.getDecl();
+            assert(decl.isVariable());
+            VarDecl* vd = (VarDecl*)decl;
+            format = vd.getInit();
+            assert(format);
+            continue;
+        case Member:
+            QualType qt = format.getType();
+            assert(qt.isArray());
+            ArrayType* at = qt.getArrayType();
+            qt = at.getElemType();
+            if (!qt.isConst()) return nil;
+
+            MemberExpr* m = (MemberExpr*)format;
+            Decl* decl = m.getFullDecl();
+            assert (decl.isVariable());
+            VarDecl* vd = (VarDecl*)decl;
+            format = vd.getInit();
+            assert(format);
+            continue;
+        default:
+            assert(0);
+            return nil;
+        }
+    }
+}
+
+fn bool Analyser.checkFormatArgs(Analyser* ma, Expr** format_ptr, u32 num_args, Expr** args, FormatAttr format_attr) {
     Expr* format = *format_ptr;
     SrcLoc format_loc = format.getLoc();
-    const char* format_text = printf_utils.get_format(format, &format_loc);
+    const char* format_text = get_format(format, &format_loc);
     if (!format_text) {
         ma.error(format_loc, "format argument is not a constant string");
         return false;
     }
 
     string_buffer.Buf* out = string_buffer.create(256, false, 0);
-    FormatAnalyser fa = { ma, format_text, args, num_args, 0, format_loc, 0, out }
+    FormatAnalyser fa = { ma, format_text, args, num_args, 0, format_loc, 0, out, format_attr }
 
-    if (!printf_utils.parseFormat(format_text, on_format_specifier, &fa)) {
-        // error already reported
-        out.free();
-        return false;
+    switch (format_attr) {
+    case None:
+        break; // should not happen;
+    case Printf:
+        if (!parsePrintfFormat(format_text, on_printf_specifier, &fa)) {
+            // error already reported
+            out.free();
+            return false;
+        }
+        break;
+    case Scanf:
+        if (!parseScanfFormat(format_text, on_scanf_specifier, &fa)) {
+            // error already reported
+            out.free();
+            return false;
+        }
+        break;
     }
     out.add(format_text + fa.last_offset);
 

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -92,9 +92,6 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             if (vd.hasAutoAttr()) {
                 ma.error(vd.getAssignLoc(), "automatic argument cannot have default value");
             }
-            if (vd.hasPrintfFormat()) {
-                ma.error(vd.getAssignLoc(), "printf_format parameter cannot have default value");
-            }
             Expr** initExpr = vd.getInit2();
             ma.analyseInitExpr(initExpr, res, vd.getAssignLoc(), false, true);
         }
@@ -117,9 +114,9 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             }
         }
 
-        if (vd.hasPrintfFormat()) {
-            ma.checkPrintfFormat(vd, res, i, fd);
-            fd.setAttrPrintf((u8)i + 1); // change to 1-based
+        if (FormatAttr format_attr = vd.getFormatAttr()) {
+            ma.checkFormatArgument(vd, res, i, fd, format_attr);
+            fd.setFormatAttr(format_attr, (u8)i);
         }
 
         // Note: we dont check the arg name for clash here, but when checking body
@@ -287,26 +284,36 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
     ma.popCheck();
 }
 
+fn void Analyser.checkFormatArgument(Analyser* ma, VarDecl* vd, QualType qt, u32 idx, FunctionDecl* fd, FormatAttr format_attr) {
+    Decl* d = (Decl*)vd;
+    const char* attr_name = "format";
 
-fn void Analyser.checkPrintfFormat(Analyser* ma, VarDecl* v, QualType qt, u32 idx, FunctionDecl* fd) {
-    Decl* d = (Decl*)v;
+    switch (format_attr) {
+    case None: break;
+    case Printf: attr_name = "printf_format"; break;
+    case Scanf: attr_name = "scanf_format"; break;
+    }
+
+    if (vd.hasInit()) {
+        ma.error(vd.getAssignLoc(), "%s parameter cannot have default value", attr_name);
+        return;
+    }
     if (!qt.isCharPointer()) {
-        ma.error(d.getLoc(), "printf_format parameter must have type 'const char*'");
+        ma.error(d.getLoc(), "%s parameter must have type 'const char*'", attr_name);
         return;
     }
-    if (v.hasAutoAttr()) {
-        ma.error(d.getLoc(), "printf_format parameter cannot be an auto-argument");
+    if (vd.hasAutoAttr()) {
+        ma.error(d.getLoc(), "%s parameter cannot be an auto-argument", attr_name);
         return;
     }
-
     if (!fd.isVariadic()) {
-        ma.error(d.getLoc(), "printf_format functions must have a variable number of arguments");
+        ma.error(d.getLoc(), "%s functions must have a variable number of arguments", attr_name);
         return;
     }
 
     u32 num_params = fd.getNumParams();
     if (idx != num_params - 1) {
-        ma.error(d.getLoc(), "printf_format parameter must be the last parameter");
+        ma.error(d.getLoc(), "%s parameter must be the last parameter", attr_name);
         return;
     }
 }

--- a/analyser/printf_utils.c2
+++ b/analyser/printf_utils.c2
@@ -15,80 +15,36 @@
 
 module printf_utils;
 
-import ast local;
-import ctype;
-import src_loc local;
+import ctype local;
 
-public fn const char* get_format(Expr* format, SrcLoc* format_loc) {
-    // if format is StringLiteral or vardecl of type char[], it will wrapped in ArrayToPointerDecay
-    // otherwise it's a VarDecl of type (const) char* we cannot check and report this as an error
-
-    if (!format.isImplicitCast()) return nil;
-    ImplicitCastExpr* ic = (ImplicitCastExpr*)format;
-    if (!ic.isArrayToPointerDecay()) return nil;
-    format = ic.getInner();
-    *format_loc = format.getLoc();
-
-    for (;;) {
-        switch (format.getKind()) {
-        case StringLiteral:
-            // set location to first character of string literal
-            // this works for simple strings only: multi-strings, raw strings,
-            // strings with escape sequences may show an incorrect position for
-            // format specifier errors.
-            *format_loc = format.getLoc() + 1;
-            StringLiteral* s = (StringLiteral*)format;
-            return s.getText();
-        case Identifier:
-            QualType qt = format.getType();
-            assert(qt.isArray());
-            ArrayType* at = qt.getArrayType();
-            qt = at.getElemType();
-            if (!qt.isConst()) return nil;
-
-            IdentifierExpr* id = (IdentifierExpr*)format;
-            Decl* decl = id.getDecl();
-            assert(decl.isVariable());
-            VarDecl* vd = (VarDecl*)decl;
-            format = vd.getInit();
-            assert(format);
-            continue;
-        case Member:
-            QualType qt = format.getType();
-            assert(qt.isArray());
-            ArrayType* at = qt.getArrayType();
-            qt = at.getElemType();
-            if (!qt.isConst()) return nil;
-
-            MemberExpr* m = (MemberExpr*)format;
-            Decl* decl = m.getFullDecl();
-            assert (decl.isVariable());
-            VarDecl* vd = (VarDecl*)decl;
-            format = vd.getInit();
-            assert(format);
-            continue;
-        default:
-            assert(0);
-            return nil;
-        }
-    }
-}
-
-public type Specifier enum u8 {
-    Other,          // %% or unknown
+public type PrintfSpecifier enum u8 {
+    Invalid,        // unknown or length prefix
     String,         // %s, %-s, %4s
     Char,           // %c
     Integer,        // %i, %-i, %-8i, %08i, %x, %o
     FloatingPoint,  // %f
     Pointer,        // %p
-    Invalid,        // other
+    Offset,         // %n
+    Percent,        // %%
+}
+
+public type PrintfConversion struct {
+    char c;
+    u8 nflags;
+    bool has_width : 1;
+    bool has_width_star : 1;
+    bool has_prec : 1;
+    bool has_prec_star : 1;
+    u32 len;
+    i32 width;
+    i32 prec;
 }
 
 // cp points after first %, len is # of characters between % and conversion specifier (so '%d' -> len 0)
-fn Specifier getSpecifier(const char* format, u32* len, i32 *pstars, char* c) {
+fn PrintfSpecifier getPrintfSpecifier(const char* format, PrintfConversion* conv) {
     const char* cp = format;
-    Specifier spec = Specifier.Invalid;
-    i32 stars = 0;
+
+    *conv = { .width = -1, .prec = -1 }
 
     for (;;) {
         /* skip optional flags */
@@ -99,39 +55,46 @@ fn Specifier getSpecifier(const char* format, u32* len, i32 *pstars, char* c) {
         case '#':
         case '\'':  // non-standard extension
         case '0':
+            conv.nflags++;
             cp++;
             continue;
         }
         break;
     }
     if (*cp == '*') {
-        stars++;
+        conv.has_width = true;
+        conv.has_width_star = true;
         cp++;
-    } else {
-        while (ctype.isdigit(*cp)) {
-            cp++;
+    } else
+    if (isdigit(*cp)) {
+        conv.has_width = true;
+        conv.width = *cp++ - '0';
+        while (isdigit(*cp)) {
+            conv.width = conv.width * 10 + *cp++ - '0';
         }
     }
     if (*cp == '.') {
+        conv.has_prec = true;
         cp++;
         if (*cp == '*') {
-            stars++;
+            conv.has_prec_star = true;
             cp++;
-        } else {
-            while (ctype.isdigit(*cp)) {
-                cp++;
+        } else
+        if (isdigit(*cp)) {
+            conv.prec = *cp++ - '0';
+            while (isdigit(*cp)) {
+                conv.prec = conv.prec * 10 + *cp++ - '0';
             }
         }
     }
-    switch (*c = *cp) {
+    conv.len = (u32)(cp - format);
+    switch (conv.c = *cp) {
     case '%':
         // only if it is first char
-        if (cp == format)
-            spec = Specifier.Other;
-        break;
+        if (cp == format) return Percent;
+        return Invalid;
     case 'c':
-        spec = Specifier.Char;
-        break;
+        return Char;
     case 'a':
     case 'e':
     case 'f':
@@ -140,45 +103,127 @@ fn Specifier getSpecifier(const char* format, u32* len, i32 *pstars, char* c) {
     case 'E':
     case 'F':
     case 'G':
-        spec = Specifier.FloatingPoint;
-        break;
+        return FloatingPoint;
     case 'p':
-        spec = Specifier.Pointer;
-        break;
+        return Pointer;
     case 's':
-        spec = Specifier.String;
-        break;
+        return String;
     case 'b':
     case 'B':
     case 'd':
     case 'o':
     case 'x':
     case 'X':
-        spec = Specifier.Integer;
-        break;
+        return Integer;
+    case 'n':
+        return Offset;
     }
-    *pstars = stars;
-    *len = (u32)(cp - format);
-    return spec;
+    return Invalid;
 }
 
-// return whether parseFormat should continue.
-public type FormatHandler fn bool (void* arg, Specifier specifier, u32 offset, i32 stars, char letter);
+public type PrintfFormatHandler fn bool (void* arg, u32 offset, PrintfSpecifier specifier, PrintfConversion* conv);
 
-public fn bool parseFormat(const char* format, FormatHandler handler, void* arg) {
+public fn bool parsePrintfFormat(const char* format, PrintfFormatHandler handler, void* arg) {
     const char* cp = format;
     while (*cp) {
         if (*cp++ == '%') {
-            u32 len = 0;
-            i32 stars = 0;
-            char c = 0;
-            Specifier s = getSpecifier(cp, &len, &stars, &c);
-            cp += len;
-            if (s != Specifier.Other) {
-                if (!handler(arg, s, (u32)(cp - format), stars, c))
-                    return false;
-            }
+            u32 offset = (u32)(cp - format);
+            PrintfConversion conv;
+            PrintfSpecifier s = getPrintfSpecifier(cp, &conv);
+            cp += conv.len;
             if (*cp) cp++;
+            if (!handler(arg, offset, s, &conv)) return false;
+        }
+    }
+    return true;
+}
+
+public type ScanfSpecifier enum u8 {
+    Invalid,        // unknown or length prefix
+    String,         // %s, %-s, %4s
+    Char,           // %c
+    Integer,        // %i, %-i, %-8i, %08i, %x, %o
+    FloatingPoint,  // %f
+    Pointer,        // %p
+    Scanset,        // %[   only scanf
+    Offset,         // %n
+    Percent,        // %%
+}
+
+public type ScanfConversion struct {
+    char c;
+    bool has_star;
+    bool has_width;
+    u32 len;        // characters between % and the conversion specifier
+    i32 width;      // specified width
+    u32 len2;       // extra characters for Scanset conversion
+}
+
+public type ScanfFormatHandler fn bool (void* arg, u32 offset, ScanfSpecifier specifier, ScanfConversion* conv);
+
+// format points after first %
+fn ScanfSpecifier getScanfSpecifier(const char* format, ScanfConversion* conv) {
+    const char* cp = format;
+    *conv = { .width = -1 }
+
+    if (*cp == '*') {
+        conv.has_star = true;
+        cp++;
+    }
+    if (isdigit(*cp)) {
+        conv.has_width = true;
+        conv.width = *cp++ - '0';
+        while (isdigit(*cp)) {
+            conv.width = conv.width * 10 + *cp++ - '0';
+        }
+    }
+    conv.len = (u32)(cp - format);
+    switch (conv.c = *cp) {
+    case '%':
+        if (cp == format) return Percent;
+        return Invalid;
+    case 'b':
+    case 'd':
+    case 'i':
+    case 'o':
+    case 'u':
+    case 'x':
+        return Integer;
+    case 'a':
+    case 'e':
+    case 'f':
+    case 'g':
+        return FloatingPoint;
+    case 'c':
+        return Char;
+    case 's':
+        return String;
+    case '[':
+        u32 pos = 1;
+        if (cp[pos] == '^') pos++;
+        if (cp[pos] == '[') pos++;
+        while (cp[pos] && cp[pos++] != ']') continue;
+        conv.len2 = pos - 1;
+        return Scanset;
+    case 'p':
+        return Pointer;
+    case 'n':
+        return Offset;
+    }
+    return Invalid;
+}
+
+public fn bool parseScanfFormat(const char* format, ScanfFormatHandler handler, void* arg) {
+    const char* cp = format;
+    while (*cp) {
+        if (*cp++ == '%') {
+            u32 offset = (u32)(cp - format);
+            ScanfConversion conv;
+            ScanfSpecifier s = getScanfSpecifier(cp, &conv);
+            cp += conv.len;
+            if (*cp) cp++;
+            cp += conv.len2;
+            if (!handler(arg, offset, s, &conv)) return false;
         }
     }
     return true;

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -25,7 +25,7 @@ type CallExprBits struct {
     u32 calls_type_func : 1;
     u32 calls_static_sf : 1;
     u32 is_template_call : 1;
-    u32 printf_format : 4;  // 1-based, 0 means no printf-format
+    u32 format_attr : 2;
     u32 has_auto_args : 1;   // if c-generator needs to insert extra arguments (file, line)
     u32 is_noreturn : 1;
     u32 num_args : 8;
@@ -155,17 +155,12 @@ public fn bool CallExpr.isNoreturn(const CallExpr* e) {
     return e.base.base.callExprBits.is_noreturn;
 }
 
-// note: format_idx is 0-based
-public fn void CallExpr.setPrintfFormat(CallExpr* e, u32 format_idx) {
-    e.base.base.callExprBits.printf_format = format_idx + 1;
+public fn void CallExpr.setFormatAttr(CallExpr* e, FormatAttr kind) {
+    e.base.base.callExprBits.format_attr = kind;
 }
 
-fn bool CallExpr.isPrintfCall(const CallExpr* e) {
-    return e.base.base.callExprBits.printf_format != 0;
-}
-
-fn u32 CallExpr.getPrintfFormat(const CallExpr* e) {
-    return e.base.base.callExprBits.printf_format - 1;
+fn FormatAttr CallExpr.getFormatAttr(const CallExpr* e) {
+    return (FormatAttr)e.base.base.callExprBits.format_attr;
 }
 
 public fn void CallExpr.setHasAutoArgs(CallExpr* e) {
@@ -211,8 +206,10 @@ fn void CallExpr.print(const CallExpr* e, string_buffer.Buf* out, u32 indent) {
     if (e.base.base.callExprBits.calls_type_func) out.add(" TF");
     if (e.base.base.callExprBits.calls_static_sf) out.add(" STF");
     if (e.base.base.callExprBits.is_noreturn) out.add(" noreturn");
-    if (e.isPrintfCall()) {
-        out.print(" printf=%d", e.getPrintfFormat());
+    switch (e.getFormatAttr()) {
+    case None: break;
+    case Printf: out.print(" printf"); break;
+    case Scanf: out.print(" scanf"); break;
     }
     if (e.hasAutoArgs()) out.add(" auto-args");
     out.newline();

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -72,6 +72,7 @@ type FunctionDeclFlags struct {
     u32 attr_constructor : 1;
     u32 attr_destructor : 1;
     u32 attr_pure : 1;
+    u32 format_attr : 2; // FormatAttr
 }
 
 public type FunctionDecl struct @(opaque) {
@@ -82,7 +83,7 @@ public type FunctionDecl struct @(opaque) {
     }
     QualType rt;          // return type after analysis
     u8 num_params;
-    u8 attr_printf_arg;        // 0 means not present
+    u8 attr_format_arg;
     u16 instance_idx;     // template functions only
     u32 template_name;    // index into string pool
     SrcLoc template_loc;
@@ -118,7 +119,7 @@ public fn FunctionDecl* FunctionDecl.create(ast_context.Context* c,
     d.body = nil;
     d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
-    d.attr_printf_arg = 0;
+    d.attr_format_arg = 0;
     d.instance_idx = 0;
     d.template_name = 0;
     d.template_loc = 0;
@@ -163,7 +164,7 @@ public fn FunctionDecl* FunctionDecl.createTemplate(ast_context.Context* c,
     d.body = nil;
     d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
-    d.attr_printf_arg = 0;
+    d.attr_format_arg = 0;
     d.instance_idx = 0;
     d.template_name = template_name;
     d.template_loc = template_loc;
@@ -205,7 +206,7 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
         fd2.body = fd.body.instantiate(inst);
     fd2.rt = QualType_Invalid;
     fd2.num_params = fd.num_params;
-    fd2.attr_printf_arg = fd.attr_printf_arg;
+    fd2.attr_format_arg = fd.attr_format_arg;
     fd2.instance_idx = 0;
     fd2.template_name = 0;
     fd2.template_loc = fd.template_loc;
@@ -457,18 +458,14 @@ public fn bool FunctionDecl.hasAttrPure(const FunctionDecl* d) {
     return d.flags.attr_pure;
 }
 
-public fn void FunctionDecl.setAttrPrintf(FunctionDecl* d, u8 arg) {
-    d.attr_printf_arg = arg;
+public fn void FunctionDecl.setFormatAttr(FunctionDecl* d, FormatAttr format_attr, u8 format_arg) {
+    d.flags.format_attr = format_attr;
+    d.attr_format_arg = format_arg;
 }
 
-/*
-public fn bool FunctionDecl.hasAttrPrintf(const FunctionDecl* d) {
-    return d.attr_printf_arg != 0;
-}
-*/
-
-public fn u8 FunctionDecl.getAttrPrintf(const FunctionDecl* d) {
-    return d.attr_printf_arg;
+public fn FormatAttr FunctionDecl.getFormatAttr(const FunctionDecl* d, u8 *format_arg_ptr) {
+    *format_arg_ptr = d.attr_format_arg;
+    return (FormatAttr)d.flags.format_attr;
 }
 
 public fn const char* FunctionDecl.getDiagKind(const FunctionDecl* d) {
@@ -498,7 +495,12 @@ fn void FunctionDecl.print(const FunctionDecl* d, string_buffer.Buf* out, u32 in
     if (d.hasAttrNoReturn()) out.add(" noreturn");
     if (d.hasAttrInline()) out.add(" inline");
     if (d.hasAttrWeak()) out.add(" weak");
-    if (d.attr_printf_arg != 0) out.print(" printf_format=%d", d.attr_printf_arg);
+    u8 format_arg = 0;
+    switch (d.getFormatAttr(&format_arg)) {
+    case None: break;
+    case Printf: out.print(" printf_format=%d", format_arg); break;
+    case Scanf: out.print(" scanf_format=%d", format_arg); break;
+    }
     if (d.hasAttrConstructor()) out.add(" constructor");
     if (d.hasAttrDestructor()) out.add(" destructor");
     if (d.hasAttrPure()) out.add(" pure");

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -42,6 +42,12 @@ type AutoAttr enum u32 {
     Func,
 }
 
+public type FormatAttr enum u8 {
+    None,
+    Printf,
+    Scanf,
+}
+
 type VarDeclBits struct {
     u32 : NumDeclBits;
     u32 kind : 3;
@@ -52,7 +58,7 @@ type VarDeclBits struct {
     u32 attr_weak : 1; // globals only
     u32 addr_used : 1;
     u32 auto_attr : 2;  // AutoAttr, for parameters only
-    u32 printf_format : 1; // for parameters only
+    u32 format_attr : 2; // FormatAttr, for parameters only
 }
 
 public type BitFieldLayout struct {
@@ -337,12 +343,12 @@ public fn bool VarDecl.hasAutoAttr(const VarDecl* d) {
     return d.base.varDeclBits.auto_attr != AutoAttr.None;
 }
 
-public fn void VarDecl.setPrintfFormat(VarDecl* d) {
-    d.base.varDeclBits.printf_format = 1;
+public fn void VarDecl.setFormatAttr(VarDecl* d, FormatAttr kind) {
+    d.base.varDeclBits.format_attr = kind;
 }
 
-public fn bool VarDecl.hasPrintfFormat(const VarDecl* d) {
-    return d.base.varDeclBits.printf_format;
+public fn FormatAttr VarDecl.getFormatAttr(const VarDecl* d) {
+    return (FormatAttr)d.base.varDeclBits.format_attr;
 }
 
 fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
@@ -368,7 +374,11 @@ fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
     case Line: out.add(" auto_line"); break;
     case Func: out.add(" auto_func"); break;
     }
-    if (d.base.varDeclBits.printf_format) out.add(" printf_format");
+    switch (d.getFormatAttr()) {
+    case None: break;
+    case Printf: out.add(" printf_format"); break;
+    case Scanf: out.add(" scanf_format"); break;
+    }
     if (d.base.varDeclBits.has_init_call) out.add(" init_call");
     d.base.printBits(out);
     d.base.printAttrs(out);

--- a/ast_utils/attr.c2
+++ b/ast_utils/attr.c2
@@ -29,6 +29,7 @@ public type AttrKind enum u8 {
     NoReturn,       //        Func
     Inline,         //        Func
     PrintfFormat,   //             | Var, function param only
+    ScanfFormat,    //             | Var, function param only
     Aligned,        // Type | Func | Var, needs number arg
     Weak,           //        Func | Var
     Opaque,         // Struct
@@ -54,6 +55,7 @@ const char*[] attrKind_names = {
     "noreturn",
     "inline",
     "printf_format",
+    "scanf_format",
     "aligned",
     "weak",
     "opaque",
@@ -114,7 +116,7 @@ public fn void AttrRegistry.init(AttrRegistry* ar, string_pool.Pool* pool) {
 }
 
 public fn AttrKind AttrRegistry.find(AttrRegistry* ar, u32 name_idx) {
-    // skip unused
+    // skip unknown
     for (u32 i = 1; i < elemsof(AttrKind); i++) {
         if (name_idx == ar.name_indexes[i]) return (AttrKind)i;
     }
@@ -131,6 +133,7 @@ const AttrReq[] Required_arg = {
     [AttrKind.NoReturn]     = AttrReq.NoArg,
     [AttrKind.Inline]       = AttrReq.NoArg,
     [AttrKind.PrintfFormat] = AttrReq.NoArg,
+    [AttrKind.ScanfFormat]  = AttrReq.NoArg,
     [AttrKind.Aligned]      = AttrReq.Number,
     [AttrKind.Weak]         = AttrReq.NoArg,
     [AttrKind.Opaque]       = AttrReq.NoArg,

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -527,7 +527,10 @@ public fn bool Builder.hasEmbedAttr(Builder* b) {
 fn bool Builder.actOnParamAttr(Builder* b, VarDecl* d, const Attr* a) {
     switch (a.kind) {
     case PrintfFormat:
-        d.setPrintfFormat();
+        d.setFormatAttr(Printf);
+        return true;
+    case ScanfFormat:
+        d.setFormatAttr(Scanf);
         return true;
     case AutoFile:
         if (d.hasAutoAttr()) break;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -264,7 +264,9 @@ fn void Compiler.build(Compiler* c,
     if (opts.ubsan) c.addFeature("__UBSAN__", "1");
 
     c.addFeature("USE_NATIVE_CTYPES", "1");
-
+#ifndef BOOTSTRAP
+    c.addFeature("EXPERIMENTAL", "1");
+#endif
     c.parser = c2_parser.create(sm,
                                 diags,
                                 c.astPool,

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -856,9 +856,13 @@ fn void Generator.gen_func_proto(Generator* gen, FunctionDecl* fd, string_buffer
         out.add("__attribute__((destructor)) ");
     }
 
-    u8 printf_arg = fd.getAttrPrintf();
-    if (printf_arg) {
-        out.print("__attribute__((__format__(printf, %d, %d))) ", printf_arg, fd.getNumParams() +1);
+    u8 format_arg;
+    if (FormatAttr format_attr = fd.getFormatAttr(&format_arg)) {
+        out.print("__attribute__((__format__(%s, %d, %d))) ",
+                  format_attr == Printf ? "printf" :
+                  format_attr == Scanf ? "scanf" :
+                  "",
+                  fd.getNumParams(), fd.getNumParams() + 1);
     }
     if (out.endsWith(' ')) {
         out.trim(1);

--- a/libs/libc/stdio.c2i
+++ b/libs/libc/stdio.c2i
@@ -107,9 +107,15 @@ fn c_int printf(const c_char* __format @(printf_format), ...);
 fn c_int sprintf(c_char* __s, const c_char* __format @(printf_format), ...);
 fn c_int snprintf(c_char* __s, c_size size, const c_char* __format @(printf_format), ...);
 fn c_int dprintf(c_int __fd, const c_char* __fmt @(printf_format), ...);
+#if EXPERIMENTAL
+fn c_int fscanf(FILE* stream, const c_char* format @(scanf_format), ...);
+fn c_int scanf(const c_char* format @(scanf_format), ...);
+fn c_int sscanf(const c_char* s, const c_char* format @(scanf_format), ...);
+#else
 fn c_int fscanf(FILE* __stream, const c_char* __format, ...);
 fn c_int scanf(const c_char* __format, ...);
 fn c_int sscanf(const c_char* __s, const c_char* __format, ...);
+#endif
 fn c_int fgetc(FILE* __stream);
 fn c_int getc(FILE* __stream);
 fn c_int getchar();
@@ -175,15 +181,19 @@ fn c_int ferror_unlocked(FILE* __stream);
 //fn c_int fileno_unlocked(FILE* __stream);
 
 fn c_int asprintf(c_char**, const c_char* @(printf_format), ...);
+fn c_int vasprintf(c_char**, const c_char* format, va_list ap);
 fn c_char* ctermid_r(c_char*);
 fn c_char* fgetln(FILE*, c_size*);
 fn const c_char* fmtcheck(const c_char*, const c_char*);
 fn c_int fpurge(FILE *);
-//fn c_int vasprintf(c_char**, const c_char*, va_list);
 fn FILE *zopen(const c_char*, const c_char*, c_int);
 
-fn c_int vdprintf(c_int __fd, const c_char *format, va_list ap);
-fn c_int vfprintf(FILE* stream, const c_char *format, va_list ap);
+fn c_int vdprintf(c_int __fd, const c_char* format, va_list ap);
+fn c_int vfprintf(FILE* stream, const c_char* format, va_list ap);
 fn c_int vprintf(const c_char* format, va_list ap);
 fn c_int vsprintf(c_char* str, const c_char *format, va_list ap);
 fn c_int vsnprintf(c_char* str, c_size size, const c_char *format, va_list ap);
+
+fn c_int vfscanf(FILE* stream, const c_char* format, va_list ap);
+fn c_int vscanf(const c_char* format, va_list ap);
+fn c_int vsscanf(const c_char* str, const c_char* format, va_list ap);

--- a/test/attr/custom.c2
+++ b/test/attr/custom.c2
@@ -1,0 +1,13 @@
+// @warnings{no-unused}
+module test;
+
+i32 var @(custom); // @warning{unknown attribute 'custom'}
+
+type Enum enum u8 @(custom) { // @warning{unknown attribute 'custom'}
+    None,
+}
+
+fn void foo(i32 a) @(custom) {} // @warning{unknown attribute 'custom'}
+
+fn void run(i32 a @(custom)) {} // @warning{unknown attribute 'custom'}
+


### PR DESCRIPTION
* add `@(scanf_format)` attribute
* update format attribute bits
* accept `%n` pseudo-conversion in `printf_format` format strings
* add declarations in libc for `scanf` family of functions
* define `EXPERIMENTAL` feature when compiling new compiler to enable features not supported by bootstrap compiler