### PR TITLE
Compiler: use snprintf instead of risky sprintf

### DIFF
--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -614,8 +614,8 @@ fn bool Analyser.checkFormatArgs(Analyser* ma, Expr** format_ptr, u32 num_args, 
     return true;
 }
 
-fn void create_template_name(char* name, const char* orig, u16 idx) {
-    stdio.sprintf(name, "%s_%d_", orig, idx);
+fn void create_template_name(char* name, u32 size, const char* orig, u16 idx) {
+    stdio.snprintf(name, size, "%s_%d_", orig, idx);
 }
 
 fn void Analyser.opaque_callback(void* arg, SrcLoc loc, Decl* d) {
@@ -673,7 +673,7 @@ fn FunctionDecl* Analyser.instantiateTemplateFunction(Analyser* ma, CallExpr* ca
         u16 instance_idx = ma.mod.addInstance(fd, templateType, instance);
         instance.setTemplateInstanceIdx(instance_idx);
         char[64] name;
-        create_template_name(name, d.getName(), instance_idx);
+        create_template_name(name, elemsof(name), d.getName(), instance_idx);
         instance.setInstanceName(ma.astPool.addStr(name, true));
     }
     call.setTemplateIdx(instance.getTemplateInstanceIdx());

--- a/ast/value.c2
+++ b/ast/value.c2
@@ -828,13 +828,13 @@ public fn char *ftoa(char *dest, usize size, f64 d) {
     }
     if (d < 0.0001 || d > 1000000) {
         for (i32 prec = 14; prec < 17; prec++) {
-            stdio.snprintf(buf, sizeof(buf), "%.*e", prec, d);
+            stdio.snprintf(buf, elemsof(buf), "%.*e", prec, d);
             if (stdlib.atof(buf) == d)
                 break;
         }
     } else {
         for (i32 prec = 17 - 4; prec < 17 + 4; prec++) {
-            stdio.snprintf(buf, sizeof(buf), "%.*f", prec, d);
+            stdio.snprintf(buf, elemsof(buf), "%.*f", prec, d);
             if (stdlib.atof(buf) == d)
                 break;
         }
@@ -865,12 +865,13 @@ public fn const char* Value.str(const Value* v) {
     local char[4][64] text;
     local u8 index = 0;
     char* out = text[index];
+    u32 out_size = elemsof(text[0]);
     index = (index+1) % 4;
 
     switch (v.kind) {
     case Integer:
         *out = '-';
-        stdio.snprintf(out + v.negative, 64 - 1, "%d", v.uvalue);
+        stdio.snprintf(out + v.negative, out_size - 1, "%d", v.uvalue);
         break;
     case Float:
         ftoa(out, 64, v.fvalue);

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -17,8 +17,8 @@ module string_buffer;
 
 import color local;
 
-import stdio local;
 import stdarg local;
+import stdio local;
 import stdlib local;
 import string local;
 
@@ -173,17 +173,17 @@ public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) {
     // NOTE: no growing
     va_list args;
     va_start(args, format);
-    i32 len = vsnprintf(tmp, sizeof(tmp), format, args);
+    i32 len = vsnprintf(tmp, elemsof(tmp), format, args);
     va_end(args);
-    assert(len < sizeof(tmp));
+    assert(len < elemsof(tmp));
     buf.add2(tmp, (u32)len);
 }
 
 public fn void Buf.vprintf(Buf* buf, const char* format, va_list args) {
     char[4096] tmp;
     // NOTE: no growing
-    i32 len = vsnprintf(tmp, sizeof(tmp), format, args);
-    assert(len < sizeof(tmp));
+    i32 len = vsnprintf(tmp, elemsof(tmp), format, args);
+    assert(len < elemsof(tmp));
     buf.add2(tmp, (u32)len);
 }
 

--- a/common/console.c2
+++ b/common/console.c2
@@ -15,10 +15,10 @@
 
 module console;
 
-import stdio local;
-import stdarg local;
-
 import color local;
+
+import stdarg local;
+import stdio local;
 
 bool use_color = false;
 bool show_debug = false;
@@ -44,7 +44,7 @@ public fn void debug(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
     va_list args;
     va_start(args, format);
-    vsnprintf(buf, sizeof(buf), format, args);
+    vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
         printf("%s%s%s\n", color.Blue.str(), buf, color.Normal.str());
@@ -57,7 +57,7 @@ public fn void log(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
     va_list args;
     va_start(args, format);
-    vsnprintf(buf, sizeof(buf), format, args);
+    vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     printf("%s\n", buf);
 }
@@ -66,7 +66,7 @@ public fn void warn(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
     va_list args;
     va_start(args, format);
-    vsnprintf(buf, sizeof(buf), format, args);
+    vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
         fprintf(stderr, "%swarning: %s%s\n", color.Yellow.str(), buf, color.Normal.str());
@@ -79,7 +79,7 @@ public fn void error(const char* format @(printf_format), ...) {
     char[BUF_SIZE] buf;
     va_list args;
     va_start(args, format);
-    vsprintf(buf, format, args);
+    vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
         fprintf(stderr, "%serror: %s%s\n", color.Red.str(), buf, color.Normal.str());
@@ -92,7 +92,7 @@ public fn void error_diag(const char* loc, const char* format @(printf_format), 
     char[BUF_SIZE] buf;
     va_list args;
     va_start(args, format);
-    vsprintf(buf, format, args);
+    vsnprintf(buf, elemsof(buf), format, args);
     va_end(args);
     if (use_color) {
         fprintf(stderr, "%s%s: error: %s%s\n", color.Red.str(), loc, buf, color.Normal.str());

--- a/common/process_utils.c2
+++ b/common/process_utils.c2
@@ -17,15 +17,15 @@ module process_utils;
 
 import file_utils;
 
+import c_errno local;
 import ctype local;
-import string local;
+import libc_fcntl local;
 import stdarg local;
 import stdio local;
-import unistd local;
-import c_errno local;
-import sys_stat local;
 import stdlib local;
-import libc_fcntl local;
+import string local;
+import sys_stat local;
+import unistd local;
 
 const u32 MAX_ARG_LEN = 512;
 const u32 MAX_ARGS = 16;
@@ -47,7 +47,7 @@ fn void child_error(i32 fd, const char* format @(printf_format), ...) @(noreturn
     char[256] msg;
     va_list args;
     va_start(args, format);
-    i32 res = vsnprintf(msg, sizeof(msg), format, args);
+    i32 res = vsnprintf(msg, elemsof(msg), format, args);
     va_end(args);
     if (res >= 0) {
         usize len = (usize)res;

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -28,8 +28,8 @@ import warning_flags;
 import csetjmp local;
 import stdarg local;
 import stdio local;
-import string;
 import stdlib;
+import string;
 
 type Kind enum u8 {
     // global
@@ -177,7 +177,7 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) @(nore
     char[128] msg;
     va_list args;
     va_start(args, format);
-    vsnprintf(msg, sizeof(msg), format, args);
+    vsnprintf(msg, elemsof(msg), format, args);
     va_end(args);
 
     char[256] locstr;
@@ -195,7 +195,7 @@ fn void Parser.warning(Parser* p, const char* format @(printf_format), ...) {
     char[128] msg;
     va_list args;
     va_start(args, format);
-    vsnprintf(msg, sizeof(msg), format, args);
+    vsnprintf(msg, elemsof(msg), format, args);
     va_end(args);
 
     char[256] locstr;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -43,9 +43,9 @@ import utils;
 
 import c_errno local;
 import ctype;
-import string;
-import stdlib;
 import stdio;
+import stdlib;
+import string;
 
 public type BeginTargetFn fn void (void* arg, plugin_info.Info* info);
 public type PluginFn fn void (void* arg);
@@ -489,7 +489,7 @@ fn void Compiler.removeFeature(Compiler* c, const char* str) {
 
 fn void Compiler.addGlobalDefine(Compiler* c, const char* prefix, const char* tail) {
     char[32] tmp;
-    stdio.snprintf(tmp, 32, "%s_%s", prefix, tail);
+    stdio.snprintf(tmp, elemsof(tmp), "%s_%s", prefix, tail);
     for (usize i = 0; tmp[i]; i++) {
         u8 ch = (u8)tmp[i];
         tmp[i] = (ch == '-') ? '_' : (char)ctype.toupper(ch);

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -37,11 +37,11 @@ import string_pool;
 import string_utils;
 import utils;
 
-import stdio;
-import stdlib local;
-import unistd;
-import string local;
 import c_errno local;
+import stdio local;
+import stdlib local;
+import string local;
+import unistd;
 
 type Options struct {
     bool log_verbose;
@@ -524,7 +524,7 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
                 if (!c.plugins.loadGlobal(p.name, p.options)) {
                     source_mgr.Location loc = c.sm.locate(p.loc);
                     char[256] loc_str;
-                    stdio.sprintf(loc_str, "%s:%d:%d", loc.filename, loc.line, loc.column);
+                    snprintf(loc_str, elemsof(loc_str), "%s:%d:%d", loc.filename, loc.line, loc.column);
                     console.error_diag(loc_str, "%s", c.plugins.getError());
                     exit(EXIT_FAILURE);
                 }
@@ -560,7 +560,7 @@ fn void Context.handle_plugins(Context* c) {
         if (!c.plugins.loadGlobal(p.name, p.options)) {
             source_mgr.Location loc = c.sm.locate(p.loc);
             char[256] loc_str;
-            stdio.sprintf(loc_str, "%s:%d:%d", loc.filename, loc.line, loc.column);
+            snprintf(loc_str, elemsof(loc_str), "%s:%d:%d", loc.filename, loc.line, loc.column);
             console.error_diag(loc_str, "%s", c.plugins.getError());
             exit(EXIT_FAILURE);
         }
@@ -606,7 +606,7 @@ fn bool Context.build_target(Context* c,
         if (!c.plugins.loadLocal(p.name, p.options)) {
             source_mgr.Location loc = c.sm.locate(p.loc);
             char[256] loc_str;
-            stdio.sprintf(loc_str, "%s:%d:%d", loc.filename, loc.line, loc.column);
+            snprintf(loc_str, elemsof(loc_str), "%s:%d:%d", loc.filename, loc.line, loc.column);
             console.error_diag(loc_str, "%s", c.plugins.getError());
             continue;
         }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -36,9 +36,9 @@ import string_utils;
 import target_info;
 
 import c_errno local;
-import string;
+import stdio local;
 import stdlib;
-import stdio;
+import string;
 
 type Fragment struct {
     string_buffer.Buf* buf;
@@ -894,7 +894,7 @@ fn void Generator.emitFuncParams(Generator* gen, FunctionDecl* fd, string_buffer
                 const char* name = argx.getName();
                 char[8] temp;
                 if (!name) {
-                    stdio.sprintf(temp, "_arg%d", i);
+                    snprintf(temp, elemsof(temp), "_arg%d", i);
                     name = temp;
                 }
                 gen.gen_member_type_func(fd2, out, name);
@@ -1207,11 +1207,11 @@ fn void Generator.write_files(Generator* gen) {
 
     char[64] outfile;
     if (!gen.cur_external) {
-        stdio.sprintf(outfile, "%s.c", gen.mod_name);
+        snprintf(outfile, elemsof(outfile), "%s.c", gen.mod_name);
         gen.write(gen.cgen_dir, outfile, gen.out);
     }
 
-    stdio.sprintf(outfile, "%s.h", gen.mod_name);
+    snprintf(outfile, elemsof(outfile), "%s.h", gen.mod_name);
     gen.write(gen.cgen_dir, outfile, gen.header);
 
     gen.out.clear();

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -25,8 +25,8 @@ import module_list;
 import string_buffer;
 import string_list;
 
+import stdio local;
 import string;
-import stdio;
 
 fn void Generator.createMakefile(Generator* gen,
                                  const char* output_dir,
@@ -188,7 +188,7 @@ fn void Generator.createMakefile(Generator* gen,
         out.newline();
         break;
     case StaticLibrary:
-        stdio.sprintf(target_name, "lib%s.a", gen.target);
+        snprintf(target_name, elemsof(target_name), "lib%s.a", gen.target);
         out.print("all: ../%s\n\n", target_name);
 
         out.print("../%s: $(objects) $(headers)\n", target_name);
@@ -197,9 +197,9 @@ fn void Generator.createMakefile(Generator* gen,
     case DynamicLibrary:
         out.add("CFLAGS+=-fPIC\n");
         if (gen.targetInfo.sys == Darwin) {
-            stdio.sprintf(target_name, "lib%s.dylib", gen.target);
+            snprintf(target_name, elemsof(target_name), "lib%s.dylib", gen.target);
         } else {
-            stdio.sprintf(target_name, "lib%s.so", gen.target);
+            snprintf(target_name, elemsof(target_name), "lib%s.so", gen.target);
         }
         out.print("all: ../%s\n\n", target_name);
 

--- a/generator/ir/ir_generator_stmt.c2
+++ b/generator/ir/ir_generator_stmt.c2
@@ -283,8 +283,8 @@ fn void Generator.emitAssertStmt(Generator* gen, const Stmt* s) {
 
     char[32] body_blk;
     char[32] join_blk;
-    sprintf(body_blk, "@assert_body.%d", gen.getNewBlockIndex());
-    sprintf(join_blk, "@assert_join.%d", gen.getNewBlockIndex());
+    snprintf(body_blk, elemsof(body_blk), "@assert_body.%d", gen.getNewBlockIndex());
+    snprintf(join_blk, elemsof(join_blk), "@assert_join.%d", gen.getNewBlockIndex());
 
     // TODO check if CtvCondition, then skip rest
     ExprRef check;
@@ -301,7 +301,7 @@ fn void Generator.emitAssertStmt(Generator* gen, const Stmt* s) {
     source_mgr.Location loc = gen.sm.getLocation(a.getLoc());
     const char* funcname = gen.cur_function.asDecl().getFullName();
     char[512] location;
-    stdio.sprintf(location, "%s:%d: %s", loc.filename, loc.line, funcname);
+    stdio.snprintf(location, elemsof(location), "%s:%d: %s", loc.filename, loc.line, funcname);
     ExprRef loc_str;
     gen.createString(&loc_str, location);
 

--- a/ir/context.c2
+++ b/ir/context.c2
@@ -91,7 +91,7 @@ public fn Context* create(bool print, const target_info.Info* info, const BuildI
         char[8] slot_name;
         // Result: starts at 4, then +4 each
         // Note: just 4,8,12,
-        stdio.sprintf(slot_name, "s%d", slot);
+        stdio.snprintf(slot_name, elemsof(slot_name), "s%d", slot);
         u32 idx = c.pool.addStr(slot_name, false);
     }
 

--- a/ir/ref.c2
+++ b/ir/ref.c2
@@ -126,7 +126,8 @@ public fn const char* Ref.str(const Ref* r) @(unused) {
     local u32 idx;
     idx = (idx+1) % 4;
     char* tmp = buf[idx++];
-    stdio.sprintf(tmp, "%s %d", r.getKind().str(), r.value);
+    u32 tmp_size = elemsof(buf[0]);
+    stdio.snprintf(tmp, tmp_size, "%s %d", r.getKind().str(), r.value);
     return tmp;
 }
 

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -24,11 +24,11 @@ import string_pool;
 import token local;
 import utf8;
 
-import string;
-import stdlib;
 import ctype local;
 import stdarg local;
 import stdio local;
+import stdlib;
+import string;
 
 type Action enum u8 {
     INVALID = 0,  // ensure the default Action in Char_lookup is INVALID
@@ -674,7 +674,7 @@ invalid_char:
 fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
     va_list args;
     va_start(args, format);
-    vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
+    vsnprintf(t.error_msg, elemsof(t.error_msg), format, args);
     va_end(args);
 
     result.loc = t.loc_start + (SrcLoc)(t.cur - t.input_start);
@@ -688,7 +688,7 @@ fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf
 fn void Tokenizer.num_error(Tokenizer* t, Token* result, const char* p, const char* format @(printf_format), ...) {
     va_list args;
     va_start(args, format);
-    vsnprintf(t.error_msg, sizeof(t.error_msg), format, args);
+    vsnprintf(t.error_msg, elemsof(t.error_msg), format, args);
     va_end(args);
 
     SrcLoc err_loc = t.loc_start + (SrcLoc)(p - t.input_start);

--- a/plugins/deps_generator.c2
+++ b/plugins/deps_generator.c2
@@ -24,9 +24,9 @@ import string_buffer;
 import string_list;
 import string_pool;
 
-import string local;
-import stdlib local;
 import stdio local;
+import stdlib local;
+import string local;
 
 type Dir struct {
     u32 name_idx;
@@ -141,7 +141,7 @@ fn void Generator.on_decl(void* arg, Decl* d, bool global) {
             Decl* ecd = (Decl*)constants[i];
             // NOTE: we add the symbol here, since we have the EnumDecl here
             char[64] fullname;
-            sprintf(fullname, "%s.%s", d.getName(), ecd.getName());
+            snprintf(fullname, elemsof(fullname), "%s.%s", d.getName(), ecd.getName());
             //gen.refs.add_symbol(fullname, &dest);
 
             Generator.on_decl(arg, ecd, false);

--- a/plugins/deps_generator_utils.c2
+++ b/plugins/deps_generator_utils.c2
@@ -16,7 +16,8 @@
 module deps_generator_utils;
 
 import ast local;
-import stdio;
+
+import stdio local;
 
 public fn const char* getPrefixedName(const Decl* d) {
     switch (d.getKind()) {
@@ -24,7 +25,7 @@ public fn const char* getPrefixedName(const Decl* d) {
         const FunctionDecl* fd = (FunctionDecl*)d;
         if (fd.hasPrefix()) {
             local char[64] fullname;
-            stdio.sprintf(fullname, "%s.%s", fd.getPrefixName(), d.getName());
+            snprintf(fullname, elemsof(fullname), "%s.%s", fd.getPrefixName(), d.getName());
             return fullname;
         }
         break;

--- a/plugins/unit_test2.c2
+++ b/plugins/unit_test2.c2
@@ -138,7 +138,7 @@ public fn i32 run_tests() {
 
   const char* color = stats.failed ? Red : Green;
   char[80] results;
-  sprintf(results, "RESULT: %d tests (%d ok, %d failed, %d skipped) ran in %d ms",
+  snprintf(results, elemsof(results), "RESULT: %d tests (%d ok, %d failed, %d skipped) ran in %d ms",
     stats.total, stats.ok, stats.failed, stats.skipped, (t2 - t1) / 1000);
   color_print(color, results);
   return 0;

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -152,10 +152,10 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         i32 len;
         switch (tok.getRadix()) {
         case Hex:
-            len = sprintf(tmp, "0x%x", tok.int_value);
+            len = snprintf(tmp, elemsof(tmp), "0x%x", tok.int_value);
             break;
         default:
-            len = sprintf(tmp, "%d", tok.int_value);
+            len = snprintf(tmp, elemsof(tmp), "%d", tok.int_value);
             break;
         }
         out.add(tmp);
@@ -167,10 +167,10 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         i32 len;
         switch (tok.getRadix()) {
         case Hex:
-            len = sprintf(tmp, "%a", tok.float_value);
+            len = snprintf(tmp, elemsof(tmp), "%a", tok.float_value);
             break;
         default:
-            len = sprintf(tmp, "%#.16g", tok.float_value);
+            len = snprintf(tmp, elemsof(tmp), "%#.16g", tok.float_value);
             break;
         }
         out.add(tmp);
@@ -183,14 +183,14 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         i32 len = 0;
         switch (tok.getRadix()) {
         case Hex:
-            len = sprintf(tmp, "'\\x%02x'", tok.char_value);
+            len = snprintf(tmp, elemsof(tmp), "'\\x%02x'", tok.char_value);
             break;
         case Octal:
-            len = sprintf(tmp, "'\\%o'", tok.char_value);
+            len = snprintf(tmp, elemsof(tmp), "'\\%o'", tok.char_value);
             break;
         default:
             if (ctype.isprint(tok.char_value)) {
-                len = sprintf(tmp, "'%c'", tok.char_value);
+                len = snprintf(tmp, elemsof(tmp), "'%c'", tok.char_value);
             } else {
                 tmp[0] = 0;
                 // TODO print nicely (eg \n etc)

--- a/tools/tester/test_db.c2
+++ b/tools/tester/test_db.c2
@@ -476,7 +476,7 @@ fn void Db.error(Db* db, const char* format @(printf_format), ...) {
     char[1024] msg;
     va_list args;
     va_start(args, format);
-    vsnprintf(msg, sizeof(msg), format, args);
+    vsnprintf(msg, elemsof(msg), format, args);
     va_end(args);
     color_print2(db.output, colError, "%s:%d: %s", db.filename, db.line_nr, msg);
     db.hasErrors = true;

--- a/tools/tester/test_utils.c2
+++ b/tools/tester/test_utils.c2
@@ -54,7 +54,7 @@ public fn void color_print(Color col, const char* format @(printf_format), ...) 
     char[1024] buffer;
     va_list args;
     va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
+    vsnprintf(buffer, elemsof(buffer), format, args);
     va_end(args);
 
     if (color_output) printf("%s%s%s\n", col.str(), buffer, color.Normal.str());
@@ -65,7 +65,7 @@ public fn void print_error(const char* format @(printf_format), ...) {
     char[1024] buffer;
     va_list args;
     va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
+    vsnprintf(buffer, elemsof(buffer), format, args);
     va_end(args);
 
     if (color_output) fprintf(stderr, "%s: %s%s%s\n", proc_name, color.Byellow.str(), buffer, color.Normal.str());
@@ -80,7 +80,7 @@ public fn void color_print2(string_buffer.Buf* output,
     char[1024] buffer;
     va_list args;
     va_start(args, format);
-    vsnprintf(buffer, sizeof(buffer), format, args);
+    vsnprintf(buffer, elemsof(buffer), format, args);
     va_end(args);
 
     output.color(col);

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -15,15 +15,15 @@
 
 module tester_main;
 
+import c_errno local;
+import libc_dirent local;
+import pthread;
 import stdio local;
 import stdlib local;
 import string local;
 import sys_stat local;
 import sys_time;
-import libc_dirent local;
-import c_errno local;
 import unistd;
-import pthread;
 
 import color;
 import test_utils local;
@@ -207,7 +207,7 @@ fn Tester* Tester.create(u32 idx, TestQueue* q, const char* cwd, bool sync) {
     t.queue = q;
     t.cwd = cwd;
     t.thread = 0;
-    snprintf(t.tmp_dir, sizeof(t.tmp_dir), "/tmp/tester%d", idx);
+    snprintf(t.tmp_dir, elemsof(t.tmp_dir), "/tmp/tester%d", idx);
     if (sync)
         tester_thread_main(t);
     else
@@ -236,7 +236,7 @@ fn void Tester.run_test(Tester* t, Test* test) {
     // setup dir
     // temp, just delete this way
     char[64] cmd;
-    snprintf(cmd, sizeof(cmd), "rm -rf %s", t.tmp_dir);
+    snprintf(cmd, elemsof(cmd), "rm -rf %s", t.tmp_dir);
     i32 err = system(cmd);
     if (err != 0 && errno != ECHILD) {
         i32 saved = errno;


### PR DESCRIPTION
* always pass the number of elements of the destination array this ensures `sizeof` is not used on a pointer.
* this does not cause any overhead: `snprintf` and `sprintf` share the same implementation in the C library.