### PR TITLE
AST: use simpler `MemberExpr` nodes

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -147,6 +147,7 @@ public fn bool Checker.check(Checker* c, QualType lhs, QualType rhs, Expr** e_pt
     const Type* rcanon = t2.getTypeOrNil();
 
     if (lcanon == rcanon) {
+#if 0   // This is bogus!
         //u32 lquals = lhs.getQuals();
         //u32 rquals = rhs.getQuals();
         // TODO: check constness of pointed thing instead of that of pointer
@@ -155,6 +156,7 @@ public fn bool Checker.check(Checker* c, QualType lhs, QualType rhs, Expr** e_pt
             c.diags.error(loc, "conversion discards const qualifier");
             return false;
         }
+#endif
         return true;
     }
 

--- a/analyser/module_analyser_builtin.c2
+++ b/analyser/module_analyser_builtin.c2
@@ -167,9 +167,8 @@ fn QualType Analyser.analyseOffsetOf(Analyser* ma, BuiltinExpr* b) {
 }
 
 fn QualType Analyser.analyseToContainer(Analyser* ma, BuiltinExpr* b) {
-    // syntax: Type* to_container(Type, member, member*)
-    //         const Type* to_container(Type, member, const member*)
-    Expr* inner = b.getInner();
+    // syntax: const? volatile? Type* to_container(Type, member, const? volatile? member*)
+    Expr* inner = b.getInner(); // Type
     QualType qt = ma.analyseExpr(&inner, false, RHS);
     if (qt.isInvalid()) return QualType_Invalid;
 
@@ -186,32 +185,40 @@ fn QualType Analyser.analyseToContainer(Analyser* ma, BuiltinExpr* b) {
     Expr* member = b.getToContainerMember();
     Decl* d = ma.findMemberOffset(b, std, member);
     if (!d) return QualType_Invalid;
-    QualType qmem = d.getType();
-    qmem = ma.builder.actOnPointerType(qmem);
 
     // check ptr
-    QualType qptr = ma.analyseExpr(b.getToContainerPointer2(), false, RHS);
+    Expr** pptr = b.getToContainerPointer2();
+    QualType qptr = ma.analyseExpr(pptr, false, RHS);
     if (qptr.isInvalid()) return QualType_Invalid;
 
-    // Note: 3rd argument may be const ptr, but result will be const ptr as well then
-    Expr* eptr = b.getToContainerPointer();
-    if (!ma.checker.check(qptr, qmem, b.getToContainerPointer2(), eptr.getLoc())) {
+    // Note: 3rd argument may be const/volatile ptr: copy qualifiers to result type
+    PointerType* pt = qptr.getPointerType();
+    qt.copyQuals(pt.getInner());
+
+    // Construct expected pointer type with proper qualifiers
+    QualType qmem = d.getType();
+    qmem.copyQuals(pt.getInner());
+    QualType expectedType = ma.builder.actOnPointerType(qmem);
+
+    if (!ma.checker.check(expectedType, qptr, pptr, (*pptr).getLoc())) {
         return QualType_Invalid;
     }
 
-    if (qptr.isConstPtr()) qt.setConst();
     return ma.builder.actOnPointerType(qt);
 }
 
-fn Decl* Analyser.findMemberOffset(Analyser* ma, BuiltinExpr* b, StructTypeDecl* std, Expr* member) {
-    u32 base_offset = 0;
-    Decl* d = nil;
+type FindMemberOffsetContext struct {
+    StructTypeDecl* std;
+    u32 base_offset;
+}
 
+fn Decl* Analyser.findMemberOffsetAux(Analyser* ma, FindMemberOffsetContext* ctx, Expr* member) {
+    Decl* d = nil;
     if (member.isIdentifier()) {
         IdentifierExpr* i = (IdentifierExpr*)member;
         u32 name_idx = i.getNameIdx();
 
-        d = ma.findStructMemberOffset(std, name_idx, member.getLoc(), &base_offset);
+        d = ma.findStructMemberOffset(ctx.std, name_idx, member.getLoc(), &ctx.base_offset);
         if (!d) return nil;
 
         i.setDecl(d);
@@ -221,20 +228,33 @@ fn Decl* Analyser.findMemberOffset(Analyser* ma, BuiltinExpr* b, StructTypeDecl*
     } else {
         assert(member.isMember());
         MemberExpr* m = (MemberExpr*)member;
-        for (u32 i=0; i<m.getNumRefs(); i++) {
+        u32 start = 0;
+        if (m.hasExpr()) {
+            d = ma.findMemberOffsetAux(ctx, m.getBaseExpr());
+            if (!d) return nil;
+            if (d.isStructType()) ctx.std = (StructTypeDecl*)d;
+            start = 1;
+        }
+        for (u32 i = start; i < 2; i++) {
             u32 name_idx = m.getNameIdx(i);
             SrcLoc loc = m.getLoc(i);
-            d = ma.findStructMemberOffset(std, name_idx, loc, &base_offset);
+            d = ma.findStructMemberOffset(ctx.std, name_idx, loc, &ctx.base_offset);
             if (!d) return nil;
 
-            if (d.isStructType()) std = (StructTypeDecl*)d;
+            if (d.isStructType()) ctx.std = (StructTypeDecl*)d;
             d.setUsed();
             m.setDecl(d, i);
         }
         m.setKind(StructMember);
     }
     member.setType(d.getType());
-    b.setUValue(base_offset);
+    return d;
+}
+
+fn Decl* Analyser.findMemberOffset(Analyser* ma, BuiltinExpr* b, StructTypeDecl* std, Expr* member) {
+    FindMemberOffsetContext ctx = { std, 0 }
+    Decl* d = ma.findMemberOffsetAux(&ctx, member);
+    if (d) b.setUValue(ctx.base_offset);
     return d;
 }
 

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -108,7 +108,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
                 call.setCallsTypeFunc();
                 baseType = m.getBaseType();
                 // loc points to the last member of the function name
-                loc = m.getLastLoc();
+                loc = m.getMemberLoc();
             }
             break;
         case StaticTypeFunc:
@@ -149,7 +149,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
             if (!baseType.isPointer()) {
                 // TODO: Check if structure is lvalue. If not, we should add a local object to
                 // store the rvalue and use that as the lvalue
-                Expr* base = m.getExprBase();
+                Expr* base = m.getBaseExpr();
                 if (base && !base.isLValue()) {
                     ma.errorRange(m.getLoc(0), base.getRange(), "type function needs lvalue");
                     return QualType_Invalid;

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -167,7 +167,7 @@ fn Decl* Analyser.analyseIdentifier(Analyser* ma, Expr** e_ptr, u32 side) {
     IdentifierKind kind = ma.setExprFlags(e_ptr, d);
     i.setKind(kind);
 
-    if (ma.usedPublic && !d.isPublic() && d.isGlobal()) {
+    if (ma.usedPublic && !d.isPublic() && d.isGlobal() && !d.isImport()) {
         // Note: can also be a function or type for inline function bodies
         const char* kind_str = type2str(qt);
         if (ma.scope.inFunction()) {
@@ -400,12 +400,12 @@ fn bool Analyser.checkAssignment(Analyser* ma, Expr* assignee, QualType tleft, c
             case Type:
                 break;
             case Var:
-                ma.error(loc, "cannot assign to read-only variable '%s'", m.getLastMemberName());
+                ma.error(loc, "cannot assign to read-only variable '%s'", m.getMemberName());
                 return false;
             case EnumConstant:
                 break;
             case StructMember:
-                ma.error(loc, "assignment of member '%s' in read-only object", m.getLastMemberName());
+                ma.error(loc, "assignment of member '%s' in read-only object", m.getMemberName());
                 return false;
             case Label:
                 break;

--- a/analyser/module_analyser_member.c2
+++ b/analyser/module_analyser_member.c2
@@ -24,30 +24,29 @@ const char[] DiagStaticThoughVar = "cannot access static type-function through v
 
 fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
     Expr* e = *e_ptr;
-    MemberExpr* m =(MemberExpr*)e;
+    MemberExpr* m = (MemberExpr*)e;
 
     SrcLoc baseLoc = 0;
-    ValType valtype = ValType.NValue;
+    ValType valtype = NValue;
     QualType baseType = QualType_Invalid;
 
     CallKind ck = Invalid;
+    u32 start = 0;
 
     if (m.hasExpr()) {
-        Expr* exprBase = m.getExprBase();
+        Expr* exprBase = m.getBaseExpr();
+        baseLoc = exprBase.getLoc();
         // note: no ImplicitCast can be added
         baseType = ma.analyseExpr(&exprBase, false, side);
         if (baseType.isInvalid()) return QualType_Invalid;
 
         valtype = exprBase.getValType();
-
-        //stdio.printf("EXPR BASE\n");
-        //baseType.dump();
+        start = 1;
     }
 
     Decl* d = nil;
-    u32 refcount = m.getNumRefs();
-    bool is_substruct;
-    for (u32 i=0; i<refcount; i++) {
+    bool is_substruct = false;
+    for (u32 i = start; i < 2; i++) {
         is_substruct = false;
         u32 name_idx = m.getNameIdx(i);
         SrcLoc loc = m.getLoc(i);
@@ -55,6 +54,7 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
         //stdio.printf("  [%d/%d] %s\n", i, refcount, m.getName(i));
 
         if (baseType.isInvalid()) {
+            // first member
             d = ma.scope.find(name_idx, loc, ma.usedPublic);
             if (!d) {
                 ma.has_error = true;
@@ -121,15 +121,14 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
                 //stdio.printf("ENUM BASE  (type: %d)\n", valtype == ValType.NValue);
                 EnumType* et = (EnumType*)t;
                 EnumTypeDecl* etd = et.getDecl();
+                d = (Decl*)etd;
 
                 // check if constant/enum-function (by first casing)
-                const char* last = m.getLastMemberName();
-                if (ctype.isupper(last[0]) || name_idx == ma.min_idx || name_idx == ma.max_idx) {   // search for constants
-                    if (valtype != ValType.NValue) {    // variable of Enum type (eg Enum a; a.x)
+                const char* name = m.getMemberName();
+                if (ctype.isupper(name[0]) || name_idx == ma.min_idx || name_idx == ma.max_idx) {   // search for constants
+                    if (valtype != NValue) {    // variable of Enum type (eg Enum a; a.x)
                         // TODO reset msg to normal invalid base
-                        // TODO use range
-                        //ma.errorRange(baseLoc, m.getRange(i), "invalid member reference base (enum constant/variable)");
-                        ma.error(baseLoc, "invalid member reference base (enum constant/variable)");
+                        ma.errorRange(baseLoc, m.getBaseRange(), "invalid member reference base (enum constant/variable)");
                         return QualType_Invalid;
                     }
                     EnumConstantDecl* ecd;
@@ -143,7 +142,7 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
                     } else {
                         ecd = etd.findConstant(name_idx);
                         if (!ecd) {
-                            ma.error(loc, "enum '%s' has no constant '%s'", d.getFullName(), m.getLastMemberName());
+                            ma.error(loc, "enum '%s' has no constant '%s'", d.getFullName(), name);
                             return QualType_Invalid;
                         }
                     }
@@ -154,10 +153,9 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
                     }
                     // no need to update baseType
                 } else {    // search for enum-function
-                    d = (Decl*)etd;
                     Decl* ef = etd.findFunction(name_idx);
                     if (!ef) {
-                        ma.error(loc, "enum '%s' has no function '%s'", d.getFullName(), m.getLastMemberName());
+                        ma.error(loc, "enum '%s' has no function '%s'", d.getFullName(), name);
                         return QualType_Invalid;
                     }
                     //FunctionDecl* fd = (FunctionDecl*)ef);
@@ -167,7 +165,7 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
                     baseType = ef.getType();
                     if (!ma.scope.checkAccess(d, loc)) return QualType_Invalid;
                 }
-                valtype = ValType.RValue;
+                valtype = RValue;
                 break;
             case Alias:
                 assert(0);
@@ -188,7 +186,7 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
                 valtype = decl2valtype(d);
                 break;
             default:
-                ma.errorRange(loc, m.getRange(i), "invalid member reference base");
+                ma.errorRange(loc, m.getBaseRange(), "invalid member reference base");
                 return QualType_Invalid;
             }
         }
@@ -196,14 +194,12 @@ fn QualType Analyser.analyseMemberExpr(Analyser* ma, Expr** e_ptr, u32 side) {
         baseLoc = loc;
 
         // Note: a.b.c  = 1; -> b is always used, c only if in RHS
-        if (i == refcount -1) {
+        if (i == 1) {
             if (side & RHS) d.setUsed();
         } else {
             d.setUsed();
         }
         m.setDecl(d, i);
-
-        //baseType.dump();
     }
 
     if (is_substruct) {
@@ -278,7 +274,7 @@ fn Decl* Analyser.analyseStructMemberAccess(Analyser* ma, StructTypeDecl* std, u
         // StructTypeDecl for substruct or VarDecl for normal members
         // TODO FIX THIS (do in outer?)
 #if 1
-        if (side && valtype == ValType.NValue) {
+        if (side && valtype == NValue) {
             QualType t = std.asDecl().getType();
             ma.error(loc, "member access needs an instantiation of type '%s'", t.diagName());
             return nil;
@@ -303,7 +299,7 @@ fn TypeKind Analyser.analyseBaseType(Analyser* ma, QualType baseType) {
 fn ValType decl2valtype(const Decl* d) {
     switch (d.getKind()) {
     case Function:
-        return ValType.RValue;
+        return RValue;
     case Import:
     case StructType:
     case EnumType:
@@ -312,8 +308,8 @@ fn ValType decl2valtype(const Decl* d) {
     case AliasType:
         break;
     case Variable:
-        return ValType.LValue;
+        return LValue;
     }
-    return ValType.NValue;
+    return NValue;
 }
 

--- a/ast/identifier_expr.c2
+++ b/ast/identifier_expr.c2
@@ -18,7 +18,6 @@ module ast;
 import ast_context;
 import string_buffer;
 import src_loc local;
-import string local;
 
 public type IdentifierKind enum u8 {
     Unresolved,
@@ -49,6 +48,7 @@ type IdentifierExprBits struct {
     u32 : NumExprBits;
     u32 has_decl : 1;
     u32 kind : 3;   // IdentifierKind
+    u32 name_len : 32 - 18;
 }
 
 public type IdentifierExpr struct @(opaque) {
@@ -59,10 +59,11 @@ public type IdentifierExpr struct @(opaque) {
     }
 }
 
-public fn IdentifierExpr* IdentifierExpr.create(ast_context.Context* c, SrcLoc loc, u32 name) {
+public fn IdentifierExpr* IdentifierExpr.create(ast_context.Context* c, SrcLoc loc, u32 name, u32 name_len) {
     IdentifierExpr* e = c.alloc(sizeof(IdentifierExpr));
     e.base.init(Identifier, loc, 0, 0, 0, ValType.NValue);
     e.name_idx = name;
+    e.base.base.identifierExprBits.name_len = name_len;
 #if AstStatistics
     Stats.addExpr(Identifier, sizeof(IdentifierExpr));
 #endif
@@ -70,10 +71,10 @@ public fn IdentifierExpr* IdentifierExpr.create(ast_context.Context* c, SrcLoc l
 }
 
 fn Expr* IdentifierExpr.instantiate(IdentifierExpr* e, Instantiator* inst) {
-    return (Expr*)IdentifierExpr.create(inst.c, e.base.base.loc, e.name_idx);
+    return (Expr*)IdentifierExpr.create(inst.c, e.base.base.loc, e.name_idx, e.base.base.identifierExprBits.name_len);
 }
 
-public fn Expr* IdentifierExpr.asExpr(IdentifierExpr* e) { return &e.base; }
+fn Expr* IdentifierExpr.asExpr(IdentifierExpr* e) { return &e.base; }
 
 public fn void IdentifierExpr.setDecl(IdentifierExpr* e, Decl* decl) {
     e.decl = decl;
@@ -105,7 +106,7 @@ public fn const char* IdentifierExpr.getName(const IdentifierExpr* e) {
 }
 
 fn SrcLoc IdentifierExpr.getEndLoc(const IdentifierExpr* e) {
-    return e.base.base.loc + (u32)strlen(e.getName());
+    return e.base.base.loc + e.base.base.identifierExprBits.name_len;
 }
 
 public fn u32 IdentifierExpr.getNameIdx(const IdentifierExpr* e) {

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -21,8 +21,6 @@ import string_buffer;
 
 import string;
 
-public const u32 MemberExprMaxDepth = 7;
-
 public type MemberConversion enum u8 {
     None,
     Addr,       // Foo -> Foo* (ie &f)
@@ -32,8 +30,7 @@ public type MemberConversion enum u8 {
 type MemberExprBits struct {
     u32 : NumExprBits;
     u32 kind : 3;   // IdentifierKind
-    u32 num_refs : 3;   // Excluding one for Expr* if has_expr
-    u32 num_decls : 3;  // how many refs have a decl (from the bottom up), set during analysis
+    u32 num_decls : 2;  // how many refs have a decl (from the bottom up), set during analysis
     u32 has_expr : 1;
     u32 is_struct_func : 1; // not only a function with prefix, but also used that way
     u32 is_static_sf : 1;
@@ -41,53 +38,39 @@ type MemberExprBits struct {
     u32 is_volatile_base : 1;
     u32 conversion : 2; // MemberConversion
     u32 is_bitfield : 1;
+    u32 base_len : 5;
 }
 
-/*
-    2 variants: (a.b.c.d..)
-    - Pure (a = Identifier, num_refs >= 1
-        -> base.loc is the loc of the rhs (= first ref)
-    - Non-Pure (a = Expr, num_refs >= 2)
-        -> base.loc is the loc of the first ref (= lhs)
-        u32 locs[num_refs-1]
-*/
-
+// 2 variants: pure: `a.b` and non pure: `<expr>.b`
 type MemberRef union {
     u32 name_idx;
     Decl* decl;     // set during analysis
     Expr* expr;     // for first ref in non-pure mode
+    usize bits;
 }
 
 static_assert(8, sizeof(MemberRef));
 
 public type MemberExpr struct @(opaque) {
-    // Note: loc is that of Member or first ref
+    // base.loc points to the beginning of the member name in refs[1]
     Expr base;
-    MemberRef[0] refs;  // tail-allocated, num_ref times
-    // u32[numrefs-1] locs  // tail-allocated
+    MemberRef[2] refs;
 }
 
 // if base == nil, MemberExpr is pure, otherwise non-pure
-public fn MemberExpr* MemberExpr.create(ast_context.Context* c, Expr* base, const Ref* refs, u32 refcount) {
-    u32 size = sizeof(MemberExpr) + refcount * sizeof(MemberRef) + (refcount - 1) * sizeof(u32);
-    if (base) size += sizeof(MemberRef);
+public fn MemberExpr* MemberExpr.create(ast_context.Context* c, Expr* base, u32 base_name_idx, u32 base_len, SrcLoc loc, u32 member_name_idx) {
+    u32 size = sizeof(MemberExpr);
     MemberExpr* e = c.alloc(size);
-    e.base.init(Member, refs[0].loc, 0, 0, 0, NValue);
-    e.base.base.memberExprBits.num_refs = refcount;
-    u32 offset = 0;
+    e.base.init(Member, loc, 0, 0, 0, NValue);
+    e.base.base.memberExprBits.base_len = base_len;
+    e.refs[0].bits = 0;
+    e.refs[0].name_idx = base_name_idx;
     if (base) {
-        offset = 1;
         e.refs[0].expr = base;
         e.base.base.memberExprBits.has_expr = 1;
     }
-
-    for (u32 i=0; i<refcount; i++) {
-        e.refs[i+offset].name_idx = refs[i].name_idx;
-    }
-    SrcLoc* locs = (SrcLoc*)&e.refs[refcount + offset];
-    for (u32 i=0; i<refcount-1; i++) { // first loc already in base.loc
-        locs[i] = refs[i+1].loc;    // shift them all
-    }
+    e.refs[1].bits = 0;
+    e.refs[1].name_idx = member_name_idx;
 #if AstStatistics
     Stats.addExpr(Member, size);
 #endif
@@ -95,14 +78,11 @@ public fn MemberExpr* MemberExpr.create(ast_context.Context* c, Expr* base, cons
 }
 
 fn Expr* MemberExpr.instantiate(MemberExpr* e, Instantiator* inst) {
-    u32 refcount = e.base.base.memberExprBits.num_refs;
-    Expr* base = e.getExprBase();
-    u32 size = sizeof(MemberExpr) + refcount * sizeof(MemberRef) + (refcount - 1) * sizeof(u32);
-    if (base) size += sizeof(MemberRef);
+    u32 size = sizeof(MemberExpr);
     MemberExpr* e2 = inst.c.alloc(size);
 
     string.memcpy(e2, e, size);
-    if (base) e2.refs[0].expr = base.instantiate(inst);
+    if (e2.hasExpr()) e2.refs[0].expr = e2.refs[0].expr.instantiate(inst);
 
 #if AstStatistics
     Stats.addExpr(Member, size);
@@ -114,7 +94,7 @@ public fn bool MemberExpr.hasExpr(const MemberExpr* e) {
     return e.base.base.memberExprBits.has_expr;
 }
 
-public fn Expr* MemberExpr.getExprBase(const MemberExpr* e) {
+public fn Expr* MemberExpr.getBaseExpr(const MemberExpr* e) {
     if (e.hasExpr()) return e.refs[0].expr;
     return nil;
 }
@@ -127,21 +107,18 @@ public fn MemberConversion MemberExpr.getConversion(const MemberExpr* e) {
     return (MemberConversion)e.base.base.memberExprBits.conversion;
 }
 
-fn const char* MemberExpr.getName(const MemberExpr* e, u32 ref_idx) {
-    const MemberRef* ref = &e.refs[ref_idx + e.hasExpr()];
-    if (e.base.base.memberExprBits.num_decls > ref_idx) {
-        return ref.decl.getName();
-    }
-    return idx2name(ref.name_idx);
-}
-
-public fn u32 MemberExpr.getNumRefs(const MemberExpr* e) {
-    return e.base.base.memberExprBits.num_refs;
+public fn const char* MemberExpr.getName(const MemberExpr* e, u32 ref_idx) {
+    if (u32 name_idx = e.getNameIdx(ref_idx)) return idx2name(name_idx);
+    return nil;
 }
 
 public fn u32 MemberExpr.getNameIdx(const MemberExpr* e, u32 ref_idx) {
-    const MemberRef* ref = &e.refs[ref_idx + e.hasExpr()];
-
+    if (ref_idx == 0 && e.hasExpr()) {
+        Expr* base = e.getBaseExpr();
+        if (base.isIdentifier()) return ((IdentifierExpr*)base).getNameIdx();
+        return 0;
+    }
+    const MemberRef* ref = &e.refs[ref_idx];
     if (e.base.base.memberExprBits.num_decls > ref_idx) {
         Decl* d = ref.decl;
         if (d.isImport()) {
@@ -154,23 +131,48 @@ public fn u32 MemberExpr.getNameIdx(const MemberExpr* e, u32 ref_idx) {
     return ref.name_idx;
 }
 
-public fn SrcLoc MemberExpr.getLoc(const MemberExpr* e, u32 ref_idx) {
-    if (ref_idx == 0) return e.base.getLoc();
-
-    SrcLoc* locs = (SrcLoc*)&e.refs[e.getNumRefs() + e.hasExpr()];
-    return locs[ref_idx-1];
+public fn SrcLoc MemberExpr.getLoc(const MemberExpr* e, u32 ref_idx = 1) {
+    SrcLoc loc = e.base.getLoc();
+    if (ref_idx) return loc;
+    if (e.hasExpr()) return e.getBaseExpr().getLoc();
+    return loc - 1 - e.base.base.memberExprBits.base_len;
 }
 
-public fn SrcRange MemberExpr.getRange(const MemberExpr* e, u32 ref_idx) {
-    SrcRange range = { e.getStartLoc(), e.getLoc(ref_idx) - 1 } // cut off . and member
-    return range;
+public fn SrcLoc MemberExpr.getMemberLoc(const MemberExpr* e) {
+    return e.base.getLoc();
 }
 
-public fn Ref MemberExpr.getRef(const MemberExpr* e, u32 ref_idx) {
+fn SrcLoc MemberExpr.getStartLoc(const MemberExpr* e) {
+    if (e.hasExpr()) return e.refs[0].expr.getStartLoc();
+    return e.base.getLoc() - 1 - e.base.base.memberExprBits.base_len;
+}
+
+fn SrcLoc MemberExpr.getEndLoc(const MemberExpr* e) {
+    return e.base.getLoc() + (u32)string.strlen(e.getName(1));
+}
+
+fn SrcLoc MemberExpr.getBaseEndLoc(const MemberExpr* e) {
+    if (e.hasExpr()) return e.getBaseExpr().getEndLoc();
+    return e.base.getLoc() - 1;
+}
+
+public fn SrcRange MemberExpr.getBaseRange(const MemberExpr* e) {
+    return { e.getStartLoc(), e.getBaseEndLoc() }
+}
+
+public fn Ref MemberExpr.getBaseRef(const MemberExpr* e) {
     Ref ref;
-    ref.loc = e.getLoc(ref_idx);
-    ref.name_idx = e.getNameIdx(ref_idx);
-    ref.decl = e.getDecl(ref_idx);
+    ref.loc = e.getStartLoc();
+    ref.name_idx = e.getNameIdx(0);
+    ref.decl = e.getDecl(0);
+    return ref;
+}
+
+public fn Ref MemberExpr.getRef(const MemberExpr* e) {
+    Ref ref;
+    ref.loc = e.getLoc(1);
+    ref.name_idx = e.getNameIdx(1);
+    ref.decl = e.getDecl(1);
     return ref;
 }
 
@@ -228,65 +230,45 @@ fn bool MemberExpr.isVolatileBase(const MemberExpr* e) {
     return e.base.base.memberExprBits.is_volatile_base;
 }
 
-// returns the final decl after a.b.c.d <-  returns c. Must be fully analysed
-// does not work when first expr is an expr!
-public fn Decl* MemberExpr.getPrevLastDecl(const MemberExpr* e) {
-    u32 num = e.getNumRefs();
-    if (e.base.base.memberExprBits.num_decls < num) return nil;
-
-    num += e.hasExpr();
-    return e.refs[num-2].decl;
+// returns the final base decl (eg: a.b.c.d <- returns c). Must be fully analysed
+public fn Decl* MemberExpr.getBaseDecl(const MemberExpr* e) {
+    if (e.hasExpr()) {
+        Expr* base = e.getBaseExpr();
+        if (base.isIdentifier()) return ((IdentifierExpr*)base).getDecl();
+        if (base.isMember()) return ((MemberExpr*)base).getFullDecl();
+        return nil;
+    }
+    if (e.base.base.memberExprBits.num_decls < 1) return nil;
+    return e.refs[0].decl;
 }
 
 // returns the final decl after a.b.c.d <-, must be fully analysed
 public fn Decl* MemberExpr.getFullDecl(const MemberExpr* e) {
-    u32 num = e.getNumRefs();
-    if (e.base.base.memberExprBits.num_decls < num) return nil;
-
-    num += e.hasExpr();
-    return e.refs[num-1].decl;
+    if (e.base.base.memberExprBits.num_decls < 2) return nil;
+    return e.refs[1].decl;
 }
 
 public fn Decl* MemberExpr.getDecl(const MemberExpr* e, u32 ref_idx) {
     if (e.base.base.memberExprBits.num_decls <= ref_idx) return nil;
-    return e.refs[ref_idx + e.hasExpr()].decl;
+    return e.refs[ref_idx].decl;
 }
 
 public fn void MemberExpr.setDecl(MemberExpr* e, Decl* d, u32 ref_idx) {
     e.base.base.memberExprBits.num_decls = ref_idx + 1;
-
-    e.refs[ref_idx + e.hasExpr()].decl = d;
-}
-
-fn SrcLoc MemberExpr.getStartLoc(const MemberExpr* e) {
-    if (e.hasExpr()) return e.refs[0].expr.getStartLoc();
-    return e.base.getLoc();
-}
-
-public fn SrcLoc MemberExpr.getLastLoc(const MemberExpr* e) {
-    return e.getLoc(e.getNumRefs() - 1);
-}
-
-fn SrcLoc MemberExpr.getEndLoc(const MemberExpr* e) {
-    u32 last = e.getNumRefs() - 1;
-    return e.getLoc(last) + (u32)string.strlen(e.getName(last));
+    e.refs[ref_idx].decl = d;
 }
 
 public fn QualType MemberExpr.getBaseType(const MemberExpr* m) {
-    u32 numRefs = m.getNumRefs();
-    QualType qt;
-    if (m.hasExpr() && numRefs == 1) {
-        qt = m.refs[0].expr.getType();
-    } else {
-        qt = m.refs[m.hasExpr() + numRefs-2].decl.getType();
-    }
+    if (m.hasExpr()) return m.refs[0].expr.getType();
+    // TODO: check num_decls?
+    QualType qt = m.refs[0].decl.getType();
     if (m.isConstBase()) qt.setConst();
     if (m.isVolatileBase()) qt.setVolatile();
     return qt;
 }
 
-public fn const char* MemberExpr.getLastMemberName(const MemberExpr* e) {
-    return e.getName(e.getNumRefs()-1);
+public fn const char* MemberExpr.getMemberName(const MemberExpr* e) {
+    return e.getName(1);
 }
 
 fn void MemberExpr.print(const MemberExpr* e, string_buffer.Buf* out, u32 indent) {
@@ -313,7 +295,7 @@ fn void MemberExpr.print(const MemberExpr* e, string_buffer.Buf* out, u32 indent
         out.add(" Deref");
         break;
     }
-    out.print(" refs=%d/%d ", e.base.base.memberExprBits.num_decls, e.getNumRefs());
+    out.print(" refs=%d/2 ", e.base.base.memberExprBits.num_decls);
     out.color(col_Value);
     e.printLiteral(out);
     out.newline();
@@ -323,43 +305,42 @@ fn void MemberExpr.print(const MemberExpr* e, string_buffer.Buf* out, u32 indent
 fn void MemberExpr.printLiteral(const MemberExpr* e, string_buffer.Buf* out) {
     if (e.hasExpr()) {
         e.refs[0].expr.printLiteral(out);
-        out.add1('.');
+    } else {
+        out.add(e.getName(0));
     }
-    for (u32 i = 0; i < e.getNumRefs(); i++) {
-        if (i != 0) out.add1('.');
-        out.add(e.getName(i));
-    }
+    out.add1('.');
+    out.add(e.getName(1));
 }
 
 public fn void MemberExpr.dump(const MemberExpr* m) @(unused) {
     string_buffer.Buf* out = ast.getDumpBuf();
     out.color(col_Expr);
-    out.print("MemberExpr expr %d ref %d/%d\n", m.hasExpr(), m.base.base.memberExprBits.num_decls, m.getNumRefs());
+    out.print("MemberExpr loc %d expr %d decl %d/2\n",
+              m.base.getLoc(), m.hasExpr(), m.base.base.memberExprBits.num_decls);
     const MemberExprBits* bits = &m.base.base.memberExprBits;
     IdentifierKind k = (IdentifierKind)bits.kind;
-    out.print("  bits: %d refs, kind %s, sf %d, ssf %d, conv %d, bitf %d\n",
-        bits.num_refs, k.str(), bits.is_struct_func, bits.is_static_sf,
-        bits.conversion, bits.is_bitfield);
+    out.print("  bits: kind %s, sf %d, ssf %d, conv %d, bitf %d\n",
+              k.str(), bits.is_struct_func, bits.is_static_sf,
+              bits.conversion, bits.is_bitfield);
+    u32 start = 0;
     if (m.hasExpr()) {
         out.indent(1);
         out.color(col_Value);
         out.add("<expr>\n");
-        Expr* e = m.getExprBase();
+        Expr* e = m.getBaseExpr();
         e.print(out, 1);
+        start = 1;
     }
-    out.indent(1);
-    out.print("[0]   (loc %d)\n", m.base.getLoc());
-    for (u32 i=0; i<m.getNumRefs(); i++) {
-        const MemberRef* ref = &m.refs[i + m.hasExpr()];
+    for (u32 i = start; i < 2; i++) {
+        const MemberRef* ref = &m.refs[i];
         out.indent(1);
         out.color(col_Expr);
         if (m.base.base.memberExprBits.num_decls > i) {
             out.print("[%d]\n", i);
             ref.decl.print(out, 1);
         } else {
-            out.print("[%d] %s  (loc %d)\n", i, idx2name(ref.name_idx), m.getLoc(i));
+            out.print("[%d] %s\n", i, idx2name(ref.name_idx));
         }
-
     }
     ast.flushDumpBuf(out);
 }

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -171,12 +171,6 @@ public fn QualType QualType.getImplType(const QualType* qt) {
     return canon;
 }
 
-// Note: should be valid and PointerType
-public fn bool QualType.isConstPtr(const QualType qt) {
-    PointerType* pt = qt.getPointerType();
-    return pt.inner.isConst();
-}
-
 public fn TypeKind QualType.getKind(const QualType qt) {
     Type* t = qt.getType();
     return t.getKind();

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -57,7 +57,7 @@ static_assert(8, sizeof(ReturnStmt));
 static_assert(16, sizeof(Expr));
 static_assert(16, sizeof(BooleanLiteral));
 static_assert(16, sizeof(CharLiteral));
-static_assert(16, sizeof(MemberExpr));
+static_assert(32, sizeof(MemberExpr));
 static_assert(16, sizeof(NilExpr));
 static_assert(24, sizeof(IdentifierExpr));
 static_assert(24, sizeof(ImplicitCastExpr));

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -905,8 +905,8 @@ public fn Stmt* Builder.actOnGotoStmt(Builder* b, u32 name, SrcLoc loc) {
     return (Stmt*)GotoStmt.create(b.context, name, loc);
 }
 
-public fn IdentifierExpr* Builder.actOnIdentifier(Builder* b, SrcLoc loc, u32 name) {
-    return IdentifierExpr.create(b.context, loc, name);
+public fn Expr* Builder.actOnIdentifier(Builder* b, SrcLoc loc, u32 name, u32 name_len) {
+    return (Expr*)IdentifierExpr.create(b.context, loc, name, name_len);
 }
 
 public fn Expr* Builder.actOnIntegerLiteral(Builder* b, SrcLoc loc, u32 src_len, u64 value, Radix radix, BuiltinKind kind) {
@@ -1025,8 +1025,8 @@ public fn Expr* Builder.actOnExplicitCast(Builder* b,
     return (Expr*)ExplicitCastExpr.create(b.context, loc, src_len, ref, inner, c_style);
 }
 
-public fn Expr* Builder.actOnMemberExpr(Builder* b, Expr* base, const Ref* refs, u32 refcount) {
-    return (Expr*)MemberExpr.create(b.context, base, refs, refcount);
+public fn Expr* Builder.actOnMemberExpr(Builder* b, Expr* base, u32 base_name_idx, u32 base_len, SrcLoc loc, u32 member_name_idx) {
+    return (Expr*)MemberExpr.create(b.context, base, base_name_idx, base_len, loc, member_name_idx);
 }
 
 public fn Expr* Builder.actOnRange(Builder* b, SrcLoc loc, Expr* lhs, Expr* rhs) {

--- a/generator/ast_visitor_expr.c2
+++ b/generator/ast_visitor_expr.c2
@@ -129,12 +129,15 @@ fn void Visitor.handleCallExpr(Visitor* v, CallExpr* c) {
 }
 
 fn void Visitor.handleMemberExpr(Visitor* v, MemberExpr* m) {
-    if (m.hasExpr()) v.handleExpr(m.getExprBase());
-
-    for (u32 i=0; i<m.getNumRefs(); i++) {
-        Ref ref = m.getRef(i);
+    Ref ref;
+    if (m.hasExpr()) {
+        v.handleExpr(m.getBaseExpr());
+    } else {
+        ref = m.getBaseRef();
         v.on_ref(v.arg, &ref);
     }
+    ref = m.getRef();
+    v.on_ref(v.arg, &ref);
 }
 
 fn void Visitor.handleBuiltinExpr(Visitor* v, BuiltinExpr* b) {

--- a/generator/c/c_generator_call.c2
+++ b/generator/c/c_generator_call.c2
@@ -72,7 +72,8 @@ fn void Generator.emitCall(Generator* gen, string_buffer.Buf* out, Expr* e) {
                     out.add1('*');
                     break;
                 }
-                gen.emitMemberExprBase(out, func);
+                MemberContext mc = {}
+                gen.emitMemberExpr(out, m, &mc, true);
             }
         } else {
             bool no_trace = gen.no_trace;

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -124,7 +124,8 @@ fn void Generator.emitExpr2(Generator* gen, string_buffer.Buf* out, Expr* e, C_P
         }
         break;
     case Member:
-        gen.emitMemberExpr(out, e);
+        MemberContext mc = {}
+        gen.emitMemberExpr(out, (MemberExpr*)e, &mc);
         break;
     case Paren:
         ParenExpr* p = (ParenExpr*)e;
@@ -248,131 +249,80 @@ fn void emitDotOrArrow(string_buffer.Buf* out, QualType qt) {
     else out.add1('.');
 }
 
-fn void Generator.emitMemberExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
-    MemberExpr* m = (MemberExpr*)e;
-    bool need_dot = false;
-    QualType baseType = { }
-    if (m.hasExpr()) {
-        Expr* base = m.getExprBase();
-        gen.emitExpr2(out, base, Postfix);
-        baseType = base.getType();
-        need_dot = true;
-    }
+type MemberContext struct {
+    bool need_dot;
+    QualType baseType;
+    bool is_local;
+}
 
-    // dont switch on final, just generate
-    u32 numrefs = m.getNumRefs();
-    bool is_local = false;
-    for (u32 i=0; i<numrefs; i++) {
-        Decl* d = m.getDecl(i);
-        switch (d.getKind()) {
-        case Function:
-            if (need_dot) emitDotOrArrow(out, baseType);
-            baseType = d.getType();
-            gen.emitCNameMod(out, d, d.getModule());
-            break;
-        case Import:
-            // ignore
-            break;
-        case StructType:
-            // Note: can be substruct here or Type
-            if (need_dot) emitDotOrArrow(out, baseType);
-            StructTypeDecl* std = (StructTypeDecl*)d;
-            // Dont generate anything for Type, will be in prefix
-            if (!std.isGlobal()) {
-                baseType = d.getType();
-                out.add(d.getName());
-                need_dot = true;
-            }
-            break;
-        case EnumType:
-            // ignore
-            gen.genDeclIfNeeded(d);
-            break;
-        case EnumConstant:
-            gen.emitCNameMod(out, d, d.getModule());
-            break;
-        case FunctionType:
-            assert(0);
-            break;
-        case AliasType:
-            gen.emitCNameMod(out, d, d.getModule());
-            break;
-        case Variable:
-            if (need_dot) emitDotOrArrow(out, baseType);
-            baseType = d.getType();
-            if (is_local) {
-                out.add(d.getName());
-            } else {
-                gen.emitDeclName(out, d);
-            }
-            need_dot = true;
-            is_local = true;
-            break;
+fn void Generator.emitMemberDecl(Generator* gen, string_buffer.Buf* out, Decl* d, MemberContext* mc = nil) {
+    switch (d.getKind()) {
+    case Function:
+        if (mc.need_dot) emitDotOrArrow(out, mc.baseType);
+        mc.baseType = d.getType();
+        gen.emitCNameMod(out, d, d.getModule());
+        break;
+    case Import:
+        // ignore
+        break;
+    case StructType:
+        // Note: can be substruct here or Type
+        if (mc.need_dot) emitDotOrArrow(out, mc.baseType);
+        StructTypeDecl* std = (StructTypeDecl*)d;
+        // Dont generate anything for Type, will be in prefix
+        if (!std.isGlobal()) {
+            mc.baseType = d.getType();
+            out.add(d.getName());
+            mc.need_dot = true;
         }
+        break;
+    case EnumType:
+        // ignore
+        gen.genDeclIfNeeded(d);
+        break;
+    case EnumConstant:
+        gen.emitCNameMod(out, d, d.getModule());
+        break;
+    case FunctionType:
+        assert(0);
+        break;
+    case AliasType:
+        gen.emitCNameMod(out, d, d.getModule());
+        break;
+    case Variable:
+        if (mc.need_dot) emitDotOrArrow(out, mc.baseType);
+        mc.baseType = d.getType();
+        if (mc.is_local) {
+            out.add(d.getName());
+        } else {
+            gen.emitDeclName(out, d);
+        }
+        mc.need_dot = true;
+        mc.is_local = true;
+        break;
     }
 }
 
-fn void Generator.emitMemberExprBase(Generator* gen, string_buffer.Buf* out, Expr* e) {
-    // Note: used by SF/SSF calls
-    MemberExpr* m = (MemberExpr*)e;
-
-    bool need_dot = false;
-    QualType baseType = { }
+fn void Generator.emitMemberExpr(Generator* gen, string_buffer.Buf* out, MemberExpr* m, MemberContext* mc, bool base_only = false) {
     if (m.hasExpr()) {
-        Expr* base = m.getExprBase();
-        gen.emitExpr2(out, base, Postfix);
-        baseType = base.getType();
-        need_dot = true;
-    }
-
-    // dont switch on final, just generate
-    u32 numrefs = m.getNumRefs();
-    numrefs -= 1;   // Skip final arg
-    bool is_local = false;
-    for (u32 i=0; i<numrefs; i++) {
-        Decl* d = m.getDecl(i);
-        switch (d.getKind()) {
-        case Function:
-            if (need_dot) emitDotOrArrow(out, baseType);
-            baseType = d.getType();
-            gen.emitCNameMod(out, d, d.getModule());
-            break;
-        case Import:
-            // ignore
-            break;
-        case StructType:
-            // Note: always substruct here
-            if (need_dot) emitDotOrArrow(out, baseType);
-            baseType = d.getType();
-            out.add(d.getName());
-            need_dot = true;
-            break;
-        case EnumType:
-            // ignore
-            gen.genDeclIfNeeded(d);
-            break;
-        case EnumConstant:
-            gen.emitCNameMod(out, d, d.getModule());
-            break;
-        case FunctionType:
-            assert(0);
-            break;
-        case AliasType:
-            gen.emitCNameMod(out, d, d.getModule());
-            break;
-        case Variable:
-            if (need_dot) emitDotOrArrow(out, baseType);
-            baseType = d.getType();
-            if (is_local) {
-                out.add(d.getName());
-            } else {
-                gen.emitDeclName(out, d);
-            }
-            need_dot = true;
-            is_local = true;
-            break;
+        Expr* base = m.getBaseExpr();
+        if (base.isIdentifier()) {
+            IdentifierExpr* e = (IdentifierExpr*)base;
+            gen.emitMemberDecl(out, e.getDecl(), mc);
+        } else
+        if (base.isMember()) {
+            MemberExpr* e = (MemberExpr*)base;
+            gen.emitMemberExpr(out, e, mc);
+        } else {
+            gen.emitExpr2(out, base, Postfix);
+            mc.baseType = base.getType();
+            mc.need_dot = true;
         }
+    } else {
+        gen.emitMemberDecl(out, m.getDecl(0), mc);
     }
+    // dont switch on final, just generate
+    if (!base_only) gen.emitMemberDecl(out, m.getDecl(1), mc);
 }
 
 fn void Generator.emitFieldDesigExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {

--- a/generator/c/dep_finder.c2
+++ b/generator/c/dep_finder.c2
@@ -245,7 +245,7 @@ fn void Finder.handleMemberExpr(Finder* s, MemberExpr* m) {
     Decl* d = m.getFullDecl();
     if (d.isEnumConstant()) {
         // change Constant -> Enum
-        d = m.getPrevLastDecl();
+        d = m.getBaseDecl();
         assert(d.isEnum());
     }
     // TODO also add dep to struct for (static)type-functions

--- a/generator/c2i/c2i_generator_expr.c2
+++ b/generator/c2i/c2i_generator_expr.c2
@@ -174,19 +174,19 @@ fn void Generator.emitUnaryOperator(Generator* gen, string_buffer.Buf* out, cons
 }
 
 fn void Generator.emitMemberExpr(Generator* gen, string_buffer.Buf* out, const MemberExpr* m) {
-    const Expr* base = m.getExprBase();
+    const Expr* base = m.getBaseExpr();
     if (base) {
         gen.emitExpr(out, base);
-    }
-    for (u32 i=0; i<m.getNumRefs(); i++) {
-        if (i != 0 || base) out.add1('.');
-        Ref r = m.getRef(i);
-        if (i == 0 && r.decl.getModule() != gen.mod) {
-            out.add(r.decl.getFullName());
+    } else {
+        Decl* d = m.getDecl(0);
+        if (d.getModule() != gen.mod) {
+            out.add(d.getFullName());
         } else {
-            out.add(r.decl.getName());
+            out.add(d.getName());
         }
     }
+    out.add1('.');
+    out.add(m.getName(1));
 }
 
 fn void Generator.emitFieldDesigExpr(Generator* gen, string_buffer.Buf* out, const FieldDesignatedInitExpr* fdi) {

--- a/generator/ir/ir_generator_binop.c2
+++ b/generator/ir/ir_generator_binop.c2
@@ -374,7 +374,7 @@ fn void Generator.emitBitfieldAssign(Generator* gen, ir.Ref* result, const Expr*
 
     ir.Ref base;
     // TODO need without load
-    gen.emitMemberExpr(&base, lhs);
+    gen.emitMemberExpr(&base, (MemberExpr*)lhs);
 
     ir.Ref dest = base;
     if (!allBitsSet) {

--- a/generator/ir/ir_generator_call.c2
+++ b/generator/ir/ir_generator_call.c2
@@ -36,13 +36,13 @@ fn void Generator.emitCallExpr(Generator* gen, ir.Ref* result, const Expr* e) {
     ir.Ref name_ref;
     if (is_tf) {
         Expr* func = call.getFunc();
+        const MemberExpr* m = (MemberExpr*)func;
 
         // MemberExpr is marked as TF, so emitMemberExpr should only emit base part
         ir.Ref ref;
-        gen.emitMemberExpr(&ref, func);
+        gen.emitMemberExpr(&ref, m, true);
         arg_refs.add(ref);
 
-        const MemberExpr* m = (MemberExpr*)func;
         gen.emitSymbol(&name_ref, m.getFullDecl());
     } else {
         gen.emitExpr(&name_ref, call.getFunc());

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -78,7 +78,7 @@ fn void Generator.emitExpr(Generator* gen, ir.Ref* result, const Expr* e) {
         gen.emitArraySubscript(result, e);
         break;
     case Member:
-        gen.emitMemberExpr(result, e);
+        gen.emitMemberExpr(result, (MemberExpr*)e);
         break;
     case Paren:
         ParenExpr* p = (ParenExpr*)e;

--- a/generator/ir/ir_generator_member.c2
+++ b/generator/ir/ir_generator_member.c2
@@ -21,8 +21,7 @@ import ir local;
 import ir_context;
 
 // NOTE: should not be used for LHS bitfields!
-fn void Generator.emitMemberExpr(Generator* gen, ir.Ref* result, const Expr* e) {
-    const MemberExpr* m = (MemberExpr*)e;
+fn void Generator.emitMemberExpr(Generator* gen, ir.Ref* result, const MemberExpr* m, bool base_only = false) {
     ir_context.Context* c = gen.ctx;
 
     u32 tail = 0;
@@ -51,31 +50,40 @@ fn void Generator.emitMemberExpr(Generator* gen, ir.Ref* result, const Expr* e) 
 next:
     // base
     ir.Ref base_ref;
-    QualType base_type;
-    u32 idx = 0;
+    QualType base_type = {}
+    u32 start = 1;
     if (m.hasExpr()) {
-        const Expr* base = m.getExprBase();
-        gen.emitExpr(&base_ref, base);
-        base_type = base.getType();
-    } else {
-        Decl* base = m.getDecl(idx);
-        if (base.isImport()) {  // skip module prefix
-            idx++;
-            base = m.getDecl(idx);
+        const Expr* base = m.getBaseExpr();
+        // TODO: handle MemberExpr
+        if (base.isIdentifier()) {
+            // ignore module prefix
+            IdentifierExpr* i = (IdentifierExpr*)base;
+            Decl* dd = i.getDecl();
+            if (!dd.isImport()) {
+                gen.emitExpr(&base_ref, base);
+                base_type = base.getType();
+            }
+        } else {
+            gen.emitExpr(&base_ref, base);
+            base_type = base.getType();
         }
-        idx++;
+    } else {
+        Decl* base = m.getDecl(0);
+        if (base.isImport()) {  // skip module prefix
+            base = m.getDecl(1);
+            start = 2;
+        }
         assert(base.isVarDecl());
         gen.emitVarDecl(&base_ref, base);
         base_type = base.getType();
     }
 
     // member (a.b.c.etc)
-    u32 numrefs = m.getNumRefs();
-    numrefs -= tail;
+    u32 numrefs = 2 - tail;
 
     // TODO needs overhaul, a big mess at the moment
 
-    for (u32 i=idx; i<numrefs; i++) {
+    for (u32 i=start; i<numrefs; i++) {
         // for final only load if conversion is set?
         // First add offset, then deref!, also should not have to do this here anymore!
         bool is_pointer = base_type.isPointer();
@@ -92,7 +100,7 @@ next:
         u32 offset = 0;
         Decl* dd = std.findMember(d.getNameIdx(), &offset);
         if (!dd) {
-            e.dump();
+            ((Expr*)m).dump();
         }
         assert(dd);
 

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -252,13 +252,8 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
         p.error("expected expression");
         break;
     case 1: // Identifier
-        // Fast-path, keep checking multiple identifier.identifier. etc
-        // parse them all in a single MemberExpr
-        if (p.peekToken(1) == Dot) {
-            res = p.parsePureMemberExpr();
-        } else {
-            res = p.parseIdentifier().asExpr();
-        }
+        // parse all members in a single shot
+        res = p.parsePureMemberExpr();
         couldBeTemplateCall = true;
 /*
         // Make sure to pass down the right value for isAddressOfOperand.
@@ -448,60 +443,29 @@ fn Expr* Parser.parseTemplateCallExpr(Parser* p, Expr* func, const TypeRefHolder
 }
 
 fn Expr* Parser.parseImpureMemberExpr(Parser* p, Expr* base) {
-    // a[x].b.c, a[x] is base
-    p.consumeToken();   // dot
-    p.expectIdentifier();
-
-    Ref[MemberExprMaxDepth] ref;
-
-    ref[0].loc = p.tok.loc;
-    ref[0].name_idx = p.tok.name_idx;
-    u32 refcount = 1;
-    p.consumeToken();
-
-    while (p.tok.kind == Dot) {
-        p.consumeToken();
+    // Create simple `MemberExpr` for all parts
+    for (;;) {
+        p.consumeToken();   // dot
         p.expectIdentifier();
-
-        if (refcount == elemsof(ref)) p.error("max member depth is %d", MemberExprMaxDepth);
-
-        ref[refcount].loc = p.tok.loc;
-        ref[refcount].name_idx = p.tok.name_idx;
-        refcount++;
+        base = p.builder.actOnMemberExpr(base, 0, 0, p.tok.loc, p.tok.name_idx);
         p.consumeToken();
+        if (p.tok.kind != Dot) break;
     }
-
-    return p.builder.actOnMemberExpr(base, ref, refcount);
+    return base;
 }
 
 fn Expr* Parser.parsePureMemberExpr(Parser* p) {
-    // parse as many <id>.<id>.<id> and store them in a single member-expr
-    Ref[MemberExprMaxDepth] ref;
-
-    ref[0].loc = p.tok.loc;
-    ref[0].name_idx = p.tok.name_idx;
-    u32 refcount = 1;
+    SrcLoc loc = p.tok.loc;
+    u32 name_idx = p.tok.name_idx;
+    u32 name_len = p.tok.len;
     p.consumeToken();
-
-    while (p.tok.kind == Dot) {
-        p.consumeToken();
-        p.expectIdentifier();
-
-        if (refcount == elemsof(ref)) p.error("max member depth is %d", MemberExprMaxDepth);
-
-        ref[refcount].loc = p.tok.loc;
-        ref[refcount].name_idx = p.tok.name_idx;
-        refcount++;
-        p.consumeToken();
-    }
-
-    return p.builder.actOnMemberExpr(nil, ref, refcount);
-}
-
-fn IdentifierExpr* Parser.parseIdentifier(Parser* p) {
-    IdentifierExpr* e = p.builder.actOnIdentifier(p.tok.loc, p.tok.name_idx);
+    if (p.tok.kind != Dot) return p.builder.actOnIdentifier(loc, name_idx, name_len);
+    p.consumeToken();  // Dot
+    p.expectIdentifier();
+    Expr* lhs = p.builder.actOnMemberExpr(nil, name_idx, name_len, p.tok.loc, p.tok.name_idx);
     p.consumeToken();
-    return e;
+    if (p.tok.kind != Dot) return lhs;
+    return p.parseImpureMemberExpr(lhs);
 }
 
 fn Expr* Parser.parseStringLiteral(Parser* p) {
@@ -628,8 +592,6 @@ fn Expr* Parser.parseElemsof(Parser* p) {
     p.consumeToken();
 
     p.expectAndConsume(LParen);
-
-    p.expectIdentifier();
 
     // TODO parse as TypeRefholder (can have module.prefix and array index
     Expr* res = p.parseFullIdentifier();
@@ -789,11 +751,7 @@ fn Expr* Parser.parseToContainerExpr(Parser* p) {
 //   identifier.identifier.identifier etc
 fn Expr* Parser.parseFullIdentifier(Parser* p) {
     p.expectIdentifier();
-
-    if (p.peekToken(1) == Dot) {
-        return p.parsePureMemberExpr();
-    }
-    return p.parseIdentifier().asExpr();
+    return p.parsePureMemberExpr();
 }
 
 /*

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -564,13 +564,9 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
                     p.error("local qualified variables cannot have an init call");
                 if (isCondition)
                     p.error("cannot use an init call inside a condition");
+                u32 name_len = p.tok.len;
                 p.consumeToken();
-                Ref[2] refs;
-                refs[0].loc = loc;
-                refs[0].name_idx = name;
-                refs[1].loc = p.tok.loc;
-                refs[1].name_idx = p.tok.name_idx;
-                Expr* func = p.builder.actOnMemberExpr(nil, refs, 2);
+                Expr* func = p.builder.actOnMemberExpr(nil, name, name_len, p.tok.loc, p.tok.name_idx);
                 p.consumeToken();
                 initValue = p.parseCallExpr(func);
                 has_init_call = true;


### PR DESCRIPTION
* restrict `MemberExpr` nodes to `<expr>.b` and `a.b` forms
* store a single `SrcLoc` for the member name (size is always 32 bytes)
* use bitfield to avoid using `strlen` for SrcLoc computations
* simplify `Parser.parseCastExpr`, `p.parsePureMemberExpr` and `Parser.parseImpureMemberExpr`: no longer use `peekToken` on identifiers.
* store name length in `IdentifierExpr` nodes to simplify end location computation
* rename `MemberExpr.getExprBase` as `MemberExpr.getBaseExpr` for consistency
* merge `Generator.emitMemberExprBase` into `Generator.emitMemberExpr`
* disable bogus const check in `conversion_checker.Checker.check`
* improve `Analyser.analyseToContainer` for const/volatile correctness
* fix `Analyser.findMemberOffset` for member expression chains should support  ̀to_container(s, array[n].ptr, ptr)`?
* this simplifies the code and reduces memory usage by 100KB