### PR TITLE
Language: attr deprecated attribute

### DIFF
--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -16,6 +16,7 @@
 module module_analyser;
 
 import ast local;
+import attr local;
 import printf_utils local;
 import scope;
 import src_loc local;
@@ -70,6 +71,14 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
             ma.errorRange(e.getLoc(), e.getRange(), "function %s is not a template function", fd.asDecl().getFullName());
             return QualType_Invalid;
         }
+    }
+
+    if (fd.hasAttrDeprecated() && !ma.warnings.no_deprecated) {
+        const AST* a = ((Decl*)fd).getAST();
+        const Attr* deprecated = a.getAttr(((Decl*)fd), Deprecated);
+        const char* msg = ma.astPool.idx2str(deprecated.value.text);
+        ma.warn(origFn.getLoc(), "function %s is deprecated: %s", fd.asDecl().getFullName(), msg);
+        //return QualType_Invalid;
     }
 
     u32 func_num_args = fd.getNumParams();

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -16,6 +16,7 @@
 module ast;
 
 import ast_context;
+import attr local;
 import src_loc local;
 import string_buffer;
 
@@ -72,6 +73,7 @@ type FunctionDeclFlags struct {
     u32 attr_constructor : 1;
     u32 attr_destructor : 1;
     u32 attr_pure : 1;
+    u32 attr_deprecated : 1;
     u32 format_attr : 2; // FormatAttr
 }
 
@@ -468,6 +470,14 @@ public fn FormatAttr FunctionDecl.getFormatAttr(const FunctionDecl* d, u8 *forma
     return (FormatAttr)d.flags.format_attr;
 }
 
