### PR TITLE
Statistics: allow for finer grained analysis

### DIFF
--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -71,7 +71,6 @@ public type MemberExpr struct @(opaque) {
 public fn MemberExpr* MemberExpr.create(ast_context.Context* c, Expr* base, const Ref* refs, u32 refcount) {
     u32 size = sizeof(MemberExpr) + refcount * sizeof(MemberRef) + (refcount - 1) * sizeof(u32);
     if (base) size += sizeof(MemberRef);
-    size = (size + 7) & ~0x7; // round to 8-byte (temp)
     MemberExpr* e = c.alloc(size);
     e.base.init(ExprKind.Member, refs[0].loc, 0, 0, 0, ValType.NValue);
     e.base.base.memberExprBits.num_refs = refcount;
@@ -99,9 +98,7 @@ fn Expr* MemberExpr.instantiate(MemberExpr* e, Instantiator* inst) {
     u32 refcount = e.base.base.memberExprBits.num_refs;
     Expr* base = e.getExprBase();
     u32 size = sizeof(MemberExpr) + refcount * sizeof(MemberRef) + (refcount - 1) * sizeof(u32);
-
     if (base) size += sizeof(MemberRef);
-    size = (size + 7) & ~0x7; // round to 8-byte (temp)
     MemberExpr* e2 = inst.c.alloc(size);
 
     string.memcpy(e2, e, size);

--- a/ast/statistics.c2
+++ b/ast/statistics.c2
@@ -19,7 +19,8 @@ module ast;
 import string;
 import stdio local;
 
-const u32 NCat = 1;
+const u32 NCat = 1;             // 32 for fine grained analysis
+const u32 BucketWidth = 8;      // 4 or less for slack analysis
 
 type Stat struct {
     u32[NCat] count;
@@ -32,8 +33,6 @@ type Stats struct {
     Stat[elemsof(StmtKind)] stmts;
     Stat[elemsof(DeclKind)] decls;
     Stat[3] others; // 0=ArrayValue, 1=StaticAssert, 2=SwitchCase
-    //Stat arrayValues;
-    //Stat staticAsserts;
 }
 
 fn void Stats.reset(Stats* s) {
@@ -41,10 +40,15 @@ fn void Stats.reset(Stats* s) {
 }
 
 fn void Stat.add(Stat* ss, u32 size) {
-    u32 cat = (size + 7) >> 3;
-    if (cat >= NCat) cat = NCat - 1;
-    ss.count[cat]++;
-    ss.size[cat] += size;
+    if (NCat > 1) {
+        u32 cat = (size + BucketWidth - 1) / BucketWidth;
+        if (cat >= NCat) cat = NCat - 1;
+        ss.count[cat]++;
+        ss.size[cat] += (size + 7) & ~0x7;
+    } else {
+        ss.count[0]++;
+        ss.size[0] += (size + 7) & ~0x7;
+    }
 }
 
 fn void Stats.addType(TypeKind kind, u32 size) {
@@ -77,6 +81,17 @@ fn void Stats.addSwitchCase(u32 size) {
     globals.stats.others[2].add(size);
 }
 
+fn void Stat.slack(const Stat* ss, u32* countp, u32* totalp) {
+    if (BucketWidth & 0x7) {
+        for (u32 cat = 0; cat < NCat; cat++) {
+            if (u32 frac = (cat * BucketWidth) & 0x7) {
+                *countp += ss.count[cat];
+                *totalp += ss.count[cat] * (8 - frac);
+            }
+        }
+    }
+}
+
 fn void Stat.dump(const Stat* ss, const char* name, u32* countp, u32* totalp) {
     u32 count = 0;
     u32 size = 0;
@@ -90,10 +105,10 @@ fn void Stat.dump(const Stat* ss, const char* name, u32* countp, u32* totalp) {
         if (!ss.count[cat]) continue;
         if (count == ss.count[cat]) {
             // no repeat if single category
-            if (NCat > 1) printf("  %d", cat * 8);
+            if (NCat > 1) printf("  %d", cat * BucketWidth);
             break;
         }
-        printf("  %d:%d/%d", cat * 8, ss.count[cat], ss.size[cat]);
+        printf("  %d:%d/%d", cat * BucketWidth, ss.count[cat], ss.size[cat]);
     }
     printf("\n");
     *countp += count;
@@ -151,7 +166,18 @@ fn void Stats.dump(const Stats* s) {
     u32 totalCount = typesCount + exprCount + stmtCount + declCount + otherCount;
     u32 totalSize = typesTotal + exprTotal + stmtTotal + declTotal + otherTotal;
     printf("  %20s  %6d  %7d\n", "objects", totalCount, totalSize);
-
+    if (NCat > 1 && BucketWidth < 8) {
+        u32 slackCount = 0;
+        u32 slackTotal = 0;
+        u32 nStats = sizeof(Stats) / sizeof(Stat);
+        Stat* sp = (Stat*)s;
+        for (u32 i = 0; i < nStats; i++) {
+            sp[i].slack(&slackCount, &slackTotal);
+        }
+        if (slackCount) {
+            printf("  %20s  %6d  %7d\n", "slack", slackCount, slackTotal);
+        }
+    }
     printf("---------------------------------------\n");
 }
 

--- a/ast/struct_type_decl.c2
+++ b/ast/struct_type_decl.c2
@@ -115,7 +115,6 @@ public fn StructTypeDecl* StructTypeDecl.create(ast_context.Context* c,
     u32 size = sizeof(StructTypeDecl) + num_members * sizeof(Decl*);
     size += sizeof(StructLayout);
     size += num_members * sizeof(StructMemberLayout); // to store StructMemberLayouts
-    size = (size + 7) & ~0x7; // round to 8-byte (temp)
     StructTypeDecl* d = c.alloc(size);
     StructType* stype = StructType.create(c, d);
     QualType qt = QualType.create(stype.asType());

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -103,7 +103,6 @@ public fn VarDecl* VarDecl.create(ast_context.Context* c,
     // Note: for incremental arrays, the initValue will be set later
     if (initValue || ref.isIncrArray() || has_embed) size += sizeof(VarDeclInit);
     assert (kind != VarDeclKind.StructMember);
-    size = (size + 7) & ~0x7; // round to 8-byte (temp)
 
     VarDecl* d = c.alloc(size);
     d.base.init(DeclKind.Variable, name, loc, is_public, QualType_Invalid, ast_idx);
@@ -131,7 +130,6 @@ public fn VarDecl* VarDecl.createStructMember(ast_context.Context* c,
 {
     u32 size = sizeof(VarDecl) + ref.getExtraSize();
     if (bitfield) size += sizeof(BitFieldInfo); // see above
-    size = (size + 7) & ~0x7; // round to 8-byte (temp)
 
     VarDecl* d = c.alloc(size);
     d.base.init(DeclKind.Variable, name, loc, is_public, QualType_Invalid, ast_idx);
@@ -160,7 +158,7 @@ fn VarDecl* VarDecl.instantiate(const VarDecl* vd, Instantiator* inst)
     if (vd.base.varDeclBits.has_init) extra += sizeof(VarDeclInit);
     if (vd.base.varDeclBits.is_bitfield) extra += sizeof(BitFieldInfo);
     u32 size = sizeof(VarDecl) + extra;
-    size = (size + 7) & ~0x7; // round to 8-byte (temp)
+
     VarDecl* vd2 = inst.c.alloc(size);
     vd2.base = vd.base;
     vd2.typeRef.instantiate(&vd.typeRef, inst);


### PR DESCRIPTION
* add `BucketWidth` to specify stats size granularity
* don't round size up in ast node factories
* sizes are rounded up in `alloc` and `Stat.add`
* compute slack amount (79k for the c2c compiler < 2%)