### PR TITLE
Analyser: use precise enum bit width for bitfield width validation

### DIFF
--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -104,11 +104,15 @@ fn void Analyser.analyseStructMembers(Analyser* ma, StructTypeDecl* d) {
                 u32 field_width = value.as_u32();
                 vd.setBitfieldWidth((u8)field_width);
 
-                if (qt.isEnum() && field_width < type_width) {
-                    if (name)
-                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has insufficient bits for enum '%s'", name, qt.diagName());
-                    else
-                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "unnamed bit-field has insufficient bits for enum '%s'", qt.diagName());
+                u32 minimum_type_width = qt.getBitFieldWidth(true);
+                if (qt.isEnum() && field_width < minimum_type_width) {
+                    if (name) {
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "bit-field '%s' has insufficient bits for enum '%s' (need %d bits)",
+                                      name, qt.diagName(), minimum_type_width);
+                    } else {
+                        ma.errorRange(bitfield.getLoc(), bitfield.getRange(), "unnamed bit-field has insufficient bits for enum '%s' (need %d bits)",
+                                      qt.diagName(), minimum_type_width);
+                    }
                     return;
                 }
 

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -88,7 +88,7 @@ public fn bool QualType.isValid(const QualType qt) { return qt.ptr != 0; }
 public fn bool QualType.isInvalid(const QualType qt) { return qt.ptr == 0; }
 
 // Note: assumes type is valid
-public fn u32 QualType.getBitFieldWidth(const QualType qt) {
+public fn u32 QualType.getBitFieldWidth(const QualType qt, bool precise = false) {
     QualType canon = qt.getCanonicalType();
     const Type* t = canon.getTypeOrNil();
     if (t.isBuiltinType()) {
@@ -96,10 +96,21 @@ public fn u32 QualType.getBitFieldWidth(const QualType qt) {
         return bi.getWidth();
     }
     if (t.isEnumType()) {
-        // TODO return bits needed for max value to allow use in bitfields
-        EnumType* et = (EnumType*)t;
-        QualType impl = et.getImplType();
-        return impl.getBitFieldWidth();
+        EnumTypeDecl* d = ((EnumType*)t).getDecl();
+        if (d.isRegular() && precise) {
+            u32 n = d.getNumConstants() - 1;
+            u32 bits = 1;
+            for (u32 i = 16; i != 0; i >>= 1) {
+                if (u32 m = n >> i) {
+                    n = m;
+                    bits += i;
+                }
+            }
+            return bits;
+        }
+        // TODO handle non regular enums and signed implementation types
+        QualType impl = d.getImplType();
+        return impl.getBitFieldWidth(precise);
     }
     return 0;
 }

--- a/test/types/struct/bitfield_enum_type.c2
+++ b/test/types/struct/bitfield_enum_type.c2
@@ -1,10 +1,12 @@
 // @warnings{no-unused}
 module test;
 
-type B enum u8 { AA, BB }
+type B enum u8 { AA, BB, CC, DD }
 
 type A struct {
-    B a : 8;
-    B b : 7; // @error{bit-field 'b' has insufficient bits for enum 'test.B'}
+    B a8 : 8;
+    B a3 : 3;
+    B a2 : 2;
+    B b : 1; // @error{bit-field 'b' has insufficient bits for enum 'test.B' (need 2 bits)}
 }
 


### PR DESCRIPTION
* add `precise` argument to `QualType.getBitFieldWidth`
* accept bitfield widths smaller than enum implementation type but sufficiently large for akk enum values