### PR TITLE
libc: suggest strlcpy and strlcat as alternatives for strncpy and str…

### DIFF
--- a/libs/libc/stdio.c2i
+++ b/libs/libc/stdio.c2i
@@ -87,7 +87,7 @@ FILE* stderr @(cname="(&__sF[2])", cdef="FILE __sF[]");
 int remove(const char* __filename);
 int rename(const char* __old, const char* __new);
 
-FILE* tmpfile();
+FILE* tmpfile(void);
 char* tmpnam(char* __s) @(deprecated="use unistd.mkstemp instead");
 char* tempnam(const char* __dir, const char* __pfx) @(deprecated="use unistd.mkstemp instead");
 int fclose(FILE* __stream);
@@ -109,14 +109,14 @@ int scanf(const char* __format @(scanf_format), ...);
 int sscanf(const char* __s, const char* __format @(scanf_format), ...);
 int fgetc(FILE* __stream);
 int getc(FILE* __stream);
-int getchar();
+int getchar(void);
 int getc_unlocked(FILE* __stream);
-int getchar_unlocked();
+int getchar_unlocked(void);
 int fputc(int __c, FILE* __stream);
 int putc(int __c, FILE* __stream);
 int putchar(int __c);
 int putchar_unlocked(int __c);
-char* gets(char* __s) @(deprecated="function cannot be used safely");
+char* gets(char* __s) @(deprecated="function cannot be used safely, consider using getsn");
 int getw(FILE* __stream);
 int putw(int __w, FILE* __stream);
 char* fgets(char* __s, int __n, FILE* __stream);
@@ -189,3 +189,22 @@ int vsnprintf(char* str, size_t size, const char *format, va_list ap);
 int vfscanf(FILE* stream, const char* format, va_list ap);
 int vscanf(const char* format, va_list ap);
 int vsscanf(const char* str, const char* format, va_list ap);
+
+char* getsn(char* buf, size_t len) {
+    size_t i = 0;
+    while (i + 1 < len) {
+        int c = fgetc(stdin);
+        if (c == EOF) {
+            if (i == 0) return nil;
+            break;
+        }
+        if (c == '\n') break;
+        buf[i++] = (char)c;
+    }
+    if (len == 0) {
+        if (feof(stdin)) return nil;
+    } else {
+        buf[i] = '\0';
+    }
+    return buf;
+}

--- a/libs/libc/string.c2i
+++ b/libs/libc/string.c2i
@@ -12,13 +12,13 @@ void* memcpy(void* dest, const void* src, size_t n);
 void* memccpy(void* dest, const void* src, int c, size_t n);
 void* memmove(void* dest, const void* src, size_t n);
 char* strcpy(char* dest, const char* src);
-char* strncpy(char* dest, const char* src, size_t n) @(deprecated="function has misleading semantics");
+char* strncpy(char* dest, const char* src, size_t n) @(deprecated="function has misleading semantics, consider using strlcpy");
 char* strdup(const char* s);
 char* strndup(const char* s, size_t n);
 
 /* 7.26.3 Concatenation functions */
 char* strcat(char* dest, const char* src);
-char* strncat(char* dest, const char* src, size_t n) @(deprecated="function has misleading semantics");
+char* strncat(char* dest, const char* src, size_t n) @(deprecated="function has misleading semantics, consider using strlcat");
 
 /* 7.26.4 Comparison functions */
 int memcmp(const void* s1, const void* s2, size_t n);
@@ -69,4 +69,47 @@ char* strchrnul(const char* s, int c);
 char* strnstr(const char* s1, const char* s2, size_t n);
 size_t strlcpy(char* dest, const char* src, size_t n);
 size_t strlcat(char* dest, const char* src, size_t n);
+#else
+/*
+ * Find the first occurrence of s2 in s1, where the search is limited to the
+ * first n c_characters of s.
+ */
+char *strnstr(const char *s1, const char *s2, size_t n) {
+    /* simplistic algorithm with O(n2) worst case */
+    char c = *s2++;
+    if (c == '\0') return (char *)s1;
+    size_t len = strlen(s2);
+    for (; n-- >= len && *s1; s1++) {
+        if (*s1 == c) {
+            for (size_t i = 1;; i++) {
+                if (i == len)
+                    return (char *)s1;
+                if (s1[i] != s2[i])
+                    break;
+            }
+        }
+    }
+    return nil;
+}
+
+size_t strlcpy(char *dst, const char *src, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        if ((dst[i] = *src++) == '\0') return i;
+    }
+    if (n) dst[n - 1] = '\0';
+    while (*src++) n++;
+    return n;
+}
+
+size_t strlcat(char *dst, const char *src, size_t n) {
+    size_t i = 0;
+    while (i < n && dst[i]) i++;
+    while (i < n) {
+        if ((dst[i] = *src++) == '\0') return i;
+        i++;
+    }
+    if (n) dst[n - 1] = '\0';
+    while (*src++) n++;
+    return n;
+}
 #endif

--- a/test/expr/call_deprecated.c2
+++ b/test/expr/call_deprecated.c2
@@ -6,13 +6,13 @@ import string local;
 
 fn void test1() {
     char[128] buf;
-    gets(buf);  // @warning{function stdio.gets is deprecated: function cannot be used safely}
+    gets(buf);  // @warning{function stdio.gets is deprecated: function cannot be used safely, consider using getsn}
 }
 
 fn void test2(char* dest, const char* src) {
-    strncpy(dest, src, 10);  // @warning{function string.strncpy is deprecated: function has misleading semantics}
+    strncpy(dest, src, 10);  // @warning{function string.strncpy is deprecated: function has misleading semantics, consider using strlcpy}
 }
 
 fn void test3(char* dest, const char* src) {
-    strncat(dest, src, 10);  // @warning{function string.strncat is deprecated: function has misleading semantics}
+    strncat(dest, src, 10);  // @warning{function string.strncat is deprecated: function has misleading semantics, consider using strlcat}
 }


### PR DESCRIPTION
…ncat

* improve warning about obsolete functions
* add inline implementation of `strlcpy` and `strlcat` for linux targets
* suggest `getsn` as aternative for `gets`, added inline implementation.