### PR TITLE
compiler: more flexible warning system

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -30,7 +30,7 @@ import src_loc local;
 import scope;
 import string_buffer;
 import string_pool;
-import warning_flags;
+import warning_flags local;
 import struct_func_list as sf_list;
 import incr_array_list as ia_list;
 import value_type local;
@@ -49,7 +49,7 @@ public type Analyser struct @(opaque) {
     string_pool.Pool* astPool;
     ast_builder.Builder* builder;
     module_list.List* allmodules;
-    const warning_flags.Flags* warnings;
+    const WarningFlags* warnings;
 
     // variables below differs per run
     Module* mod;
@@ -93,7 +93,7 @@ public fn Analyser* create(diagnostics.Diags* diags,
                              string_pool.Pool* astPool,
                              ast_builder.Builder* builder,
                              module_list.List* allmodules,
-                             const warning_flags.Flags* warnings,
+                             const WarningFlags* warnings,
                              bool has_asserts, bool check_only)
 {
     Analyser* ma = stdlib.calloc(1, sizeof(Analyser));
@@ -367,10 +367,10 @@ fn void Analyser.note(Analyser* ma, SrcLoc loc, const char* format @(printf_form
     va_end(args);
 }
 
-fn void Analyser.warn(Analyser* ma, SrcLoc loc, const char* format @(printf_format), ...) {
+fn void Analyser.warn(Analyser* ma, WarningKind wk, SrcLoc loc, const char* format @(printf_format), ...) {
     va_list args;
     va_start(args, format);
-    ma.diags.warn2(loc, format, args);
+    ma.diags.warn2(wk, loc, format, args);
     va_end(args);
 }
 
@@ -402,7 +402,7 @@ fn void Analyser.createGlobalScope(void* arg, AST* a) {
                                   a.getImports(),
                                   ma.mod,
                                   ma.mod.getSymbols(),
-                                  !ma.warnings.no_unused_variable);
+                                  ma.warnings.test(W_unused_variable));
     a.setPtr(s);
 }
 

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -97,10 +97,10 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         }
     }
 
-    if (fd.hasAttrDeprecated() && !ma.warnings.no_deprecated) {
+    if (fd.hasAttrDeprecated() && ma.warnings.test(W_deprecated)) {
         const Attr* deprecated = ((Decl*)fd).getAttr(Deprecated);
         const char* msg = ma.idx2name(deprecated.value.text);
-        ma.warn(origFn.getLoc(), "function %s is deprecated: %s", ma.getFullName(fd.asDecl()), msg);
+        ma.warn(W_deprecated, origFn.getLoc(), "function %s is deprecated: %s", ma.getFullName(fd.asDecl()), msg);
         //return QualType_Invalid;
     }
 
@@ -703,7 +703,7 @@ fn FunctionDecl* Analyser.instantiateTemplateFunction(Analyser* ma, CallExpr* ca
                                              d.getAST().getImports(),
                                              template_mod,
                                              template_mod.getSymbols(),
-                                             !ma.warnings.no_unused_variable);
+                                             ma.warnings.test(W_unused_variable));
         analyser.analyseFunctionBody(instance, tmpScope);
         tmpScope.free();
         analyser.free();

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -55,7 +55,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd, bool full) {
     }
 
     if (canon.isConst()) {
-        ma.warn(rtype.getLoc(), "'const' type qualifier on return type has no effect");
+        ma.warn(W_const_return_type, rtype.getLoc(), "'const' type qualifier on return type has no effect");
     }
 
     bool is_public = fd.asDecl().isPublic();
@@ -230,7 +230,7 @@ fn bool Analyser.analyseFunctionBody2(Analyser* ma, FunctionDecl* fd, Module* mo
                                          fd.asDecl().getAST().getImports(),
                                          mod,
                                          mod.getSymbols(),
-                                         !ma.warnings.no_unused_variable);
+                                         ma.warnings.test(W_unused_variable));
     analyser.analyseFunctionBody(fd, tmpScope);
     bool has_error = analyser.has_error;
     tmpScope.free();
@@ -284,12 +284,12 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
         }
     }
 
