### PR TITLE
Compiler: add support for extern "C" specifiers

### DIFF
--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -36,7 +36,7 @@ fn void Analyser.analyseStructType(Analyser* ma, StructTypeDecl* d) {
 
     ma.analyseStructMembers(d);
 
-    if (!ma.has_error && d.getSize() == 0 && !ma.mod.isExternal()) {
+    if (!ma.has_error && d.getSize() == 0 && !d.isOpaque() && !ma.mod.isExternal()) {
         Decl* dd = (Decl*)d;
         dd.dump();
         ma.error(dd.getLoc(), "empty structs are only allowed in interface files");
@@ -213,5 +213,3 @@ fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, NameVector*
         }
     }
 }
-
-

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -155,6 +155,18 @@ public fn void TypeRefHolder.addArray(TypeRefHolder* h, Expr* array) {
     r.flags.num_arrays++;
 }
 
+public fn void TypeRefHolder.rotateArrays(TypeRefHolder* h, u32 r) {
+    if (!r) return;
+    u32 n = h.getNumArrays();
+    if (!n) return;
+    while (r--) {
+        Expr* e = h.arrays[0];
+        for (u32 i = 1; i < n; i++)
+            h.arrays[i - 1] = h.arrays[i];
+        h.arrays[n - 1] = e;
+    }
+}
+
 public fn void TypeRefHolder.setBuiltin(TypeRefHolder* h, BuiltinKind kind, SrcLoc loc) {
     TypeRef* r = (TypeRef*)&h.ref;
     r.flags.builtin_kind = kind;

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -75,6 +75,12 @@ public fn void Builder.setComponent(Builder* b, component.Component* comp) {
     b.is_private = comp.isExternalSourceLib();  // all non-exported modules created here will be private
 }
 
+public fn bool Builder.setExternal(Builder* b, bool is_interface) {
+    bool was_interface = b.is_interface;
+    b.is_interface = is_interface;
+    return was_interface;
+}
+
 public fn void Builder.actOnModule(Builder* b,
                                    u32 mod_name,
                                    SrcLoc mod_loc,

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -61,9 +61,11 @@ public type Parser struct @(opaque) {
     const string_list.List* features;
     const keywords.Info* kwinfo;
     bool is_interface;
+    bool is_generated;
     u32 va_list_idx;
     u32 varargs_idx;
     u32 stdarg_idx;
+    u32 main_idx;
 
     AttrRegistry attr_registry;
 
@@ -91,6 +93,7 @@ public fn Parser* create(SourceMgr* sm,
     p.va_list_idx = pool.addStr("va_list", true);
     p.varargs_idx = pool.addStr("varargs", true);
     p.stdarg_idx = pool.addStr("stdarg", true);
+    p.main_idx = pool.addStr("main", true);
     p.attr_registry.init(pool);
 
     // create a stack of stmt_lists to re-use (resize stack if needed)
@@ -113,6 +116,7 @@ public fn void Parser.free(Parser* p) {
 public fn void Parser.parse(Parser* p, i32 file_id, bool is_interface, bool is_generated) {
     p.file_id = file_id;
     p.is_interface = is_interface;
+    p.is_generated = is_generated;
 
     string_buffer.Buf* buf = string_buffer.create(1024, false, 0);
 #if DumpTokens
@@ -150,7 +154,7 @@ public fn void Parser.parse(Parser* p, i32 file_id, bool is_interface, bool is_g
                          false);
         p.tok.init();
         p.consumeToken();
-        p.parseModule(is_interface, is_generated);
+        p.parseModule();
         p.parseImports();
 
         while (!p.tok.done) {
@@ -273,22 +277,38 @@ fn void Parser.errorAt(Parser* p, SrcLoc loc, const char* format @(printf_format
     longjmp(&p.jmpbuf, 1);
 }
 
-fn void Parser.parseModule(Parser* p, bool is_interface, bool is_generated) {
+fn void Parser.parseModule(Parser* p) {
     p.expectAndConsume(KW_module);
     // accept builtin types as module names
-    if (!p.tok.kind.isBuiltinTypeOrVoid())
+    if (!p.tok.kind.isBuiltinType())
         p.expectIdentifier();
 
     const char*modname = p.pool.idx2str(p.tok.name_idx);
     if (!ctype.islower(modname[0])) {
         p.error("a module name must start with a lower case character");
     }
-    p.builder.actOnModule(p.tok.name_idx,
-                          p.tok.loc,
-                          p.sm.getFileNameIdx(p.file_id),
-                          is_interface,
-                          is_generated);
+    u32 module_name_idx = p.tok.name_idx;
+    SrcLoc module_loc = p.tok.loc;
     p.consumeToken();
+    if (p.tok.kind == KW_extern) {
+        p.consumeToken();
+        if (p.tok.kind == Kind.StringLiteral) {
+            const char* extern_name = p.pool.idx2str(p.tok.text_idx);
+            if (p.tok.text_len != 1 || *extern_name != 'C') {
+                p.error("unsupported extern module language tag '%s'", extern_name);
+            }
+            p.tokenizer.c_mode++;   // must set before consuming the token
+            p.consumeToken();
+        }
+        p.builder.setExternal(true);
+        p.is_interface = true;
+    }
+    p.builder.actOnModule(module_name_idx,
+                          module_loc,
+                          p.sm.getFileNameIdx(p.file_id),
+                          p.is_interface,
+                          p.is_generated);
+
     p.expectAndConsume(Semicolon);
 }
 
@@ -336,34 +356,62 @@ fn void Parser.parseTopLevel(Parser* p) {
 
     bool is_public = p.parseOptionalAccessSpecifier();
     switch (p.tok.kind) {
-        case KW_assert:
-            p.error("assert can only be used inside a function");
+    case KW_assert:
+        p.error("assert can only be used inside a function");
+        break;
+    case KW_extern:
+        p.parseExternDecl();
+        break;
+    case KW_fn:
+        if (p.tokenizer.c_mode) goto invalid_c;
+        p.parseFuncDecl(is_public);
+        break;
+    case KW_import:
+        p.error("no imports allowed after declarations");
+        break;
+    case KW_static_assert:
+        if (is_public) p.error("static_assert cannot be public");
+        p.parseStaticAssert();
+        break;
+    case KW_type:
+        //if (p.tokenizer.c_mode) goto invalid_c;
+        p.parseTypeDecl(is_public);
+        break;
+    case KW_enum:
+        if (!p.tokenizer.c_mode) goto invalid_c2;
+        p.parseCEnum(is_public);
+        break;
+    case KW_struct:
+        if (!p.tokenizer.c_mode) goto invalid_c2;
+        p.parseCStruct(true, is_public);
+        break;
+    case KW_union:
+        if (!p.tokenizer.c_mode) goto invalid_c2;
+        p.parseCStruct(false, is_public);
+        break;
+    case KW_typedef:
+        if (!p.tokenizer.c_mode) goto invalid_c2;
+        p.parseTypedef(is_public);
+        break;
+    case Eof:
+        break;
+    case Identifier:
+        if (p.peekToken(1) == PlusEqual) {
+            if (is_public) p.error("incremental array entries cannot be public");
+            if (p.is_interface) p.error("incremental array entries cannot be external");
+            p.parseArrayEntry();
             break;
-        case KW_fn:
-            p.parseFuncDecl(is_public);
-            break;
-        case KW_import:
-            p.error("no imports allowed after declarations");
-            break;
-        case KW_static_assert:
-            if (is_public) p.error("static_assert cannot be public");
-            p.parseStaticAssert();
-            break;
-        case KW_type:
-            p.parseTypeDecl(is_public);
-            break;
-        case Eof:
-            break;
-        case Identifier:
-            if (p.peekToken(1) == PlusEqual) {
-                if (is_public) p.error("incremental array entries cannot be public");
-                p.parseArrayEntry();
-                break;
-            }
-            fallthrough;
-        default:
-            p.parseVarDecl(is_public);
-            break;
+        }
+        fallthrough;
+    default:
+        p.parseVarDecl(is_public);
+        break;
+    invalid_c:
+        p.error("invalid keyword in extern C code");
+        //noreturn;
+    invalid_c2:
+        p.error("invalid definition in C2 code");
+        //noreturn;
     }
 }
 
@@ -460,6 +508,12 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
     SrcLoc func_loc = p.tok.loc;
     p.consumeToken();
 
+    p.parseFunctionDecl2(func_name, func_loc, is_public, &rtype);
+}
+
+fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
+                                  bool is_public, TypeRefHolder* rtype)
+{
     Ref prefix_ref;
     Ref* prefix = nil;
     if (p.tok.kind == Dot) {
@@ -496,7 +550,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
         f = p.builder.actOnTemplateFunctionDecl(func_name,
                                                 func_loc,
                                                 is_public,
-                                                &rtype,
+                                                rtype,
                                                 template_name,
                                                 template_loc,
                                                 (VarDecl**)params.getDecls(),
@@ -506,7 +560,7 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
         f = p.builder.actOnFunctionDecl(func_name,
                                         func_loc,
                                         is_public,
-                                        &rtype,
+                                        rtype,
                                         prefix,
                                         (VarDecl**)params.getDecls(),
                                         params.size(),
@@ -525,8 +579,10 @@ fn void Parser.parseFuncDecl(Parser* p, bool is_public) {
             return;
         }
 
-        // mark functions with bodies in interface files as 'inline'
-        f.setAttrInline();
+        if (func_name != p.main_idx) {
+            // mark functions with bodies in interface files as 'inline'
+            f.setAttrInline();
+        }
     }
 
     p.stmt_list_count = 0;
@@ -539,6 +595,13 @@ fn bool Parser.parseFunctionParams(Parser* p, DeclList* params, bool is_public, 
 
     // fast path for ()
     if (p.tok.kind == RParen) {
+        p.consumeToken();
+        return false;
+    }
+
+    // Accept (void) argument list in c_mode
+    if (p.tokenizer.c_mode && p.tok.kind == Kind.KW_void && p.peekToken(1) == Kind.RParen) {
+        p.consumeToken();
         p.consumeToken();
         return false;
     }
@@ -695,6 +758,28 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
         }
         p.consumeToken();
 
+        if (p.tok.kind == Kind.LParen) {
+            if (!p.tokenizer.c_mode) {
+                p.error("function definitions require the 'fn' keyword");
+            }
+            p.parseFunctionDecl2(name, loc, is_public, &ref);
+            return;
+        }
+
+        if (p.tok.kind == Kind.Dot) {
+            if (p.peekToken(1) == Kind.Identifier) {
+                if (p.peekToken(2) == Kind.LParen) {
+                    // Either a function definition or an init call
+                    if (!p.tokenizer.c_mode)
+                        p.error("global variables cannot have an init call");
+                    p.parseFunctionDecl2(name, loc, is_public, &ref);
+                    return;
+                }
+                p.error("global type variables not supported");
+            }
+            p.error("expected '=' or ';'");
+        }
+
         need_semi = true;
         Expr* initValue = nil;
         SrcLoc assignLoc = 0;
@@ -707,9 +792,6 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
             p.consumeToken();
             need_semi = (p.tok.kind != LBrace);
             initValue = p.parseInitValue(false);
-            break;
-        case Dot:
-            p.error("global variables cannot have an init call");
             break;
         case LSquare:
             p.error("array indices should go after type");
@@ -792,11 +874,105 @@ fn BuiltinKind tokKindToBuiltinKind(Kind kind) {
     return Tok2builtin[kind - Kind.KW_bool];
 }
 
+fn Kind Parser.convertCType(Parser* p) {
+    Kind kind = KW_i32;
+    u8 has_long = 0;
+    u8 has_short = 0;
+    u8 has_signed = 0;
+    u8 has_unsigned = 0;
+    u32 skip = 0;
+    for (;; skip++) {
+        Kind tok_kind = p.tok.kind;
+        if (skip) tok_kind = p.peekToken(skip);
+        switch (tok_kind) {
+        case KW_char:
+            if (has_signed == 1) {
+                has_signed = 0;
+                kind = Kind.KW_i8;
+            } else
+            if (has_unsigned == 1) {
+                has_unsigned = 0;
+                kind = Kind.KW_u8;
+            } else {
+                kind = Kind.KW_char;
+            }
+            break;
+        case KW_int:
+            break;
+        case KW_ssize_t:
+            kind = Kind.KW_isize;
+            break;
+        case KW_size_t:
+            kind = Kind.KW_usize;
+            break;
+        case KW_float:
+            kind = Kind.KW_f32;
+            break;
+        case KW_double:
+            if (has_long == 1) {
+                // long double -> double
+                has_long = 0;
+            }
+            kind = Kind.KW_f64;
+            break;
+        case KW_short:
+            has_short++;
+            continue;
+        case KW_long:
+            has_long++;
+            continue;
+        case KW_signed:
+            has_signed++;
+            continue;
+        case KW_unsigned:
+            has_unsigned++;
+            continue;
+        default:
+            skip--;  // no C type, keep last qualifier
+            break;
+        }
+        if (kind == Kind.KW_i32) {
+            if (has_short == 1) {
+                kind = Kind.KW_i16;
+                has_short = 0;
+            } else
+            if (has_long == 2) {
+                kind = Kind.KW_i64;
+                has_long = 0;
+            } else
+            if (has_long == 1) {
+                if (getWordSize() == 8)
+                    kind = Kind.KW_i64;
+                has_long = 0;
+            }
+            if (has_signed == 1) {
+                has_signed = 0;
+            } else
+            if (has_unsigned == 1) {
+                kind += Kind.KW_u32 - Kind.KW_i32;
+                has_unsigned = 0;
+            }
+        }
+        if (has_short + has_long + has_signed + has_unsigned)
+            p.error("invalid combination of type qualifiers");
+        while (skip-- > 0)
+            p.consumeToken();
+        break;
+    }
+    return p.tok.kind = kind;
+}
+
 fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref) {
     u32 type_qualifier = p.parseOptionalTypeQualifier();
     ref.setQualifiers(type_qualifier);
 
     Kind kind = p.tok.kind;
+    if (kind.isCType()) {
+        if (p.tokenizer.c_mode)
+            kind = p.convertCType();
+        else
+            p.error("invalid keyword");
+    }
 
     if (kind.isBuiltinType()) {
         ref.setBuiltin(tokKindToBuiltinKind(p.tok.kind), p.tok.loc);
@@ -946,5 +1122,33 @@ fn stmt_list.List* Parser.getStmtList(Parser* p) {
 
 fn void Parser.putStmtList(Parser* p) {
     p.stmt_list_count--;
+}
+
+fn void Parser.parseExternDecl(Parser* p) {
+    p.consumeToken();
+
+    bool was_external = p.builder.setExternal(true);
+    bool was_interface = p.is_interface;
+    p.is_interface = true;
+
+    if (p.tok.kind == Kind.StringLiteral) {
+        if (p.tok.text_len != 1 || *p.pool.idx2str(p.tok.text_idx) != 'C') {
+            p.error("extern must be followed by \"C\" and a block");
+        }
+        p.consumeToken();
+        p.tokenizer.c_mode++;   // must set before consuming the token
+        p.expectAndConsume(Kind.LBrace);
+        while (p.tok.kind != Kind.RBrace) {
+            if (p.tok.kind == Kind.Eof)
+                p.error("unterminated extern \"C\" block");
+            p.parseTopLevel();
+        }
+        p.tokenizer.c_mode--;   // must set before consuming the token
+        p.consumeToken();
+    } else {
+        p.parseTopLevel();
+    }
+    p.is_interface = was_interface;
+    p.builder.setExternal(was_external);
 }
 

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -536,7 +536,7 @@ fn bool Parser.isTemplateFunctionCall(Parser* p) {
     Kind kind = p.peekToken(1);
     if (kind != Identifier) {
         if (kind.isQualifier()) return true;
-        return kind.isBuiltinTypeOrVoid() && (p.peekToken(2) != Dot);
+        return kind.isTypeKeyword() && (p.peekToken(2) != Dot);
     }
 
     u32 stars = 0;
@@ -785,7 +785,7 @@ fn bool Parser.parseAsType(Parser* p) {
     Kind kind = p.tok.kind;
     if (kind != Identifier) {
         if (kind.isQualifier()) return true;
-        return kind.isBuiltinTypeOrVoid() && (p.peekToken(1) != Dot);
+        return kind.isTypeKeyword() && (p.peekToken(1) != Dot);
     }
     Token t2 = p.tok;
     // parse potential member expression
@@ -843,7 +843,7 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
         if (ahead) p.peekToken2(ahead, &t2);
         ahead++;
         Kind kind = t2.kind;
-        if (kind.isBuiltinTypeOrVoid()) {
+        if (kind.isTypeKeyword()) {
             // builtin type, non ambiguous
             ambiguous = false;
             break;

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -53,26 +53,10 @@ fn Stmt* Parser.parseStmt(Parser* p) {
         return p.parseReturnStmt();
     case KW_switch:
         return p.parseSwitchStmt();
-    case KW_bool:
-    case KW_char:
+    case KW_bool ... KW_f64:        // C2 builtin types
+    case KW_int ... KW_unsigned:    // C type keywords
     case KW_const:
-    case KW_i8:
-    case KW_i16:
-    case KW_i32:
-    case KW_i64:
-    case KW_isize:
-    case KW_f32:
-    case KW_f64:
     case KW_local:
-    case KW_reg8:
-    case KW_reg16:
-    case KW_reg32:
-    case KW_reg64:
-    case KW_u8:
-    case KW_u16:
-    case KW_u32:
-    case KW_u64:
-    case KW_usize:
     case KW_volatile:
     case KW_void:
         // checkSemi, allowLocal, !isCondition
@@ -635,7 +619,7 @@ fn Stmt* Parser.parseGotoStmt(Parser* p) {
 fn bool Parser.isDeclaration(Parser* p) {
     const Kind kind = p.tok.kind;
     if (kind == Identifier) return p.isTypeSpec();
-    if (kind.isBuiltinTypeOrVoid()) return true;
+    if (kind.isTypeKeyword()) return true;
     if (kind == KW_local) return true;
     if (kind.isQualifier()) return true;
     return false;

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -332,3 +332,51 @@ fn void Parser.parseAliasType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
     p.applyAttributes(d, num_attr);
 }
 
+fn void Parser.parseCEnum(Parser* p, bool is_public) {
+    p.consumeToken();
+    p.expectIdentifier();
+    u32 type_name = p.tok.name_idx;
+    SrcLoc type_loc = p.tok.loc;
+    const char* name = p.pool.idx2str(type_name);
+    if (!isupper(name[0]) && !p.is_interface) p.error("a type name must start with an upper case character");
+
+    p.consumeToken();
+    if (p.tok.kind != Colon) p.error("a C enum must specify an implementation type with ':'");
+    p.parseEnumType(type_name, type_loc, is_public);
+}
+
+fn void Parser.parseCStruct(Parser* p, bool is_struct, bool is_public) {
+    p.consumeToken();
+    p.expectIdentifier();
+    u32 type_name = p.tok.name_idx;
+    SrcLoc type_loc = p.tok.loc;
+    const char* name = p.pool.idx2str(type_name);
+    if (!isupper(name[0]) && !p.is_interface) p.error("a type name must start with an upper case character");
+    p.parseStructType(is_struct, type_name, type_loc, is_public);
+}
+
+fn void Parser.parseTypedef(Parser* p, bool is_public) {
+    p.consumeToken();  // typedef
+    // TODO: reject struct, union, enum
+    TypeRefHolder ref.init();
+    p.parseTypeSpecifier(&ref);
+    p.expectIdentifier();
+    u32 type_name = p.tok.name_idx;
+    SrcLoc loc = p.tok.loc;
+    const char* name = p.pool.idx2str(type_name);
+    if (!isupper(name[0]) && !p.is_interface) p.error("a type name must start with an upper case character");
+    if (p.tok.reserved) {
+        p.diags.error(loc, "reserved word '%s' cannot be used as local variable name",
+                      p.pool.idx2str(type_name));
+    }
+    p.consumeToken();
+    if (p.tok.kind == LSquare) {
+        u32 num_arrays = ref.getNumArrays();
+        p.parseOptionalArray(&ref);
+        ref.rotateArrays(num_arrays);
+    }
+    Decl* d = p.builder.actOnAliasType(type_name, loc, is_public, &ref);
+    u32 num_attr = p.parseOptionalAttributes();
+    p.expectAndConsume(Semicolon);
+    p.applyAttributes(d, num_attr);
+}

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -72,20 +72,20 @@ type Action enum u8 {
 }
 
 const Action[256] Char_lookup = {
-// 0 - 15
-   [  0]  = EOF,
-   ['\t'] = TABSPACE,
-   ['\n'] = NEWLINE,
-   ['\r'] = CR,
-// 16 - 31
-// 32 - 47
+    // 0 - 15
+    [  0]  = EOF,
+    ['\t'] = TABSPACE,
+    ['\n'] = NEWLINE,
+    ['\r'] = CR,
+    // 16 - 31
+    // 32 - 47
     [' '] = TABSPACE,
     ['!'] = EXCLAIM,
     ['"'] = DQUOTE,
     ['#'] = POUND,
     ['%'] = PERCENT,
     ['&'] = AMP,
-   ['\''] = SQUOTE,
+    ['\''] = SQUOTE,
     ['('] = LPAREN,
     [')'] = RPAREN,
     ['*'] = STAR,
@@ -94,7 +94,7 @@ const Action[256] Char_lookup = {
     ['-'] = MINUS,
     ['.'] = DOT,
     ['/'] = SLASH,
-// 48 - 63
+    // 48 - 63
     ['0'] = DIGIT,
     ['1'] = DIGIT,
     ['2'] = DIGIT,
@@ -111,7 +111,7 @@ const Action[256] Char_lookup = {
     ['='] = EQUAL,
     ['>'] = GREATER,
     ['?'] = QUESTION,
-// 64 - 79
+    // 64 - 79
     ['@'] = AT,
     ['A'] = IDENT,
     ['B'] = IDENT,
@@ -128,7 +128,7 @@ const Action[256] Char_lookup = {
     ['M'] = IDENT,
     ['N'] = IDENT,
     ['O'] = IDENT,
-// 80 - 95
+    // 80 - 95
     ['P'] = IDENT,
     ['Q'] = IDENT,
     ['R'] = IDENT,
@@ -145,7 +145,7 @@ const Action[256] Char_lookup = {
     [']'] = RSQUARE,
     ['^'] = CARET,
     ['_'] = IDENT,   // for parsing libs
-// 96 - 111
+    // 96 - 111
     ['`'] = BQUOTE,
     ['a'] = IDENT,
     ['b'] = IDENT,
@@ -162,7 +162,7 @@ const Action[256] Char_lookup = {
     ['m'] = IDENT,
     ['n'] = IDENT,
     ['o'] = IDENT,
-// 112 - 127
+    // 112 - 127
     ['p'] = IDENT,
     ['q'] = IDENT,
     ['r'] = IDENT,
@@ -275,6 +275,7 @@ public type Tokenizer struct {
     const string_list.List* features;
     bool raw_mode;  // also emit comments and invalid characters
     bool stop_at_eol; // restrict lexing to single line for preprocessor
+    u8 c_mode;      // inside a module extern "C" or an extern "C" {} block
 
     char[256] error_msg;
 }
@@ -346,7 +347,7 @@ public fn void Tokenizer.lex(Tokenizer* t, Token* result) {
             if (result.name_idx <= t.kwinfo.max_index) {
                 Kind k = t.kwinfo.indexes[result.name_idx];
                 assert(k != None);
-                if (k == Error) {
+                if (k == Error || (k >= KW_int && k <= KW_typedef && !t.c_mode)) {
                     result.reserved = true;
                     return;
                 }

--- a/parser/keywords.c2
+++ b/parser/keywords.c2
@@ -26,9 +26,11 @@ public type Info struct {
     u32 max_index;
 }
 
-const char[] C_keywords = "alignas alignof auto constexpr do double extern"
-    " float inline int long nullptr register restrict short signed static"
-    " thread_local typedef typeof typeof_unqual unsigned size_t ssize_t";
+// C type keywords handled in Parser.lex():
+//  double float int long short signed size_t ssize_t unsigned typedef
+// Other C keywords to flag as reserved:
+const char[] C_keywords = "alignas alignof auto constexpr do inline nullptr"
+    " register restrict static thread_local typeof typeof_unqual";
 
 public fn void Info.init(Info* info, string_pool.Pool* pool) {
     u32 idx = 0;

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -93,6 +93,18 @@ public type Kind enum u8 {
     KW_f32,
     KW_f64,
     KW_void,        // keep as last BuiltinType, since we check range
+    // C types
+    KW_int,
+    KW_ssize_t,
+    KW_size_t,
+    KW_float,
+    KW_double,
+    KW_short,
+    KW_long,
+    KW_signed,
+    KW_unsigned,
+    // C keywords
+    KW_typedef,
     // other keywords
     KW_as,
     KW_asm,
@@ -108,6 +120,7 @@ public type Kind enum u8 {
     KW_enum_max,
     KW_enum_min,
     KW_enum,
+    KW_extern,
     KW_fallthrough,
     KW_false,
     KW_fn,
@@ -161,8 +174,12 @@ public fn bool Kind.isBuiltinType(Kind kind) {
     return kind >= KW_bool && kind < KW_void;
 }
 
-public fn bool Kind.isBuiltinTypeOrVoid(Kind kind) {
-    return kind >= KW_bool && kind <= KW_void;
+public fn bool Kind.isTypeKeyword(Kind kind) {
+    return kind >= KW_bool && kind <= KW_unsigned;
+}
+
+public fn bool Kind.isCType(Kind kind) {
+    return kind >= KW_int && kind <= KW_unsigned;
 }
 
 // NOTE: keep in sync with TokenKind
@@ -238,6 +255,16 @@ const char*[Kind] token_names = {
     [KW_f32]           = "f32",
     [KW_f64]           = "f64",
     [KW_void]          = "void",
+    [KW_int]           = "int",
+    [KW_ssize_t]       = "ssize_t",
+    [KW_size_t]        = "size_t",
+    [KW_float]         = "float",
+    [KW_double]        = "double",
+    [KW_short]         = "short",
+    [KW_long]          = "long",
+    [KW_signed]        = "signed",
+    [KW_unsigned]      = "unsigned",
+    [KW_typedef]       = "typedef",
     [KW_as]            = "as",
     [KW_asm]           = "asm",
     [KW_assert]        = "assert",
@@ -252,6 +279,7 @@ const char*[Kind] token_names = {
     [KW_enum_max]      = "enum_max",
     [KW_enum_min]      = "enum_min",
     [KW_enum]          = "enum",
+    [KW_extern]        = "extern",
     [KW_fallthrough]   = "fallthrough",
     [KW_false]         = "false",
     [KW_fn]            = "fn",

--- a/test/parser/reserved_words.c2
+++ b/test/parser/reserved_words.c2
@@ -8,7 +8,6 @@ type Foo struct {
     u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as struct/union member name}
     u32 do;         // @error{reserved word 'do' cannot be used as struct/union member name}
     u32 double;     // @error{reserved word 'double' cannot be used as struct/union member name}
-    u32 extern;     // @error{reserved word 'extern' cannot be used as struct/union member name}
     u32 float;      // @error{reserved word 'float' cannot be used as struct/union member name}
     u32 inline;     // @error{reserved word 'inline' cannot be used as struct/union member name}
     u32 int;        // @error{reserved word 'int' cannot be used as struct/union member name}
@@ -35,7 +34,6 @@ fn void foo(
     u32 constexpr,  // @error{reserved word 'constexpr' cannot be used as parameter name}
     u32 do,         // @error{reserved word 'do' cannot be used as parameter name}
     u32 double,     // @error{reserved word 'double' cannot be used as parameter name}
-    u32 extern,     // @error{reserved word 'extern' cannot be used as parameter name}
     u32 float,      // @error{reserved word 'float' cannot be used as parameter name}
     u32 inline,     // @error{reserved word 'inline' cannot be used as parameter name}
     u32 int,        // @error{reserved word 'int' cannot be used as parameter name}
@@ -62,7 +60,6 @@ fn void bar() {
     u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as variable name}
     u32 do;         // @error{reserved word 'do' cannot be used as variable name}
     u32 double;     // @error{reserved word 'double' cannot be used as variable name}
-    u32 extern;     // @error{reserved word 'extern' cannot be used as variable name}
     u32 float;      // @error{reserved word 'float' cannot be used as variable name}
     u32 inline;     // @error{reserved word 'inline' cannot be used as variable name}
     u32 int;        // @error{reserved word 'int' cannot be used as variable name}
@@ -88,7 +85,6 @@ u32 auto;       // @error{reserved word 'auto' cannot be used as variable name}
 u32 constexpr;  // @error{reserved word 'constexpr' cannot be used as variable name}
 u32 do;         // @error{reserved word 'do' cannot be used as variable name}
 u32 double;     // @error{reserved word 'double' cannot be used as variable name}
-u32 extern;     // @error{reserved word 'extern' cannot be used as variable name}
 u32 float;      // @error{reserved word 'float' cannot be used as variable name}
 u32 inline;     // @error{reserved word 'inline' cannot be used as variable name}
 u32 int;        // @error{reserved word 'int' cannot be used as variable name}

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -102,7 +102,7 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         ctx.offset = tok.loc + (u32)strlen(str);
         return;
     }
-    if (tok.kind.isBuiltinTypeOrVoid()) {
+    if (tok.kind.isTypeKeyword()) {
         const char* str = tok.kind.str();
         out.color(col_type);
         out.add(str);


### PR DESCRIPTION
* interface files can use `module xxx extern "C";` or `extern "C" { }` to use C syntax and types in structure and function definitions. This makes bindings much easier to create and maintain.
* to allow boostrapping, the modified interface files for the libc are stored in a subdirectory named `extern` until the bootstrap code is updated.