### PR TITLE
C-Generator: use `bool` instead of `_Bool` in C backend output

### DIFF
--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -251,7 +251,7 @@ const char*[] builtinType_cnames = {
     "double",
     "ssize_t",
     "size_t",
-    "_Bool",
+    "bool",
 }
 static_assert(elemsof(BuiltinKind), elemsof(builtinType_cnames));
 
@@ -1438,6 +1438,11 @@ const char[] Include_guard1 =
 const char[] C_types =
     ```c
     // --- internally added ---
+    #if !defined __STDC_VERSION__ || __STDC_VERSION__ < 202311L
+    #define bool _Bool
+    #define true 1
+    #define false 0
+    #endif
     typedef signed char int8_t;
     typedef unsigned char uint8_t;
     typedef signed short int16_t;
@@ -1447,8 +1452,6 @@ const char[] C_types =
     ```;
 const char[] C_defines =
     ```c
-    #define true 1
-    #define false 0
 
     #define NULL ((void*)0)
     #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))

--- a/test/c_generator/types/builtins.c2t
+++ b/test/c_generator/types/builtins.c2t
@@ -25,7 +25,7 @@ type S struct {
 
 typedef struct test_S_ test_S;
 struct test_S_ {
-    _Bool b;
+    bool b;
     int8_t i_8;
     int16_t i_16;
     int32_t i_32;

--- a/test/c_generator/variables/should_initalize_globals.c2t
+++ b/test/c_generator/variables/should_initalize_globals.c2t
@@ -24,7 +24,7 @@ typedef struct test_Foo_ test_Foo;
 struct test_Foo_ {
     int32_t i;
     int8_t* cp;
-    _Bool b;
+    bool b;
 };
 
 static test_Foo test_f = { };

--- a/test/functions/func_param_nested.c2t
+++ b/test/functions/func_param_nested.c2t
@@ -31,25 +31,25 @@ fn void test2() {
 }
 // @expect{atleast, cgen/build.c}
 typedef void (*test_Cb1)(void* _arg0,  _arg1, int32_t _arg2);
-typedef _Bool (*test_Cb2)(int32_t _arg0, int32_t _arg1);
+typedef bool (*test_Cb2)(int32_t _arg0, int32_t _arg1);
 
-static void test_callback1(void* arg, _Bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a);
+static void test_callback1(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a);
 static test_Cb1 test_cb1 = test_callback1;
-static _Bool test_callback2(int32_t a, int32_t b);
+static bool test_callback2(int32_t a, int32_t b);
 static test_Cb2 test_cb2 = test_callback2;
-static void test_test1(void* arg, void (*cb)(void* arg, _Bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a), _Bool (*inner)(int32_t _arg0, int32_t _arg1), int32_t a);
+static void test_test1(void* arg, void (*cb)(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a), bool (*inner)(int32_t _arg0, int32_t _arg1), int32_t a);
 static void test_test2(void);
 
-static void test_callback1(void* arg, _Bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a)
+static void test_callback1(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a)
 {
 }
 
-static _Bool test_callback2(int32_t a, int32_t b)
+static bool test_callback2(int32_t a, int32_t b)
 {
    return true;
 }
 
-static void test_test1(void* arg, void (*cb)(void* arg, _Bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a), _Bool (*inner)(int32_t _arg0, int32_t _arg1), int32_t a)
+static void test_test1(void* arg, void (*cb)(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a), bool (*inner)(int32_t _arg0, int32_t _arg1), int32_t a)
 {
    cb(arg, test_callback2, a);
    cb(arg, inner, a);

--- a/test/functions/func_param_unnamed.c2t
+++ b/test/functions/func_param_unnamed.c2t
@@ -13,5 +13,5 @@ fn void test1(void* arg,
 }
 
 // @expect{atleast, cgen/build.c}
-static void test_test1(void* arg, void (*_arg1)(void* arg, int32_t a), _Bool (*_arg2)(void* _arg0, char _arg1), int32_t a);
+static void test_test1(void* arg, void (*_arg1)(void* arg, int32_t a), bool (*_arg2)(void* _arg0, char _arg1), int32_t a);
 

--- a/test/functions/named_arg.c2t
+++ b/test/functions/named_arg.c2t
@@ -49,27 +49,27 @@ public fn i32 main(i32 argc, char** argv) {
 }
 
 // @expect{atleast, cgen/build.c}
-static _Bool test_check_case(const char* s, _Bool is_upper);
-static void test_fun1(const char* s, _Bool is_upper, _Bool is_lower);
-static void test_fun3(const char* s, _Bool _arg1, _Bool is_lower);
+static bool test_check_case(const char* s, bool is_upper);
+static void test_fun1(const char* s, bool is_upper, bool is_lower);
+static void test_fun3(const char* s, bool _arg1, bool is_lower);
 static void test_foo1(const char* s);
 static void test_foo2(const char* s);
 static void test_foo3(const char* s);
 static void test_test1(const char* s);
 int32_t main(int32_t argc, char** argv);
 
-static _Bool test_check_case(const char* s, _Bool is_upper)
+static bool test_check_case(const char* s, bool is_upper)
 {
    if (is_upper) return isupper(*s);
    else return islower(*s);
 
 }
 
-static void test_fun1(const char* s, _Bool is_upper, _Bool is_lower)
+static void test_fun1(const char* s, bool is_upper, bool is_lower)
 {
 }
 
-static void test_fun3(const char* s, _Bool _arg1, _Bool is_lower)
+static void test_fun3(const char* s, bool _arg1, bool is_lower)
 {
 }
 


### PR DESCRIPTION
* use define and use `bool` in C generator output for readability `bool`, `true` and `false` are keywords as of C23