### PR TITLE
C-Generator: remove redundant fallthrough on consecutive case clauses

### DIFF
--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -444,8 +444,8 @@ fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) 
 
     const u32 num_stmts = c.getNumStmts();
     if (num_stmts == 0) {
-        out.indent(indent+1);
-        out.add("fallthrough;\n");
+        //out.indent(indent+1);
+        //out.add("fallthrough;\n");
     } else {
         Stmt** stmts = c.getStmts();
         for (u32 i=0; i<num_stmts; i++) {

--- a/test/c_generator/stmts/switch_stmt.c2t
+++ b/test/c_generator/stmts/switch_stmt.c2t
@@ -86,7 +86,6 @@ static void test_test1(int32_t i)
     case 5:
         return;
     case 6:
-        fallthrough;
     default:
         i += 10;
         break;

--- a/test/c_generator/stmts/switch_string.c2t
+++ b/test/c_generator/stmts/switch_string.c2t
@@ -53,7 +53,6 @@ static int32_t test_test1(char* str)
    case 3: // "aa"
       return 2;
    case 4: // "aaa"
-      fallthrough;
    case 5: // "bbb"
       return 3;
    case 0: // nil


### PR DESCRIPTION
* this shaves close to 1000 lines off output/c2c/cgen/build.c