### PR TITLE
Compiler: remove redundant prefixes and casts

### DIFF
--- a/ast/binary_operator.c2
+++ b/ast/binary_operator.c2
@@ -94,7 +94,8 @@ public fn const char* BinaryOpcode.str(BinaryOpcode opcode) {
 
 type BinaryOperatorBits struct {
     u32 : NumExprBits;
-    u32 kind : 5;
+    u32 : 2;
+    BinaryOpcode kind : 5;
 }
 
 public type BinaryOperator struct @(opaque) {
@@ -120,7 +121,7 @@ fn Expr* BinaryOperator.instantiate(BinaryOperator* e, Instantiator* inst) {
 }
 
 public fn BinaryOpcode BinaryOperator.getOpcode(const BinaryOperator* e) {
-    return (BinaryOpcode)e.base.base.binaryOperatorBits.kind;
+    return e.base.base.binaryOperatorBits.kind;
 }
 
 public fn Expr* BinaryOperator.getLHS(const BinaryOperator* e) { return e.lhs; }

--- a/ast/builtin_expr.c2
+++ b/ast/builtin_expr.c2
@@ -40,8 +40,9 @@ const char*[BuiltinExprKind] builtin_names = {
 
 type BuiltinExprBits struct {
     u32 : NumExprBits;
-    u32 kind : 3;       // BuiltinExprKind
-    u32 src_len : 32 - NumExprBits - 3; // length of () expression
+    u8 : 2; // make sure kind does not span an 8-bit boundary
+    BuiltinExprKind kind : 3;
+    u32 src_len : 32 - NumExprBits - 5; // length of () expression
 }
 
 type ToContainerData struct {
@@ -81,7 +82,7 @@ public fn BuiltinExpr* BuiltinExpr.createOffsetOf(ast_context.Context* c, SrcLoc
     const u32 size = sizeof(BuiltinExpr) + sizeof(OffsetOfData);
     BuiltinExpr* e = c.alloc(size);
     e.base.init(Builtin, loc, true, true, false, RValue);
-    e.base.base.builtinExprBits.kind = BuiltinExprKind.OffsetOf;
+    e.base.base.builtinExprBits.kind = OffsetOf;
     e.base.base.builtinExprBits.src_len = src_len;
     e.inner = typeExpr;
     e.value.setUnsigned(0);
@@ -96,7 +97,7 @@ public fn BuiltinExpr* BuiltinExpr.createToContainer(ast_context.Context* c, Src
     const u32 size = sizeof(BuiltinExpr) + sizeof(ToContainerData);
     BuiltinExpr* e = c.alloc(size);
     e.base.init(Builtin, loc, false, false, false, RValue);
-    e.base.base.builtinExprBits.kind = BuiltinExprKind.ToContainer;
+    e.base.base.builtinExprBits.kind = ToContainer;
     e.base.base.builtinExprBits.src_len = src_len;
     e.inner = typeExpr;
     e.value.setUnsigned(0);
@@ -130,7 +131,7 @@ fn Expr* BuiltinExpr.instantiate(BuiltinExpr* e, Instantiator* inst) {
 }
 
 public fn BuiltinExprKind BuiltinExpr.getKind(const BuiltinExpr* e) {
-    return (BuiltinExprKind)e.base.base.builtinExprBits.kind;
+    return e.base.base.builtinExprBits.kind;
 }
 
 public fn Value BuiltinExpr.getValue(const BuiltinExpr* e) { return e.value; }

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -163,7 +163,7 @@ public fn const char* BuiltinKind.str(BuiltinKind kind) {
 
 type BuiltinTypeBits struct {
     u32 : NumTypeBits;
-    u32 kind : 4;
+    BuiltinKind kind : 4;
 }
 
 public type BuiltinType struct @(opaque) {
@@ -181,8 +181,9 @@ fn BuiltinType* BuiltinType.create(ast_context.Context* c, BuiltinKind kind) {
     return b;
 }
 
+// TODO: redundant?
 public fn BuiltinKind BuiltinType.getKind(const BuiltinType* b) {
-    return (BuiltinKind)b.base.builtinTypeBits.kind;
+    return b.base.builtinTypeBits.kind;
 }
 
 // converts ISize/USize to Int64/UInt64 or Int32/UInt32 depending on arch
@@ -191,7 +192,7 @@ public fn BuiltinKind BuiltinType.getBaseKind(const BuiltinType* b) {
 }
 
  fn BuiltinKind BuiltinType.getBuiltinKind(const BuiltinType* b) {
-    return (BuiltinKind)b.base.builtinTypeBits.kind;
+    return b.base.builtinTypeBits.kind;
 }
 
 public fn bool BuiltinType.isInt32(const BuiltinType* b) {

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -25,7 +25,7 @@ type CallExprBits struct {
     u32 calls_type_func : 1;
     u32 calls_static_sf : 1;
     u32 is_template_call : 1;
-    u32 format_attr : 2;
+    FormatAttr format_attr : 2;
     u32 has_auto_args : 1;   // if c-generator needs to insert extra arguments (file, line)
     u32 is_noreturn : 1;
     u32 num_args : 8;
@@ -160,7 +160,7 @@ public fn void CallExpr.setFormatAttr(CallExpr* e, FormatAttr kind) {
 }
 
 fn FormatAttr CallExpr.getFormatAttr(const CallExpr* e) {
-    return (FormatAttr)e.base.base.callExprBits.format_attr;
+    return e.base.base.callExprBits.format_attr;
 }
 
 public fn void CallExpr.setHasAutoArgs(CallExpr* e) {

--- a/ast/char_literal.c2
+++ b/ast/char_literal.c2
@@ -23,7 +23,7 @@ import number_radix local;
 type CharLiteralBits struct {
     u32 : NumExprBits;
     u32 value : 8;
-    u32 radix : 2;      // number_radix.Radix enum
+    Radix radix : 2;
     u32 src_len : 32 - NumExprBits - 8 - 2;
 }
 
@@ -65,10 +65,10 @@ public fn void CharLiteral.printLiteral(const CharLiteral* e, string_buffer.Buf*
     u8 c = (u8)e.base.base.charLiteralBits.value;
 
     switch (e.base.base.charLiteralBits.radix) {
-    case Radix.Octal:
+    case Octal:
         out.print("'\\%o'", c);
         return;
-    case Radix.Hex:
+    case Hex:
         out.print("'\\x%02x'", c);
         return;
     default:

--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -56,8 +56,8 @@ const char*[DeclCheckState] declCheckState_names = {
 }
 
 type DeclBits struct {
-    u32 kind : 4;
-    u32 check_state : 2;
+    DeclKind kind : 4;
+    DeclCheckState check_state : 2;
     u32 is_public : 1;
     u32 is_used : 1;
     u32 is_used_public : 1;
@@ -120,12 +120,12 @@ public fn u32 Decl.getGenIdx(const Decl* d) {
 }
 
 // TEMP cast needed until Analyser fixed
-public fn DeclKind Decl.getKind(const Decl* d) { return (DeclKind)d.declBits.kind; }
+public fn DeclKind Decl.getKind(const Decl* d) { return d.declBits.kind; }
 
-public fn DeclCheckState Decl.getCheckState(const Decl* d) { return (DeclCheckState)d.declBits.check_state; }
+public fn DeclCheckState Decl.getCheckState(const Decl* d) { return d.declBits.check_state; }
 /*
 public fn const char* Decl.getCheckStateName(const Decl* d) {
-    return declCheckState_names[(DeclCheckState)d.declBits.check_state)];
+    return declCheckState_names[d.declBits.check_state)];
 }
 */
 
@@ -137,8 +137,8 @@ public fn bool Decl.isCheckInProgress(const Decl* d) {
     return d.getCheckState() == InProgress;
 }
 
-public fn void Decl.setChecked(Decl* d) { d.declBits.check_state = DeclCheckState.Checked; }
-public fn void Decl.setCheckInProgress(Decl* d) { d.declBits.check_state = DeclCheckState.InProgress; }
+public fn void Decl.setChecked(Decl* d) { d.declBits.check_state = Checked; }
+public fn void Decl.setCheckInProgress(Decl* d) { d.declBits.check_state = InProgress; }
 
 public fn void Decl.setHasAttr(Decl* d) { d.declBits.has_attr = 1; }
 public fn bool Decl.hasAttr(const Decl* d) { return d.declBits.has_attr; }

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -109,10 +109,10 @@ const char*[ValType] valType_names = {
 
 type ExprBits struct {
     u32 : NumStmtBits;
-    u32 kind : 5;
     u32 is_ctv : 1;
     u32 is_ctc : 1;
-    u32 valtype : 2;
+    ValType valtype : 2;
+    ExprKind kind : 5;
     u32 has_effect : 1;
 }
 const u32 NumExprBits = NumStmtBits + 10;
@@ -196,7 +196,7 @@ fn Expr* Expr.instantiate(Expr* e, Instantiator* inst) {
 public fn Stmt* Expr.asStmt(Expr* e) { return &e.base; }
 
 // TEMP cast needed until Analyser fixed
-public fn ExprKind Expr.getKind(const Expr* e) { return (ExprKind)e.base.exprBits.kind; }
+public fn ExprKind Expr.getKind(const Expr* e) { return e.base.exprBits.kind; }
 
 public fn bool Expr.isStringLiteral(const Expr* e) {
     return e.getKind() == StringLiteral;
@@ -309,7 +309,7 @@ public fn bool Expr.hasEffect(const Expr* e) {
 }
 
 public fn ValType Expr.getValType(const Expr* e) {
-    return (ValType)e.base.exprBits.valtype;
+    return e.base.exprBits.valtype;
 }
 
 public fn bool Expr.isNValue(const Expr* e) {
@@ -327,11 +327,11 @@ public fn bool Expr.isLValue(const Expr* e) {
 }
 
 public fn void Expr.setLValue(Expr* e) {
-    e.base.exprBits.valtype = ValType.LValue;
+    e.base.exprBits.valtype = LValue;
 }
 
 public fn void Expr.setRValue(Expr* e) {
-    e.base.exprBits.valtype = ValType.RValue;
+    e.base.exprBits.valtype = RValue;
 }
 
 /*

--- a/ast/float_literal.c2
+++ b/ast/float_literal.c2
@@ -22,7 +22,7 @@ import number_radix local;
 
 type FloatLiteralBits struct {
     u32 : NumExprBits;
-    u32 radix : 2;      // number_radix.Radix enum
+    Radix radix : 2;
     u32 src_len : 32 - NumExprBits - 2;
 }
 
@@ -64,7 +64,7 @@ fn void FloatLiteral.print(const FloatLiteral* e, string_buffer.Buf* out, u32 in
 
 public fn void FloatLiteral.printLiteral(const FloatLiteral* e, string_buffer.Buf* out) {
     switch (e.base.base.floatLiteralBits.radix) {
-    case Radix.Hex:
+    case Hex:
         out.print("%a", e.val);
         break;
     default:

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -56,9 +56,9 @@ type FunctionDeclBits struct {
     u32 : NumDeclBits;
     u32 is_variadic : 1;
     u32 has_prefix : 1;     // is a (static) type-function
-    u32 call_kind : 2;  // CallKind
+    CallKind call_kind : 2;
     u32 has_return : 1;     // if it returns something, set during analysis
-    u32 def_kind : 3;
+    DefKind def_kind : 3;
     u32 has_body : 1;    // if function is defined in C2
 }
 
@@ -73,7 +73,7 @@ type FunctionDeclFlags struct {
     u32 attr_destructor : 1;
     u32 attr_pure : 1;
     u32 attr_deprecated : 1;
-    u32 format_attr : 2; // FormatAttr
+    FormatAttr format_attr : 2;
 }
 
 public type FunctionDecl struct @(opaque) {
@@ -115,7 +115,7 @@ public fn FunctionDecl* FunctionDecl.create(ast_context.Context* c,
     QualType qt = QualType.create(ftype.asType());
     d.base.init(Function, name, loc, is_public, qt, ast_idx);
     d.base.functionDeclBits.is_variadic = is_variadic;
-    d.base.functionDeclBits.call_kind = prefix ? CallKind.StaticTypeFunc : CallKind.Normal;
+    d.base.functionDeclBits.call_kind = prefix ? StaticTypeFunc : Normal;
     d.base.functionDeclBits.def_kind = def_kind;
     d.body = nil;
     d.rt = QualType_Invalid;
@@ -160,8 +160,8 @@ public fn FunctionDecl* FunctionDecl.createTemplate(ast_context.Context* c,
     QualType qt = QualType.create(ftype.asType());
     d.base.init(Function, name, loc, is_public, qt, ast_idx);
     d.base.functionDeclBits.is_variadic = is_variadic;
-    d.base.functionDeclBits.call_kind = CallKind.Normal;
-    d.base.functionDeclBits.def_kind = DefKind.Template;
+    d.base.functionDeclBits.call_kind = Normal;
+    d.base.functionDeclBits.def_kind = Template;
     d.body = nil;
     d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
@@ -198,7 +198,7 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
     // copy members
     fd2.base = fd.base;
     // note: the instantiation is no longer a template function (otherwise ignored by analyseFunctionProto)
-    fd2.base.functionDeclBits.def_kind = DefKind.Global;
+    fd2.base.functionDeclBits.def_kind = Global;
     FunctionType* ftype = FunctionType.create(inst.c, fd2);
     fd2.base.qt = QualType.create(ftype.asType());
 
@@ -317,7 +317,7 @@ public fn bool FunctionDecl.isParam(const FunctionDecl* d) {
 }
 
 fn DefKind FunctionDecl.getDefKind(const FunctionDecl* d) {
-    return (DefKind)d.base.functionDeclBits.def_kind;
+    return d.base.functionDeclBits.def_kind;
 }
 
 public fn u32 FunctionDecl.getTemplateNameIdx(const FunctionDecl* d) {
@@ -380,7 +380,7 @@ public fn bool FunctionDecl.isTypeFunc(const FunctionDecl* d) {
 }
 
 public fn CallKind FunctionDecl.getCallKind(const FunctionDecl* d) {
-    return (CallKind)d.base.functionDeclBits.call_kind;
+    return d.base.functionDeclBits.call_kind;
 }
 
 public fn bool FunctionDecl.isVariadic(const FunctionDecl* d) {
@@ -467,7 +467,7 @@ public fn void FunctionDecl.setFormatAttr(FunctionDecl* d, FormatAttr format_att
 
 public fn FormatAttr FunctionDecl.getFormatAttr(const FunctionDecl* d, u8 *format_arg_ptr) {
     *format_arg_ptr = d.attr_format_arg;
-    return (FormatAttr)d.flags.format_attr;
+    return d.flags.format_attr;
 }
 
 public fn void FunctionDecl.setAttrDeprecated(FunctionDecl* d) {

--- a/ast/identifier_expr.c2
+++ b/ast/identifier_expr.c2
@@ -47,8 +47,9 @@ fn const char* IdentifierKind.str(IdentifierKind k) {
 type IdentifierExprBits struct {
     u32 : NumExprBits;
     u32 has_decl : 1;
-    u32 kind : 3;   // IdentifierKind
-    u32 name_len : 32 - NumExprBits - 4;
+    u32 : 1;
+    IdentifierKind kind : 3;
+    u32 name_len : 32 - NumExprBits - 5;
 }
 
 public type IdentifierExpr struct @(opaque) {
@@ -101,7 +102,7 @@ public fn void IdentifierExpr.setKind(IdentifierExpr* e, IdentifierKind kind) {
 }
 
 public fn IdentifierKind IdentifierExpr.getKind(const IdentifierExpr* e) {
-    return (IdentifierKind)e.base.base.identifierExprBits.kind;
+    return e.base.base.identifierExprBits.kind;
 }
 
 public fn const char* IdentifierExpr.getName(const IdentifierExpr* e) {

--- a/ast/implicit_cast_expr.c2
+++ b/ast/implicit_cast_expr.c2
@@ -39,7 +39,8 @@ const char*[ImplicitCastKind] implicitCastKind_names = {
 
 type ImplicitCastBits struct {
     u32 : NumExprBits;
-    u32 kind : 3;
+    u32 : 2;
+    ImplicitCastKind kind : 3;
 }
 
 public type ImplicitCastExpr struct @(opaque) {
@@ -81,7 +82,7 @@ public fn ImplicitCastExpr* ImplicitCastExpr.create(ast_context.Context* c, SrcL
 }
 
 public fn ImplicitCastKind ImplicitCastExpr.getKind(const ImplicitCastExpr* e) {
-    return (ImplicitCastKind)e.base.base.implicitCastBits.kind;
+    return e.base.base.implicitCastBits.kind;
 }
 
 public fn bool ImplicitCastExpr.isArrayToPointerDecay(const ImplicitCastExpr* e) {

--- a/ast/integer_literal.c2
+++ b/ast/integer_literal.c2
@@ -22,7 +22,7 @@ import number_radix local;
 
 type IntegerLiteralBits struct {
     u32 : NumExprBits;
-    u32 radix : 2;      // number_radix.Radix enum
+    Radix radix : 2;
     u32 src_len : 32 - NumExprBits - 2;
 }
 
@@ -55,7 +55,7 @@ fn SrcLoc IntegerLiteral.getEndLoc(const IntegerLiteral* e) {
 
 /*
 public fn bool IntegerLiteral.isDecimal(const IntegerLiteral* e) {
-    return e.base.base.integerLiteralBits.radix == Radix.Default;
+    return e.base.base.integerLiteralBits.radix == Default;
 }
 */
 
@@ -97,16 +97,16 @@ fn void IntegerLiteral.print(const IntegerLiteral* e, string_buffer.Buf* out, u3
 
 public fn void IntegerLiteral.printLiteral(const IntegerLiteral* e, string_buffer.Buf* out, bool c_style) {
     switch (e.base.base.integerLiteralBits.radix) {
-    case Radix.Default:
+    case Default:
         out.print("%d", e.val);
         break;
-    case Radix.Hex:
+    case Hex:
         out.print("0x%x", e.val);
         break;
-    case Radix.Octal:
+    case Octal:
         printOctal(out, e.val);
         break;
-    case Radix.Binary:
+    case Binary:
         printBinary(out, e.val);
         break;
     }

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -29,14 +29,14 @@ public type MemberConversion enum u8 {
 
 type MemberExprBits struct {
     u32 : NumExprBits;
-    u32 kind : 3;   // IdentifierKind
     u32 num_decls : 2;  // how many refs have a decl (from the bottom up), set during analysis
+    IdentifierKind kind : 3;
     u32 has_expr : 1;
     u32 is_struct_func : 1; // not only a function with prefix, but also used that way
     u32 is_static_sf : 1;
     u32 is_const_base : 1;
     u32 is_volatile_base : 1;
-    u32 conversion : 2; // MemberConversion
+    MemberConversion conversion : 2;
     u32 is_bitfield : 1;
     u32 base_len : 5;
 }
@@ -104,7 +104,7 @@ public fn void MemberExpr.setConversion(MemberExpr* e, MemberConversion c) {
 }
 
 public fn MemberConversion MemberExpr.getConversion(const MemberExpr* e) {
-    return (MemberConversion)e.base.base.memberExprBits.conversion;
+    return e.base.base.memberExprBits.conversion;
 }
 
 public fn const char* MemberExpr.getName(const MemberExpr* e, u32 ref_idx) {
@@ -177,7 +177,7 @@ public fn Ref MemberExpr.getRef(const MemberExpr* e) {
 }
 
 public fn IdentifierKind MemberExpr.getKind(const MemberExpr* e) {
-    return (IdentifierKind)e.base.base.memberExprBits.kind;
+    return e.base.base.memberExprBits.kind;
 }
 
 public fn void MemberExpr.setKind(MemberExpr* e, IdentifierKind kind) {
@@ -318,9 +318,8 @@ public fn void MemberExpr.dump(const MemberExpr* m) @(unused) {
     out.print("MemberExpr loc %d expr %d decl %d/2\n",
               m.base.getLoc(), m.hasExpr(), m.base.base.memberExprBits.num_decls);
     const MemberExprBits* bits = &m.base.base.memberExprBits;
-    IdentifierKind k = (IdentifierKind)bits.kind;
     out.print("  bits: kind %s, sf %d, ssf %d, conv %d, bitf %d\n",
-              k.str(), bits.is_struct_func, bits.is_static_sf,
+              bits.kind.str(), bits.is_struct_func, bits.is_static_sf,
               bits.conversion, bits.is_bitfield);
     u32 start = 0;
     if (m.hasExpr()) {

--- a/ast/stmt.c2
+++ b/ast/stmt.c2
@@ -55,7 +55,7 @@ const char*[StmtKind] stmtKind_names = {
 }
 
 type StmtBits struct {
-    u32 kind : NumStmtBits;
+    StmtKind kind : NumStmtBits;
 }
 
 const u32 NumStmtBits = 4;
@@ -138,7 +138,7 @@ fn Stmt* Stmt.instantiate(Stmt* s, Instantiator* inst) {
 }
 
 // TEMP cast needed until Analyser fixed
-public fn StmtKind Stmt.getKind(const Stmt* s) { return (StmtKind)s.stmtBits.kind; }
+public fn StmtKind Stmt.getKind(const Stmt* s) { return s.stmtBits.kind; }
 
 public fn bool Stmt.isExpr(const Stmt* s) {
     return s.getKind() == Expr;

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -43,9 +43,9 @@ type TypeRefBits struct {
     u32 num_ptrs : 2;   // 0 = Foo, 1 = Foo*, 2 = Foo**
     u32 num_arrays : 2; // limit to 3-dimensional arrays
     u32 incr_array : 1;
-    u32 kind : 2;   // TypeRefKind
     u32 has_prefix : 1;
-    u32 builtin_kind : 4;   // only if builtin (!is_user)
+    TypeRefKind kind : 2;
+    BuiltinKind builtin_kind : 4;   // only if builtin (!is_user)
 }
 
 public type Ref struct {
@@ -175,13 +175,13 @@ public fn void TypeRefHolder.setBuiltin(TypeRefHolder* h, BuiltinKind kind, SrcL
 
 public fn void TypeRefHolder.setVoid(TypeRefHolder* h, SrcLoc loc) {
     TypeRef* r = (TypeRef*)&h.ref;
-    r.flags.kind = TypeRefKind.Void;
+    r.flags.kind = Void;
     r.loc = loc;
 }
 
 public fn void TypeRefHolder.setUser(TypeRefHolder* h, SrcLoc loc, u32 name_idx) {
     TypeRef* r = (TypeRef*)&h.ref;
-    r.flags.kind = TypeRefKind.User;
+    r.flags.kind = User;
     h.user.loc = loc;
     h.user.name_idx = name_idx;
     h.user.decl = nil;
@@ -189,7 +189,7 @@ public fn void TypeRefHolder.setUser(TypeRefHolder* h, SrcLoc loc, u32 name_idx)
 
 public fn void TypeRefHolder.setFunction(TypeRefHolder* h, Decl* fd) {
     TypeRef* r = (TypeRef*)&h.ref;
-    r.flags.kind = TypeRefKind.Function;
+    r.flags.kind = Function;
     h.user.loc = 0;
     h.user.name_idx = 0;
     h.user.decl = fd;
@@ -245,7 +245,7 @@ fn void TypeRef.init(TypeRef* dest, const TypeRefHolder* h) {
 }
 
 fn bool TypeRef.matchesTemplate(const TypeRef* r, u32 template_arg) {
-    if (r.flags.kind != TypeRefKind.User || r.flags.has_prefix) return false;
+    if (r.flags.kind != User || r.flags.has_prefix) return false;
     return r.refs[0].name_idx == template_arg;
 }
 
@@ -256,7 +256,7 @@ fn void TypeRef.instantiate(TypeRef* r, const TypeRef* r1, Instantiator* inst) {
         // TODO enforce no prefix in template functions
         r.flagBits = r2.flagBits;
         r.dest = r2.dest;
-        if (r2.flags.kind == TypeRefKind.User) {
+        if (r2.flags.kind == User) {
             r.refs[0].name_idx = r2.refs[0].name_idx;
             r.refs[0].loc = r1.refs[0].loc;     // location from instance?
             r.refs[0].decl = r2.refs[0].decl;
@@ -285,7 +285,7 @@ public fn void TypeRef.setDest(TypeRef* r, u32 dest) {
 
 fn u32 TypeRef.getExtraSize(const TypeRef* r) {
     // User, StructMemberType use Ref
-    u32 numrefs = (r.flags.kind != TypeRefKind.Builtin) + r.flags.has_prefix;
+    u32 numrefs = (r.flags.kind != Builtin) + r.flags.has_prefix;
     u32 extra = numrefs * sizeof(Ref);
     extra += r.flags.num_arrays * sizeof(Expr*);
     return extra;
@@ -310,19 +310,19 @@ public fn bool TypeRef.isVolatile(const TypeRef* r) {
 }
 
 public fn bool TypeRef.isUser(const TypeRef* r) {
-    return r.flags.kind == TypeRefKind.User;
+    return r.flags.kind == User;
 }
 
 fn bool TypeRef.isBuiltin(const TypeRef* r) {
-    return r.flags.kind == TypeRefKind.Builtin;
+    return r.flags.kind == Builtin;
 }
 
 public fn bool TypeRef.isFunction(const TypeRef* r) {
-    return r.flags.kind == TypeRefKind.Function;
+    return r.flags.kind == Function;
 }
 
 public fn bool TypeRef.isVoid(const TypeRef* r) {
-    return r.flags.kind == TypeRefKind.Void;
+    return r.flags.kind == Void;
 }
 
 public fn bool TypeRef.isConstCharPtr(const TypeRef* r) {
@@ -348,11 +348,11 @@ public fn bool TypeRef.isPointerTo(const TypeRef* r, u32 ptr_idx) {
 }
 
 public fn BuiltinKind TypeRef.getBuiltinKind(const TypeRef* r) {
-    return (BuiltinKind)r.flags.builtin_kind;
+    return r.flags.builtin_kind;
 }
 
 public fn TypeRefKind TypeRef.getKind(const TypeRef* r) {
-    return (TypeRefKind)r.flags.kind;
+    return r.flags.kind;
 }
 
 public fn SrcLoc TypeRef.getLoc(const TypeRef* r) {
@@ -433,7 +433,7 @@ fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool prin
     if (r.isConst()) out.add("const ");
     if (r.isVolatile()) out.add("volatile ");
 
-    switch ((TypeRefKind)r.flags.kind) {
+    switch (r.flags.kind) {
     case Builtin:
         out.add(builtinType_names[r.getBuiltinKind()]);
         break;
@@ -475,7 +475,7 @@ fn void TypeRef.print(const TypeRef* r, string_buffer.Buf* out, bool filled) {
     if (r.isConst()) out.add("const ");
     if (r.isVolatile()) out.add("volatile ");
 
-    switch ((TypeRefKind)r.flags.kind) {
+    switch (r.flags.kind) {
     case Builtin:
         out.add(builtinType_names[r.getBuiltinKind()]);
         break;
@@ -530,7 +530,7 @@ public fn void TypeRef.dump_full(const TypeRef* r) @(unused) {
     out.add("flags:");
     if (r.flags.is_const) out.add(" const");
     out.print(" ptrs=%d", r.flags.num_ptrs);
-    out.print(" kind=%s", TypeRefKind.str((TypeRefKind)r.flags.kind));
+    out.print(" kind=%s", r.flags.kind.str());
     out.print(" has_prefix=%d", r.flags.has_prefix);
     out.newline();
     out.indent(1);

--- a/ast/unary_operator.c2
+++ b/ast/unary_operator.c2
@@ -47,7 +47,8 @@ const char*[UnaryOpcode] unaryOpcode_names = {
 
 type UnaryOperatorBits struct {
     u32 : NumExprBits;
-    u32 kind : 4;
+    u32 : 2;
+    UnaryOpcode kind : 4;
 }
 
 public type UnaryOperator struct @(opaque) {
@@ -71,7 +72,7 @@ fn Expr* UnaryOperator.instantiate(UnaryOperator* e, Instantiator* inst) {
 }
 
 public fn UnaryOpcode UnaryOperator.getOpcode(const UnaryOperator* e) {
-    return (UnaryOpcode)e.base.base.unaryOperatorBits.kind;
+    return e.base.base.unaryOperatorBits.kind;
 }
 
 public fn Expr* UnaryOperator.getInner(const UnaryOperator* e) { return e.inner; }

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -48,15 +48,15 @@ public type FormatAttr enum u8 {
 
 type VarDeclBits struct {
     u32 : NumDeclBits;
-    u32 kind : 3;
+    VarDeclKind kind : 3;
     u32 is_bitfield : 1;   // bitfield is struct-member
     u32 has_init : 1;      // global and local variables
     u32 has_local : 1; // local variables only
     u32 has_init_call : 1; // local variables only
     u32 attr_weak : 1; // globals only
     u32 addr_used : 1;
-    u32 auto_attr : 2;  // AutoAttr, for parameters only
-    u32 format_attr : 2; // FormatAttr, for parameters only
+    AutoAttr auto_attr : 2;  // for parameters only
+    FormatAttr format_attr : 2; // for parameters only
 }
 
 public type BitFieldLayout struct {
@@ -131,7 +131,7 @@ public fn VarDecl* VarDecl.createStructMember(ast_context.Context* c,
 
     VarDecl* d = c.alloc(size);
     d.base.init(Variable, name, loc, is_public, QualType_Invalid, ast_idx);
-    d.base.varDeclBits.kind = VarDeclKind.StructMember;
+    d.base.varDeclBits.kind = StructMember;
     if (name == 0) d.base.setUsed();  // set unnamed member to used
     d.typeRef.init(ref);
     if (bitfield) {
@@ -196,7 +196,7 @@ public fn void VarDecl.setOffset(VarDecl* d, u32 offset) {
 }
 
 public fn VarDeclKind VarDecl.getKind(const VarDecl* d) {
-    return (VarDeclKind)d.base.varDeclBits.kind;
+    return d.base.varDeclBits.kind;
 }
 
 public fn bool VarDecl.isGlobal(const VarDecl* d) {
@@ -312,11 +312,11 @@ public fn bool VarDecl.hasAttrWeak(const VarDecl* d) {
 }
 
 fn AutoAttr VarDecl.getAutoAttr(const VarDecl* d) {
-    return (AutoAttr)d.base.varDeclBits.auto_attr;
+    return d.base.varDeclBits.auto_attr;
 }
 
 public fn void VarDecl.setAttrAutoFile(VarDecl* d) {
-    d.base.varDeclBits.auto_attr = AutoAttr.File;
+    d.base.varDeclBits.auto_attr = File;
 }
 
 public fn bool VarDecl.hasAttrAutoFile(const VarDecl* d) {
@@ -324,7 +324,7 @@ public fn bool VarDecl.hasAttrAutoFile(const VarDecl* d) {
 }
 
 public fn void VarDecl.setAttrAutoLine(VarDecl* d) {
-    d.base.varDeclBits.auto_attr = AutoAttr.Line;
+    d.base.varDeclBits.auto_attr = Line;
 }
 
 public fn bool VarDecl.hasAttrAutoLine(const VarDecl* d) {
@@ -332,7 +332,7 @@ public fn bool VarDecl.hasAttrAutoLine(const VarDecl* d) {
 }
 
 public fn void VarDecl.setAttrAutoFunc(VarDecl* d) {
-    d.base.varDeclBits.auto_attr = AutoAttr.Func;
+    d.base.varDeclBits.auto_attr = Func;
 }
 
 public fn bool VarDecl.hasAttrAutoFunc(const VarDecl* d) {
@@ -348,7 +348,7 @@ public fn void VarDecl.setFormatAttr(VarDecl* d, FormatAttr kind) {
 }
 
 public fn FormatAttr VarDecl.getFormatAttr(const VarDecl* d) {
-    return (FormatAttr)d.base.varDeclBits.format_attr;
+    return d.base.varDeclBits.format_attr;
 }
 
 fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
@@ -368,7 +368,7 @@ fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
     if (d.hasLocalQualifier()) out.add(" (local)");
     if (d.base.varDeclBits.attr_weak) out.add(" weak");
     if (d.base.varDeclBits.addr_used) out.add(" addr_used");
-    switch ((AutoAttr)d.base.varDeclBits.auto_attr) {
+    switch (d.base.varDeclBits.auto_attr) {
     case None: break;
     case File: out.add(" auto_file"); break;
     case Line: out.add(" auto_line"); break;

--- a/common/target_info.c2
+++ b/common/target_info.c2
@@ -29,29 +29,29 @@ const char*[Vendor] vendor_names = { "unknown", "apple" }
 const char*[Abi] abi_names = { "unknown", "gnu", "gnueabi", "macho", "win32", "rv32", "bsd" }
 
 public fn System str2sys(const char* name) {
-    for (u32 i=0; i<elemsof(system_names); i++) {
-        if (strcasecmp(system_names[(System)i], name) == 0) return (System)i;
+    for (System i = System.min; i <= System.max; i++) {
+        if (strcasecmp(system_names[i], name) == 0) return i;
     }
     return Unknown;
 }
 
 public fn Arch str2arch(const char* name) {
-    for (u32 i=0; i<elemsof(arch_names); i++) {
-        if (strcasecmp(arch_names[(Arch)i], name) == 0) return (Arch)i;
+    for (Arch i = Arch.min; i <= Arch.max; i++) {
+        if (strcasecmp(arch_names[i], name) == 0) return i;
     }
     return Unknown;
 }
 
 public fn Vendor str2vendor(const char* name) {
-    for (u32 i=0; i<elemsof(vendor_names); i++) {
-        if (strcasecmp(vendor_names[(Vendor)i], name) == 0) return (Vendor)i;
+    for (Vendor i = Vendor.min; i <= Vendor.max; i++) {
+        if (strcasecmp(vendor_names[i], name) == 0) return i;
     }
     return Unknown;
 }
 
 public fn Abi str2abi(const char* name) {
-    for (u32 i=0; i<elemsof(abi_names); i++) {
-        if (strcasecmp(abi_names[(Abi)i], name) == 0) return (Abi)i;
+    for (Abi i = Abi.min; i <= Abi.max; i++) {
+        if (strcasecmp(abi_names[i], name) == 0) return i;
     }
     return Unknown;
 }

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -174,7 +174,7 @@ fn u32 Parser.skipArray(Parser* p, u32 ahead, Kind endKind) {
 /*
   Syntax:
     Number num = .     // id = type
-    Utils.Type t = .  // id = module.type
+    utils.Type t = .  // id = module.type
     myfunc()        // id = func
     Mod.func()     // id = module.func
     count =         // id = var

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -16,7 +16,6 @@
 module c2_tokenizer;
 
 import constants;
-import number_radix local;
 import keywords;
 import src_loc local;
 import string_buffer;
@@ -768,7 +767,7 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
 
     if (p[0] == '0') {
         if (p[1] == 'x' || p[1] == 'X') {  // hexadecimal
-            result.radix = Radix.Hex;
+            result.radix = Hex;
             p += 2;
             if (isxdigit(*p)) {
                 while (isxdigit(*p)) {
@@ -799,7 +798,7 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
             goto check_overflow;
         }
         if (p[1] == 'b' || p[1] == 'B') {   // binary
-            result.radix = Radix.Binary;
+            result.radix = Binary;
             p += 2;
             while (is_binary(*p)) {
                 if (value > u64.max >> 1) {
@@ -848,10 +847,10 @@ fn void Tokenizer.lex_number(Tokenizer* t, Token* result) {
         }
         t.cur = p;
         if (p == start + 1) {
-            // value is 0, radix = Radix.Default, len = 1
+            // value is 0, radix = Default, len = 1
             return;
         }
-        result.radix = Radix.Octal;
+        result.radix = Octal;
         goto check_overflow;
     }
 
@@ -1024,7 +1023,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result, const char* stype
     case '5':
     case '6':
     case '7':
-        result.radix = Radix.Octal;
+        result.radix = Octal;
         nc = octconv(p, 3, &cc);
         if (cc > 255) {
             t.error(result, "octal escape sequence out of range");
@@ -1035,7 +1034,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result, const char* stype
     case 'x':
         // C consumes all hex digits after \x (at least one)
         // C2 requires 2 hex digits, but rejects extra digits to simplify C generation
-        result.radix = Radix.Hex;
+        result.radix = Hex;
         nc = hexconv(p + 1, i32.max, &cc);
         if (nc == 0) {
             t.error(result, "expect hexadecimal number after '\\x'");
@@ -1067,7 +1066,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result, const char* stype
         t.buf.add1(c);
         break;
     case 'u':
-        result.radix = Radix.Hex;
+        result.radix = Hex;
         nc = hexconv(p + 1, 4, &cc);
         if (nc != 4) {
             t.error(result, "expect 4 hexadecimal digits after '\\u'");
@@ -1076,7 +1075,7 @@ fn u32 Tokenizer.lex_escaped_char(Tokenizer* t, Token* result, const char* stype
         nc++;
         goto add_utf8;
     case 'U':
-        result.radix = Radix.Hex;
+        result.radix = Hex;
         nc = hexconv(p + 1, 8, &cc);
         if (nc != 8) {
             t.error(result, "expect 8 hexadecimal digits after '\\U'");

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -329,7 +329,7 @@ public type Token struct {
     Kind kind : 8;
     bool done : 1;
     // TODO: fix QualType.getBitFieldWidth() to return actual number of bits instead of implementation type
-    u8 radix : 2;   // number_radix.Radix: for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
+    Radix radix : 2;   // for IntegerLiteral (2,8,10,16), FloatLiteral(10,16) and CharLiteral (8,16)
     u8 raw : 1;     // for StringLiteral
     bool reserved : 1;
     bool suffix_F : 1;
@@ -353,5 +353,5 @@ public fn void Token.init(Token* tok) {
 }
 
 public fn Radix Token.getRadix(const Token* tok) {
-    return (Radix)tok.radix;
+    return tok.radix;
 }


### PR DESCRIPTION
* use enum types as explicit bit-field members
* remove redundant prefixes for bit-field members
* remove redundant casts for bit-field members
* simplify more enum iterations