-    if (!ma.warnings.no_unused_parameter && !fd.hasAttrUnusedParams()) {
+    if (ma.warnings.test(W_unused_parameter) && !fd.hasAttrUnusedParams()) {
         for (u32 i=0; i<num_params; i++) {
             Decl* p = (Decl*)params[i];
             if (!p.isUsed() && p.getNameIdx()) {
                 // TODO check attribute?
-                ma.warn(p.getLoc(), "unused parameter '%s'", ma.getName(p));
+                ma.warn(W_unused_parameter, p.getLoc(), "unused parameter '%s'", ma.getName(p));
             }
         }
     }
@@ -299,8 +299,8 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
     for (u32 i=0; i<num_labels; i++) {
         const Label* l = &labels[i];
         if (l.is_label) {
-            if (!l.used && !ma.warnings.no_unused_label) {
-                ma.warn(l.loc, "unused label '%s'", ma.idx2name(l.name_idx));
+            if (!l.used) {
+                ma.warn(W_unused_label, l.loc, "unused label '%s'", ma.idx2name(l.name_idx));
             }
             if (l.stmt && l.has_goto) l.stmt.setGoto();
         } else {

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -66,8 +66,8 @@ fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt** s_ptr, bool checkEffect) {
     Stmt* s = *s_ptr;
     FlowBits flow = 0;
     if (ma.scope.isUnreachable()) {
-        if (s.getKind() != Label && !ma.warnings.no_unreachable_code) {
-            ma.warn(s.getLoc(), "unreachable code");
+        if (s.getKind() != Label) {
+            ma.warn(W_unreachable_code, s.getLoc(), "unreachable code");
         }
         ma.scope.setReachable();  // prevent multiple warnings
     }
@@ -285,7 +285,7 @@ fn QualType Analyser.analyseCondition(Analyser* ma, Stmt** s_ptr, const char* co
         e = (Expr*)*s_ptr;    // re-read in case of ImplicitCast insertions
     }
     if (check_assign && e.isAssignment()) {
-        ma.warn(e.getLoc(), "using the result of an assignment as a condition without parentheses");
+        ma.warn(W_idiomatic_parentheses, e.getLoc(), "using the result of an assignment as a condition without parentheses");
     }
 
     return qt;
@@ -321,7 +321,7 @@ fn FlowBits Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
     bool ok = ma.conv_checker.checkAssign(getBuiltinQT(Bool), qt, condp, e.getLoc());
     e = *condp;    // re-read in case of ImplicitCast insertions
     if (e.isAssignment()) {
-        ma.warn(e.getLoc(), "using the result of an assignment as a condition without parentheses");
+        ma.warn(W_idiomatic_parentheses, e.getLoc(), "using the result of an assignment as a condition without parentheses");
     }
     if (!ok) goto done;
     // TODO: handle constant conditions

--- a/analyser/scope.c2
+++ b/analyser/scope.c2
@@ -182,7 +182,7 @@ public fn void Scope.exit(Scope* s, bool has_error) {
             if (!d.isUsed()) {
                 ast.VarDecl* vd = (ast.VarDecl*)d;
                 // Note: params are handled by function
-                if (vd.isLocal()) s.diags.warn(d.getLoc(), "unused variable '%s'", s.getName(d));
+                if (vd.isLocal()) s.diags.warn(W_unused_variable, d.getLoc(), "unused variable '%s'", s.getName(d));
             }
         }
     }

--- a/analyser/unused_checker.c2
+++ b/analyser/unused_checker.c2
@@ -18,17 +18,17 @@ module unused_checker;
 import ast local;
 import diagnostics;
 import string_pool;
-import warning_flags;
+import warning_flags local;
 
 type Checker struct {
     diagnostics.Diags* diags;
     string_pool.Pool* astPool;
-    const warning_flags.Flags* warnings;
+    const WarningFlags* warnings;
 }
 
 public fn void check(diagnostics.Diags* diags,
                        string_pool.Pool* astPool,
-                       const warning_flags.Flags* warnings,
+                       const WarningFlags* warnings,
                        Module* mod)
 {
     Checker c = {
@@ -60,58 +60,56 @@ fn const char* Checker.getFullName(const Checker* c, const Decl* d) {
 
 fn void Checker.unused_module(void* arg, AST* a) {
     Checker* c = arg;
-    if (!c.warnings.no_unused_module) {
-        c.diags.warn(a.getLoc(), "unused module '%s'", c.idx2name(a.getNameIdx()));
-    }
+    c.diags.warn(W_unused_module, a.getLoc(), "unused module '%s'", c.idx2name(a.getNameIdx()));
 }
 
 fn void Checker.check(void* arg, Decl* d) {
     Checker* c = arg;
     bool used = d.isUsed();
-    if (used && d.isPublic() && !d.isUsedPublic() && !c.warnings.no_unused_public && !d.hasAttrUnused()) {
-        c.diags.warn(d.getLoc(), "%s '%s' is not used public", d.getKindName(), c.getFullName(d));
+    if (used && d.isPublic() && !d.isUsedPublic() && !d.hasAttrUnused()) {
+        c.diags.warn(W_unused_public, d.getLoc(), "%s '%s' is not used public", d.getKindName(), c.getFullName(d));
     }
 
+    WarningKind wk = W_unknown;
     switch (d.getKind()) {
     case Function:
-        if (c.warnings.no_unused_function) return;
         if (d.hasAttrUnused()) return;
+        wk = W_unused_function;
         break;
     case Import:
-        if (c.warnings.no_unused_import) return;
+        wk = W_unused_import;
         break;
     case StructType:
         if (used) {
             c.checkStructMembers(d);
         }
-        if (c.warnings.no_unused_type) return;
+        wk = W_unused_type;
         break;
     case EnumType:
         if (used) {
             EnumTypeDecl* etd = (EnumTypeDecl*)d;
-            if (!c.warnings.no_unused_enum_constant) {
+            if (c.warnings.test(W_unused_enum_constant)) {
                 c.checkEnumConstants(etd);
             }
-            if (etd.hasAssocValues() && !c.warnings.no_unused_enum_assoc_value) {
+            if (etd.hasAssocValues() && c.warnings.test(W_unused_enum_assoc_value)) {
                 c.checkEnumAssocValues(etd);
             }
         }
-        if (c.warnings.no_unused_type) return;
+        wk = W_unused_type;
         break;
     case EnumConstant:
+        wk = W_unused_enum_constant;
         break;
     case FunctionType:
-        if (c.warnings.no_unused_type) return;
-        break;
     case AliasType:
-        if (c.warnings.no_unused_type) return;
+        wk = W_unused_type;
         break;
     case Variable:
-        if (c.warnings.no_unused_variable) return;
+        wk = W_unused_variable;
         break;
     }
     if (!used && !d.hasAttrUnused() && !d.isExported()) {
-        c.diags.warn(d.getLoc(), "unused %s '%s'", d.getKindName(), c.getFullName(d));
+        c.diags.warn(wk, d.getLoc(), "unused %s '%s'", d.getKindName(), c.getFullName(d));
         return;
     }
 }
@@ -123,9 +121,7 @@ fn void Checker.checkImportList(void* arg, ImportDecl* id) {
     for (u32 i = 0; i < symlist_count; i++) {
         Decl* d = symlist[i].decl;
         if (!symlist[i].used) {
-            if (!c.warnings.no_unused_import) {
-                c.diags.warn(symlist[i].loc, "unused import '%s'", c.getFullName(d));
-            }
+            c.diags.warn(W_unused_import, symlist[i].loc, "unused %s '%s'", "import", c.getFullName(d));
         }
     }
 }
@@ -137,7 +133,7 @@ fn void Checker.checkEnumConstants(Checker* c, EnumTypeDecl* d) {
         EnumConstantDecl* ecd = constants[i];
         Decl* dd = (Decl*)ecd;
         if (!dd.isUsed()) {
-            c.diags.warn(dd.getLoc(), "unused %s '%s'", dd.getKindName(), c.getName(dd));
+            c.diags.warn(W_unused_enum_constant, dd.getLoc(), "unused %s '%s'", dd.getKindName(), c.getName(dd));
         }
     }
 }
@@ -150,15 +146,15 @@ fn void Checker.checkEnumAssocValues(Checker* c, EnumTypeDecl* etd) {
         Decl* d = (Decl*)vd;
         bool used = d.isUsed();
         if (used) {
-            if (d.isPublic() && !d.isUsedPublic() && !c.warnings.no_unused_public && !d.hasAttrUnused()) {
+            if (d.isPublic() && !d.isUsedPublic() && !d.hasAttrUnused()) {
                 Decl* ed = (Decl*)etd;
-                c.diags.warn(d.getLoc(), "enum-associated value '%s.%s' is not used public",
+                c.diags.warn(W_unused_public, d.getLoc(), "enum-associated value '%s.%s' is not used public",
                              c.getFullName(ed), c.getName(d));
             }
         } else {
             if (!d.hasAttrUnused()) {
                 Decl* ed = (Decl*)etd;
-                c.diags.warn(d.getLoc(), "unused enum-associated value '%s.%s'",
+                c.diags.warn(W_unused_enum_assoc_value, d.getLoc(), "unused enum-associated value '%s.%s'",
                              c.getFullName(ed), c.getName(d));
             }
         }
@@ -174,8 +170,8 @@ fn void Checker.checkStructMembers(Checker* c, Decl* d) {
         if (member.isStructType()) {
             c.checkStructMembers(member);
         } else {
-            if (!member.isUsed() && !member.hasAttrUnused() && !c.warnings.no_unused_struct_member) {
-                c.diags.warn(member.getLoc(), "unused %s member '%s'", std.isStruct() ? "struct" : "union", c.getName(member));
+            if (!member.isUsed() && !member.hasAttrUnused()) {
+                c.diags.warn(W_unused_struct_member, member.getLoc(), "unused %s member '%s'", std.isStruct() ? "struct" : "union", c.getName(member));
             }
         }
     }

--- a/common/attr_handler.c2
+++ b/common/attr_handler.c2
@@ -19,7 +19,7 @@ import ast;
 import attr local;
 import diagnostics;
 import string_pool;
-import warning_flags;
+import warning_flags local;
 
 import stdlib;
 import string;
@@ -33,7 +33,7 @@ type Entry struct {
 public type Handler struct @(opaque) {
     diagnostics.Diags* diags;   // no ownership
     string_pool.Pool* astPool;
-    const warning_flags.Flags* warnings;
+    const WarningFlags* warnings;
 
     Entry* entries;
     u32 count;
@@ -42,7 +42,7 @@ public type Handler struct @(opaque) {
 
 public fn Handler* create(diagnostics.Diags* diags,
                           string_pool.Pool* astPool,
-                          const warning_flags.Flags* warnings) {
+                          const WarningFlags* warnings) {
     Handler* h = stdlib.calloc(1, sizeof(Handler));
     h.diags = diags;
     h.astPool = astPool;
@@ -81,9 +81,7 @@ public fn bool Handler.handle(Handler* h, ast.Decl* d, const Attr* a) {
         Entry* e = &h.entries[i];
         if (e.name == a.name) return e.func(e.arg, d, a);
     }
-    if (!h.warnings.no_unknown_attribute) {
-        h.diags.warn(a.loc, "unknown attribute '%s'", h.astPool.idx2str(a.name));
-    }
+    h.diags.warn(W_unknown_attribute, a.loc, "unknown attribute '%s'", h.astPool.idx2str(a.name));
     return false;
 }
 

--- a/common/build_target.c2
+++ b/common/build_target.c2
@@ -20,7 +20,7 @@ import src_loc local;
 import string_list;
 import string_map;
 import string_pool;
-import warning_flags;
+import warning_flags local;
 
 import stdlib;
 import string;
@@ -101,7 +101,7 @@ public fn void PluginList.add(PluginList* l, u32 name, u32 options, SrcLoc loc) 
 public type Target struct @(opaque) {
     u32 name_idx;       // index into auxPool
     SrcLoc loc;
-    warning_flags.Flags warnings;
+    WarningFlags warnings;
     Kind kind;
 
     bool disable_asserts;
@@ -130,6 +130,7 @@ public fn Target* create(u32 name_idx, SrcLoc loc, Kind kind, string_pool.Pool* 
     t.exports.init(pool);
     t.files.init(8);
     t.asm_files.init(0);
+    t.enableWarnings();
     return t;
 }
 
@@ -188,47 +189,19 @@ public fn void Target.addLib(Target* t, u32 lib, Kind kind) {
     t.libs.add(lib, kind);
 }
 
-public fn void Target.disableWarnings(Target* t) {
-    t.warnings.no_unused = true;
-    t.warnings.no_unused_variable = true;
-    t.warnings.no_unused_struct_member = true;
-    t.warnings.no_unused_function = true;
-    t.warnings.no_unused_parameter = true;
-    t.warnings.no_unused_type = true;
-    t.warnings.no_unused_module = true;
-    t.warnings.no_unused_import = true;
-    t.warnings.no_unused_public = true;
-    t.warnings.no_unused_label = true;
-    t.warnings.no_unused_enum_constant = true;
-    t.warnings.no_unused_enum_assoc_value = true;
-    t.warnings.no_unreachable_code = true;
-    t.warnings.no_unknown_attribute = true;
-    t.warnings.no_deprecated = true;
+public fn void Target.disableWarnings(Target* t) @(unused) {
+    t.warnings.clearAll();
 }
 
 public fn void Target.enableWarnings(Target* t) {
-    t.warnings.no_unused = false;
-    t.warnings.no_unused_variable = false;
-    t.warnings.no_unused_struct_member = false;
-    t.warnings.no_unused_function = false;
-    t.warnings.no_unused_parameter = false;
-    t.warnings.no_unused_type = false;
-    t.warnings.no_unused_module = false;
-    t.warnings.no_unused_import = false;
-    t.warnings.no_unused_public = false;
-    t.warnings.no_unused_label = false;
-    t.warnings.no_unused_enum_constant = false;
-    t.warnings.no_unused_enum_assoc_value = false;
-    t.warnings.no_unreachable_code = false;
-    t.warnings.no_unknown_attribute = false;
-    t.warnings.no_deprecated = false;
+    t.warnings.setAll();
 }
 
-public fn const warning_flags.Flags* Target.getWarnings(const Target* t) {
+public fn const WarningFlags* Target.getWarnings(const Target* t) {
     return &t.warnings;
 }
 
-public fn warning_flags.Flags* Target.getWarnings2(Target* t) {
+public fn WarningFlags* Target.getWarnings2(Target* t) {
     return &t.warnings;
 }
 

--- a/common/diagnostics.c2
+++ b/common/diagnostics.c2
@@ -21,6 +21,7 @@ import string_buffer;
 import src_loc local;
 import utf8;
 import utils;
+import warning_flags local;
 
 import stdarg local;
 import stdio local;
@@ -29,6 +30,8 @@ import stdlib;
 public type Diags struct @(opaque) {
     source_mgr.SourceMgr* sm;   // no ownership
     string_buffer.Buf* out;     // owned
+    const WarningFlags *warnings;
+    WarningFlags wf;            // default warning flags
     u32 num_errors;
     u32 num_warnings;
     bool promote_warnings;
@@ -39,6 +42,8 @@ public fn Diags* create(source_mgr.SourceMgr* sm, bool use_color, const utils.Pa
     Diags* diags = stdlib.calloc(1, sizeof(Diags));
     diags.sm = sm;
     diags.out = string_buffer.create(512, use_color, 1);
+    diags.wf.setAll();
+    diags.warnings = &diags.wf;
     diags.path_info = path_info;
     return diags;
 }
@@ -53,8 +58,14 @@ public fn void Diags.clear(Diags* diags) {
     diags.num_warnings = 0;
 }
 
+#if 0
 public fn void Diags.setWarningAsError(Diags* diags, bool are_errors) {
     diags.promote_warnings = are_errors;
+}
+#endif
+
+public fn void Diags.setWarnings(Diags* diags, const WarningFlags* warnings) {
+    diags.warnings = warnings;
 }
 
 type Category enum u8 (const char* const name, const Color color) {
@@ -89,21 +100,25 @@ public fn void Diags.note2(Diags* diags, SrcLoc loc, const char* format, va_list
     diags.internal(Note, loc, range, format, args);
 }
 
-public fn void Diags.warn(Diags* diags, SrcLoc loc, const char* format @(printf_format), ...) {
+public fn bool Diags.warn(Diags* diags, WarningKind wk, SrcLoc loc, const char* format @(printf_format), ...) {
+    if (!diags.warnings.test(wk)) return false;
     va_list args;
     va_start(args, format);
     SrcRange range = { 0, 0 }
     Category category = Warning;
-    if (diags.promote_warnings) category = Error;
+    if (diags.warnings.isError(wk) || diags.promote_warnings) category = Error;
     diags.internal(category, loc, range, format, args);
     va_end(args);
+    return false;
 }
 
-public fn void Diags.warn2(Diags* diags, SrcLoc loc, const char* format, va_list args) {
+public fn bool Diags.warn2(Diags* diags, WarningKind wk, SrcLoc loc, const char* format, va_list args) {
+    if (!diags.warnings.test(wk)) return false;
     SrcRange range = { 0, 0 }
     Category category = Warning;
-    if (diags.promote_warnings) category = Error;
+    if (diags.warnings.isError(wk) || diags.promote_warnings) category = Error;
     diags.internal(category, loc, range, format, args);
+    return false;
 }
 
 public fn void Diags.errorRange(Diags* diags,

--- a/common/warning_flags.c2
+++ b/common/warning_flags.c2
@@ -15,22 +15,146 @@
 
 module warning_flags;
 
-public type Flags struct {
-    bool no_unused;
-    bool no_unused_variable;
-    bool no_unused_struct_member;
-    bool no_unused_function;
-    bool no_unused_parameter;
-    bool no_unused_type;
-    bool no_unused_module;
-    bool no_unused_import;
-    bool no_unused_public;
-    bool no_unused_label;
-    bool no_unused_enum_constant;
-    bool no_unused_enum_assoc_value;
-    bool no_unreachable_code;
-    bool no_unknown_attribute;
-    bool no_deprecated;
-    bool are_errors;
+import string local;
+
+public type WarningKind enum u8 {
+    W_unknown,
+    W_unused,
+    W_unused_variable,
+    W_unused_struct_member,
+    W_unused_function,
+    W_unused_parameter,
+    W_unused_type,
+    W_unused_module,
+    W_unused_import,
+    W_unused_public,
+    W_unused_label,
+    W_unused_enum_constant,
+    W_unused_enum_assoc_value,
+    W_unreachable_code,
+    W_unknown_attribute,
+    W_unknown_warning,
+    W_deprecated,
+    W_const_return_type,
+    W_idiomatic_parentheses,
 }
 
+const char*[WarningKind] warningName = {
+    [W_unknown]             = "unknown",
+    [W_unused]              = "unused",
+    [W_unused_variable]     = "unused-variable",
+    [W_unused_struct_member] = "unused-struct-member",
+    [W_unused_function]     = "unused-function",
+    [W_unused_parameter]    = "unused-parameter",
+    [W_unused_type]         = "unused-type",
+    [W_unused_module]       = "unused-module",
+    [W_unused_import]       = "unused-import",
+    [W_unused_public]       = "unused-public",
+    [W_unused_label]        = "unused-label",
+    [W_unused_enum_constant] = "unused-enum-constant",
+    [W_unused_enum_assoc_value] = "unused-enum-assoc-value",
+    [W_unreachable_code]    = "unreachable-code",
+    [W_unknown_attribute]   = "unknown-attribute",
+    [W_unknown_warning]     = "unknown-warning",
+    [W_deprecated]          = "deprecated",
+    [W_const_return_type]   = "const-return-type",
+    [W_idiomatic_parentheses] = "idiomatic-parentheses",
+}
+
+fn WarningKind WarningKind.find(const char* name) {
+    for (WarningKind k = W_unused; k <= WarningKind.max; k++) {
+        if (!strcmp(warningName[k], name)) return k;
+    }
+    return W_unknown;
+}
+
+fn u64 WarningKind.getMask(const char* name) {
+    switch (name) {
+    case "all":
+        return (u64)-1;
+    case "unused":
+        return (((u64)1 << WarningKind.W_unused) |
+                ((u64)1 << WarningKind.W_unused_variable) |
+                ((u64)1 << WarningKind.W_unused_struct_member) |
+                ((u64)1 << WarningKind.W_unused_function) |
+                ((u64)1 << WarningKind.W_unused_parameter) |
+                ((u64)1 << WarningKind.W_unused_type) |
+                ((u64)1 << WarningKind.W_unused_module) |
+                ((u64)1 << WarningKind.W_unused_import) |
+                ((u64)1 << WarningKind.W_unused_public) |
+                ((u64)1 << WarningKind.W_unused_label) |
+                ((u64)1 << WarningKind.W_unused_enum_constant) |
+                ((u64)1 << WarningKind.W_unused_enum_assoc_value));
+    case "unused-variable":
+        return (((u64)1 << WarningKind.W_unused_variable) |
+                ((u64)1 << WarningKind.W_unused_struct_member));  // temporary until new bootstrap
+    default:
+        WarningKind wk = WarningKind.find(name);
+        if (wk) return (u64)1 << wk;
+        return 0;
+    }
+}
+
+public type WarningFlags struct {
+    u64 flags;
+    u64 err_flags;
+}
+
+public fn bool WarningFlags.test(const WarningFlags *wf, WarningKind k) {
+    return (wf.flags >> k) & 1;
+}
+
+#if 0
+public fn void WarningFlags.set(WarningFlags *wf, WarningKind k) {
+    wf.flags |= (u64)1 << k;
+}
+
+public fn void WarningFlags.clear(WarningFlags *wf, WarningKind k) {
+    wf.flags &= ~((u64)1 << k);
+}
+
+public fn void WarningFlags.setError(WarningFlags *wf, WarningKind k) {
+    wf.err_flags |= (u64)1 << k;
+}
+
+public fn void WarningFlags.clearError(WarningFlags *wf, WarningKind k) {
+    wf.err_flags &= ~((u64)1 << k);
+}
+
+public fn void WarningFlags.setAllError(WarningFlags *wf) { wf.err_flags = (u64)-1; }
+public fn void WarningFlags.clearAllError(WarningFlags *wf) { wf.err_flags = 0; }
+#endif
+
+public fn void WarningFlags.setAll(WarningFlags *wf) { wf.flags = (u64)-1; }
+public fn void WarningFlags.clearAll(WarningFlags *wf) { wf.flags = 0; }
+
+public fn bool WarningFlags.isError(const WarningFlags *wf, WarningKind k) {
+    return (wf.err_flags >> k) & 1;
+}
+
+public fn bool WarningFlags.parseOption(WarningFlags *warnings, const char* option) {
+    bool enable = true;
+    if (!string.strncmp(option, "no-", 3)) {
+        enable = false;
+        option += 3;
+    }
+    if (!string.strncmp(option, "error=", 6)) {
+        u64 mask = WarningKind.getMask(option + 6);
+        if (!mask) return false;
+        if (enable) warnings.err_flags |= mask;
+        else warnings.err_flags &= ~mask;
+        return true;
+    }
+    if (!string.strcmp(option, "error")
+    ||  !string.strcmp(option, "promote-to-error")) {
+        if (enable) warnings.err_flags = (u64)-1;
+        else warnings.err_flags = 0;
+        return true;
+    } else {
+        u64 mask = WarningKind.getMask(option);
+        if (!mask) return false;
+        if (enable) warnings.flags |= mask;
+        else warnings.flags &= ~mask;
+        return true;
+    }
+}

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -23,7 +23,7 @@ import source_mgr;
 import src_loc local;
 import string_list;
 import string_pool;
-import warning_flags;
+import warning_flags local;
 
 import csetjmp local;
 import stdarg local;
@@ -509,79 +509,13 @@ fn void Parser.parsePlugin(Parser* p, bool is_global) {
 fn void Parser.parseWarnings(Parser* p) {
     p.consumeToken();
     p.expect(Text, "expect options");
-    warning_flags.Flags* warnings = p.target.getWarnings2();
+    WarningFlags* warnings = p.target.getWarnings2();
     // TODO no need to store in string pool
     while (p.is(Text)) {
         const char* option = p.pool.idx2str(p.token.value);
-        bool disable = false;
-        if (!string.strncmp(option, "no-", 3)) {
-            disable = true;
-            option += 3;
-        }
-        switch (option) {
-        case "unused":
-            warnings.no_unused = disable;
-            warnings.no_unused_variable = disable;
-            warnings.no_unused_struct_member = disable;
-            warnings.no_unused_function = disable;
-            warnings.no_unused_parameter = disable;
-            warnings.no_unused_type = disable;
-            warnings.no_unused_module = disable;
-            warnings.no_unused_import = disable;
-            warnings.no_unused_public = disable;
-            warnings.no_unused_label = disable;
-            warnings.no_unused_enum_constant = disable;
-            warnings.no_unused_enum_assoc_value = disable;
-            break;
-        case "unused-variable":
-            warnings.no_unused_variable = disable;
-            warnings.no_unused_struct_member = disable;  // temporary until new bootstrap
-            break;
-        case "unused-struct-member":
-            warnings.no_unused_struct_member = disable;
-            break;
-        case "unused-function":
-            warnings.no_unused_function = disable;
-            break;
-        case "unused-parameter":
-            warnings.no_unused_parameter = disable;
-            break;
-        case "unused-type":
-            warnings.no_unused_type = disable;
-            break;
-        case "unused-module":
-            warnings.no_unused_module = disable;
-            break;
-        case "unused-import":
-            warnings.no_unused_import = disable;
-            break;
-        case "unused-public":
-            warnings.no_unused_public = disable;
-            break;
-        case "unused-label":
-            warnings.no_unused_label = disable;
-            break;
-        case "unused-enum-constant":
-            warnings.no_unused_enum_constant = disable;
-            break;
-        case "unused-enum-assoc-value":
-            warnings.no_unused_enum_assoc_value = disable;
-            break;
-        case "unreachable-code":
-            warnings.no_unreachable_code = disable;
-            break;
-        case "unknown-attribute":
-            warnings.no_unknown_attribute = disable;
-            break;
-        case "deprecated":
-            warnings.no_deprecated = disable;
-            break;
-        case "promote-to-error":
-            warnings.are_errors = !disable;
-            break;
-        default:
-            p.warning("unknown warning '%s'", option);
-            break;
+        if (!warnings.parseOption(option)) {
+            if (warnings.test(W_unknown_warning))
+                p.warning("unknown warning '%s'", option);
         }
         p.consumeToken();
     }

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -205,7 +205,8 @@ fn void Compiler.build(Compiler* c,
         c.target.disableAsserts();
     }
 
-    diags.setWarningAsError(target.getWarnings().are_errors);
+    //diags.setWarningAsError(target.getWarnings().are_errors);
+    c.diags.setWarnings(target.getWarnings());
     c.diags.clear();
 
     c.astPool = string_pool.create(128*1024, 8192);

--- a/compiler/compiler_analyse.c2
+++ b/compiler/compiler_analyse.c2
@@ -23,7 +23,7 @@ import module_sorter;
 import string_list;
 import unused_checker;
 import utils;
-import warning_flags;
+import warning_flags local;
 
 fn bool Compiler.analyse(Compiler* c) {
     u64 analysis_start = utils.now();
@@ -64,8 +64,8 @@ fn bool Compiler.analyse(Compiler* c) {
     c.checkMain();
 
     // check unused
-    const warning_flags.Flags* warnings = c.target.getWarnings();
-    if (!warnings.no_unused) {
+    const WarningFlags* warnings = c.target.getWarnings();
+    if (warnings.test(W_unused)) {
         c.mainComp.visitModules(Compiler.checkUnused, c);
     }
 

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -545,7 +545,7 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
 
         for (u32 i = 0; i < c.opts.files.length(); i++)
             t.addFile(c.opts.files.get_idx(i), 0);
-        t.disableWarnings();
+        //t.disableWarnings();
     } else {
         if (c.opts.use_ir_backend) {
             console.error("c2c: the IR backend is currently experimental and only works on individual files, not recipes");

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -182,7 +182,7 @@ fn void Parser.on_tokenizer_error(void* arg, c2_tokenizer.ErrorLevel level, SrcL
         p.diags.note(loc, "%s", msg);
         break;
     case Warning:
-        p.diags.warn(loc, "%s", msg);
+        p.diags.warn(W_unknown, loc, "%s", msg);
         break;
     default:
         p.diags.error(loc, "%s", msg);


### PR DESCRIPTION
* add `WarningKind` enumeration and simplify `Flags` structure
* rename `warning_flags.Flags` as `WarningFlags`
* remove temporary unreachable code hack
* all targets have all warnings enabled by default
* extend `WarningFlags` type with type functions
* simplify `Target.enableWarnings()` and `Target.disableWarnings()`
* add warnings for `const-return-type` and `idiomatic-parentheses`
* accept both '$warnings unused' and '$warnings no-unused' etc.