### PR TITLE
Compiler: bug fixes

### DIFF
--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -49,8 +49,8 @@ const char*[] defKind_names = {
     "global",
     "type",
     "struct-member",
-    "template",
     "param",
+    "template",
 }
 
 type FunctionDeclBits struct {

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -17,7 +17,7 @@ module ast;
 
 import src_loc local;
 import string_buffer;
-import stdio;
+
 import string;
 
 public type TypeRefKind enum u8 {
@@ -538,7 +538,6 @@ public fn const char* TypeRef.diagName(const TypeRef* r) {
     local char[128] result;
     string_buffer.Buf buf.init(result, elemsof(result), false, false, 0);
     r.print(&buf, true);
-    stdio.puts(result);
     return result;
 }
 

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -188,8 +188,9 @@ public fn void deinit(bool print_stats) {
     globals.ast_list = nil;
     globals.pointers.clear();
     globals.string_types.clear();
-    stdlib.free(globals);
     globals.dump_buf.free();
+    stdlib.free(globals);
+    globals = nil;
 }
 
 public fn u32 getWordSize() {


### PR DESCRIPTION
* fix incorrect order in `defKind_names`
* remove debug output in `TypeRef.diagName`
* fix use after free in `ast.deinit`