+public fn void FunctionDecl.setAttrDeprecated(FunctionDecl* d) {
+    d.flags.attr_deprecated = 1;
+}
+
+public fn bool FunctionDecl.hasAttrDeprecated(const FunctionDecl* d) {
+    return d.flags.attr_deprecated;
+}
+
 public fn const char* FunctionDecl.getDiagKind(const FunctionDecl* d) {
     CallKind ck = d.getCallKind();
     if (ck == CallKind.TypeFunc) return "type-";
@@ -504,6 +514,13 @@ fn void FunctionDecl.print(const FunctionDecl* d, string_buffer.Buf* out, u32 in
     if (d.hasAttrConstructor()) out.add(" constructor");
     if (d.hasAttrDestructor()) out.add(" destructor");
     if (d.hasAttrPure()) out.add(" pure");
+    if (d.hasAttrDeprecated()) {
+        const Decl* dd = &d.base;
+        const AST* a = dd.getAST();
+        const Attr* deprecated = a.getAttr(dd, Deprecated);
+        const char* msg = idx2name(deprecated.value.text);
+        out.print(" deprecated=\"%s\"", msg);
+    }
 
     out.space();
     out.color(col_Value);

--- a/ast_utils/attr.c2
+++ b/ast_utils/attr.c2
@@ -43,6 +43,7 @@ public type AttrKind enum u8 {
     AutoLine,       //               Var, function param only
     AutoFunc,       //               Var, function param only
     Embed,          //               Var, globals only
+    Deprecated,     //        Func
 }
 
 const char*[] attrKind_names = {
@@ -69,6 +70,7 @@ const char*[] attrKind_names = {
     "auto_line",
     "auto_func",
     "embed",
+    "deprecated",
 }
 
 static_assert(elemsof(AttrKind), elemsof(attrKind_names));
@@ -147,6 +149,7 @@ const AttrReq[] Required_arg = {
     [AttrKind.AutoLine]     = AttrReq.NoArg,
     [AttrKind.AutoFunc]     = AttrReq.NoArg,
     [AttrKind.Embed]        = AttrReq.String,
+    [AttrKind.Deprecated]   = AttrReq.String,
 }
 static_assert(elemsof(AttrKind), elemsof(Required_arg));
 

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -392,6 +392,10 @@ fn void Builder.actOnFunctionAttr(Builder* b, Decl* d, const Attr* a) {
     case Pure:
         fd.setAttrPure();
         break;
+    case Deprecated:
+        fd.setAttrDeprecated();
+        b.storeAttr(d, a);
+        break;
     default:
         b.diags.error(a.loc, "attribute '%s' is not applicable to functions", a.kind2name());
         break;

--- a/common/build_target.c2
+++ b/common/build_target.c2
@@ -197,6 +197,7 @@ public fn void Target.disableWarnings(Target* t) {
     t.warnings.no_unused_enum_constant = true;
     t.warnings.no_unreachable_code = true;
     t.warnings.no_unknown_attribute = true;
+    t.warnings.no_deprecated = true;
 }
 
 public fn void Target.enableWarnings(Target* t) {
@@ -212,6 +213,7 @@ public fn void Target.enableWarnings(Target* t) {
     t.warnings.no_unused_enum_constant = false;
     t.warnings.no_unreachable_code = false;
     t.warnings.no_unknown_attribute = false;
+    t.warnings.no_deprecated = false;
 }
 
 public fn const warning_flags.Flags* Target.getWarnings(const Target* t) {

--- a/common/file/copy.c2
+++ b/common/file/copy.c2
@@ -15,15 +15,13 @@
 
 module file_utils;
 
-import string local;
-
 // NOTE: depends on reader + writer
 public fn i32 copy_file(const char* source, const char* dest) {
     // Note: not most optimal yet
 
     // create required sub-directories in dest
     char[file_utils.Max_path] tmp;
-    strncpy(tmp, dest, elemsof(tmp));
+    pstrcpy(tmp, elemsof(tmp), dest);
     const char* base = get_basename(tmp);
     if (base != tmp) {
         u32 len = (u32)(base - tmp);

--- a/common/warning_flags.c2
+++ b/common/warning_flags.c2
@@ -28,6 +28,7 @@ public type Flags struct {
     bool no_unused_enum_constant;
     bool no_unreachable_code;
     bool no_unknown_attribute;
+    bool no_deprecated;
     bool are_errors;
 }
 

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -583,6 +583,9 @@ fn void Parser.parseWarnings(Parser* p) {
         case "unknown-attribute":
             warnings.no_unknown_attribute = disable;
             break;
+        case "deprecated":
+            warnings.no_deprecated = disable;
+            break;
         case "promote-to-error":
             warnings.are_errors = !disable;
             break;

--- a/libs/libc/stdio.c2i
+++ b/libs/libc/stdio.c2i
@@ -90,9 +90,10 @@ fn c_int remove(const c_char* __filename);
 fn c_int rename(const c_char* __old, const c_char* __new);
 
 fn FILE* tmpfile();
-//fn c_char* tmpnam(c_char* __s); // deprecated
-fn c_char* tempnam(const c_char* __dir, const c_char* __pfx);
-
+#if EXPERIMENTAL
+fn c_char* tmpnam(c_char* __s) @(deprecated="use unistd.mkstemp instead");
+fn c_char* tempnam(const c_char* __dir, const c_char* __pfx) @(deprecated="use unistd.mkstemp instead");
+#endif
 fn c_int fclose(FILE* __stream);
 fn c_int fflush(FILE* __stream);
 fn FILE* fopen(const c_char* __filename, const c_char* __modes);
@@ -125,6 +126,9 @@ fn c_int fputc(c_int __c, FILE* __stream);
 fn c_int putc(c_int __c, FILE* __stream);
 fn c_int putchar(c_int __c);
 fn c_int putchar_unlocked(c_int __c);
+#if EXPERIMENTAL
+fn c_char* gets(c_char* __s) @(deprecated="function cannot be used safely");
+#endif
 fn c_int getw(FILE* __stream);
 fn c_int putw(c_int __w, FILE* __stream);
 fn c_char* fgets(c_char* __s, c_int __n, FILE* __stream);

--- a/libs/libc/string.c2i
+++ b/libs/libc/string.c2i
@@ -14,14 +14,17 @@ fn void* memcpy(void* dest, const void* src, c_size n);
 fn void* memccpy(void* dest, const void* src, c_int c, c_size n);
 fn void* memmove(void* dest, const void* src, c_size n);
 fn c_char* strcpy(c_char* dest, const c_char* src);
-fn c_char* strncpy(c_char* dest, const c_char* src, c_size n);
+#if EXPERIMENTAL
+fn c_char* strncpy(c_char* dest, const c_char* src, c_size n) @(deprecated="function has misleading semantics");
+#endif
 fn c_char* strdup(const c_char* s);
 fn c_char* strndup(const c_char* s, c_size n);
 
 /* 7.26.3 Concatenation functions */
 fn c_char* strcat(c_char* dest, const c_char* src);
-fn c_char* strncat(c_char* dest, const c_char* src, c_size n);
-
+#if EXPERIMENTAL
+fn c_char* strncat(c_char* dest, const c_char* src, c_size n) @(deprecated="function has misleading semantics");
+#endif
 /* 7.26.4 Comparison functions */
 fn c_int memcmp(const void* s1, const void* s2, c_size n);
 fn c_int strcmp(const c_char* s1, const c_char* s2);

--- a/libs/libc/unistd.c2i
+++ b/libs/libc/unistd.c2i
@@ -481,3 +481,7 @@ const u32 _SC_V7_ILP32_OFF32 = 113;
 
 fn c_ulong lseek (i32 fd, c_ulong offset, i32 whence);
 
+fn char* mktemp(char* tpl);
+fn c_int mkstemp(char* tpl);
+fn char* mkdtemp(char* tpl);
+

--- a/test/expr/call_deprecated.c2
+++ b/test/expr/call_deprecated.c2
@@ -1,0 +1,18 @@
+// @warnings{no-unused}
+module test;
+
+import stdio local;
+import string local;
+
+fn void test1() {
+    char[128] buf;
+    gets(buf);  // @warning{function stdio.gets is deprecated: function cannot be used safely}
+}
+
+fn void test2(char* dest, const char* src) {
+    strncpy(dest, src, 10);  // @warning{function string.strncpy is deprecated: function has misleading semantics}
+}
+
+fn void test3(char* dest, const char* src) {
+    strncat(dest, src, 10);  // @warning{function string.strncat is deprecated: function has misleading semantics}
+}

--- a/test/expr/call_deprecated_disabled.c2
+++ b/test/expr/call_deprecated_disabled.c2
@@ -1,0 +1,19 @@
+// @warnings{no-unused}
+// @warnings{no-deprecated}
+module test;
+
+import stdio local;
+import string local;
+
+fn void test1() {
+    char[128] buf;
+    gets(buf);
+}
+
+fn void test2(char* dest, const char* src) {
+    strncpy(dest, src, 10);
+}
+
+fn void test3(char* dest, const char* src) {
+    strncat(dest, src, 10);
+}


### PR DESCRIPTION
* add `@(deprecated="msg")` attribute for functions that should not be used
* mark library functions `gets()`, `strncpy()` and `strncat()` as deprecated
* replace bogus call to `strncpy()` with `pstrcpy()`