### PR TITLE
Compiler: fix and simplify pure function handling

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -78,6 +78,9 @@ public type Analyser struct @(opaque) {
     init_checker.Checker[4] init_checkers;
     u32 min_idx;
     u32 max_idx;
+
+    u32 global_initializer;
+    u32 need_const_expr;
 }
 
 public fn Analyser* create(diagnostics.Diags* diags,
@@ -488,8 +491,8 @@ fn void Analyser.handleStaticAssert(void* arg, StaticAssert* sa) {
 
     // push a dummy declaration so ma.popCheck() does not set ma.scope to nil
     if (!ma.pushCheck(nil, sa.getAST().getPtr(), nil)) return;
-    QualType t1 = ma.analyseExpr(&lhs, false, RHS);
-    QualType t2 = ma.analyseExpr(&rhs, false, RHS);
+    QualType t1 = ma.analyseConstExpr(&lhs, true);
+    QualType t2 = t1.isInvalid() ? t1 : ma.analyseConstExpr(&rhs, true);
     ma.popCheck();
     if (t1.isInvalid() || t2.isInvalid()) return;
 
@@ -621,7 +624,9 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
             ma.checkStack[ma.checkIndex-1].usedPublic = false;
             ma.usedPublic = false;
         }
+        ma.global_initializer++;
         ma.analyseInitExpr(v.getInit2(), res, v.getAssignLoc(), false, false);
+        ma.global_initializer--;
     } else {
         if (res.isConstant() && !embed) {
             ma.error(d.getLoc(), "constant variable '%s' must be initialized", d.getFullName());

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -56,7 +56,31 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
     */
 
     FunctionDecl* fd = ft.getDecl();
-    if (fd != ma.curFunction) fd.asDecl().setUsed();
+    if (fd != ma.curFunction) {
+        Decl* d = (Decl*)fd;
+        d.setUsed();
+        if (!d.isChecked()) {
+            // needed for pure function calls in type definitions and static asserts
+            if (!ma.analyseGlobalDecl(d)) return QualType_Invalid;
+        }
+    }
+
+    if (ma.globalScope() || ma.need_const_expr) {
+        if (fd.hasAttrPure()) {
+            if (ma.globalScope()) {
+                ma.analyseFunctionBody(fd, fd.asDecl().getAST().getPtr());
+            } else {
+                // if not at global scope, need explicit recursion as for template instantiation
+                ma.analyseFunctionBody2(fd, fd.asDecl().getModule());
+            }
+        } else
+        if (ma.global_initializer) {
+            ma.error(e.getLoc(), "only pure functions can be called in global initializers");
+            ma.note(fd.asDecl().getLoc(), NoteDeclaredHere, fd.asDecl().getFullName());
+            return QualType_Invalid;
+        }
+    }
+
     if (fd.hasAttrNoReturn()) call.setNoreturn();
 
     if (fd.isTemplate()) {
@@ -80,6 +104,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         //return QualType_Invalid;
     }
 
+    bool isCtv = fd.hasAttrPure();
+    bool isCtc = isCtv;
     u32 func_num_args = fd.getNumParams();
     u32 call_num_args = call.getNumArgs();
 
@@ -170,6 +196,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         if (!ok) return QualType_Invalid;
 
         func_arg_index++;
+        isCtv = isCtc = false;
     }
 
     //stdio.printf("CALL (%d | %d)\n", func_num_args, call_num_args);
@@ -184,7 +211,6 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
             func_arg_index++;
             continue;
         }
-
         if (call_arg_index >= call_num_args) break;
 
         Expr* arg = call_args[call_arg_index];
@@ -221,6 +247,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         if (!ma.analyseInitExpr(&call_args[call_arg_index], d.getType(), arg.getLoc(), false, false))
             return QualType_Invalid;
 
+        isCtv &= call_args[call_arg_index].isCtv();
+        isCtc &= call_args[call_arg_index].isCtc();
         func_arg_index++;
         call_arg_index++;
     }
@@ -253,12 +281,14 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
 
         while (call_arg_index < call_num_args) {
             QualType callType = ma.analyseExpr(&call_args[call_arg_index], true, RHS);
+            Expr* call_arg = call_args[call_arg_index];
             if (callType.isInvalid()) return QualType_Invalid;
             if (callType.isVoid()) {
-                Expr* call_arg = call_args[call_arg_index];
                 ma.error(call_arg.getLoc(), "passing 'void' as variadic argument is invalid");
                 return QualType_Invalid;
             }
+            isCtv &= call_arg.isCtv();
+            isCtc &= call_arg.isCtc();
             call_arg_index++;
         }
     }
@@ -273,6 +303,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
 
     if (rewrite && !ma.check_only) ma.rewriteCall(e_ptr, fd, new_format_arg);
 
+    if (isCtv) e.setCtv();
+    if (isCtc) e.setCtc();
     return fd.getRType();
 }
 
@@ -682,58 +714,5 @@ fn FunctionDecl* Analyser.instantiateTemplateFunction(Analyser* ma, CallExpr* ca
     call.setTemplateIdx(instance.getTemplateInstanceIdx());
 
     return instance;
-}
-
-fn QualType Analyser.analysePureCallExpr(Analyser* ma, Expr* e) {
-    CallExpr* call = (CallExpr*)e;
-    Expr** func = call.getFunc2();
-    Expr* origFn = call.getFunc();  // store here to avoid the likely inserted FunctionPointerDecay cast
-    QualType qt = ma.analyseExpr(func, true, RHS);
-    if (qt.isInvalid()) return QualType_Invalid;
-
-    if (origFn.isNValue()) {
-        ma.errorRange(origFn.getLoc(), origFn.getRange(), "called object is not a function or function pointer");
-        return QualType_Invalid;
-    }
-
-    FunctionType* ft = qt.getFunctionTypeOrNil();
-    if (!ft) {
-        Expr* fn2 = call.getFunc();
-        ma.errorRange(fn2.getLoc(), fn2.getRange(), "called object type %s is not a function or function pointer", qt.diagName());
-
-        return QualType_Invalid;
-    }
-
-    FunctionDecl* fd = ft.getDecl();
-    if (fd != ma.curFunction) fd.asDecl().setUsed();
-
-    if (!fd.hasAttrPure()) {
-        ma.error(e.getLoc(), "only pure functions can be called in global initializers");
-        ma.note(fd.asDecl().getLoc(), NoteDeclaredHere, fd.asDecl().getFullName());
-        return QualType_Invalid;
-    }
-
-    // TODO: handle default and named arguments
-    u32 func_num_args = fd.getNumParams();
-    u32 call_num_args = call.getNumArgs();
-    //VarDecl** func_args = fd.getParams();
-    Expr** call_args = call.getArgs();
-
-    if (func_num_args != call_num_args) {
-        if (call_num_args > func_num_args) {
-            // error loc is the comma after last valid argument or closing parenthesis of no arguments
-            SrcLoc loc = func_num_args ? call_args[func_num_args - 1].getEndLoc() : call.getEndLoc() - 1;
-            ma.error(loc, DiagTooManyArgs, fd.getDiagKind(), func_num_args, call_num_args);
-            ma.note(fd.asDecl().getLoc(), NoteDeclaredHere, fd.asDecl().getFullName());
-        } else {
-            // error loc is closing parenthesis
-            ma.error(call.getEndLoc() - 1, DiagTooFewArgs, fd.getDiagKind(), func_num_args, call_num_args);
-            ma.note(fd.asDecl().getLoc(), NoteDeclaredHere, fd.asDecl().getFullName());
-        }
-        return QualType_Invalid;
-    }
-
-    // TODO
-    return QualType_Invalid;
 }
 

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -20,6 +20,17 @@ import ast_builder;
 import conversion_checker;
 import src_loc local;
 
+fn QualType Analyser.analyseConstExpr(Analyser* ma, Expr** e_ptr, bool need_rvalue) {
+    assert(e_ptr);
+    ma.need_const_expr++;
+    QualType result = ma.analyseExprInner(e_ptr, RHS);
+    ma.need_const_expr--;
+    if (result.isInvalid()) return result;
+    (*e_ptr).setType(result);
+    if (need_rvalue) return ma.convertRvalue(e_ptr, result);
+    return result;
+}
+
 fn QualType Analyser.analyseExpr(Analyser* ma, Expr** e_ptr, bool need_rvalue, u32 side) {
     assert(e_ptr);
     QualType result = ma.analyseExprInner(e_ptr, side);

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -218,6 +218,24 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
     }
 }
 
+// Analyse a function body using a new analyser/scope
+fn bool Analyser.analyseFunctionBody2(Analyser* ma, FunctionDecl* fd, Module* mod) {
+    Analyser* analyser = create(ma.diags, ma.context, ma.astPool, ma.builder, ma.allmodules, ma.warnings, false);
+    analyser.setMod(mod);
+    scope.Scope* tmpScope = scope.create(ma.allmodules,
+                                         ma.diags,
+                                         fd.asDecl().getAST().getImports(),
+                                         mod,
+                                         mod.getSymbols(),
+                                         !ma.warnings.no_unused_variable);
+    analyser.analyseFunctionBody(fd, tmpScope);
+    bool has_error = analyser.has_error;
+    tmpScope.free();
+    analyser.free();
+    ma.has_error |= has_error;
+    return !has_error;
+}
+
 fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope* s) {
     if (fd.isTemplate()) return;  // only analyse on instantiation
 
@@ -245,7 +263,12 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
     ma.has_error = false;
     ma.labels.reset();
 
+    u32 stack_base = ma.scope.getStackMax();
+
     FlowBits flow = ma.analyseCompoundStmt(body);
+
+    u32 num_locals = ma.scope.getStackMax() - stack_base;
+    fd.setNumLocals(num_locals);
 
     // check for return stmt if function returns a value
     QualType rtype = fd.getRType();

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -76,13 +76,6 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
         }
     }
 
-    if (e.isCall() && ma.globalScope()) {
-        //CallExpr* c = (CallExpr*)e);
-        QualType qt = ma.analysePureCallExpr(e);
-        // TODO check if compatible
-        return true;
-    }
-
     // special case for enum init without prefix (eg Color c = Green)
     if (ma.checkEnumArg(e_ptr, expectedType)) return true;
 
@@ -178,7 +171,7 @@ fn bool Analyser.analyseArrayDesignatedInit(Analyser* ma, Expr* e, QualType expe
     if (isEnumIndex && ma.checkEnumArg(ad.getDesignator2(), indexType)) {
         qt = indexType;
     } else {
-        qt = ma.analyseExpr(ad.getDesignator2(), false, RHS);
+        qt = ma.analyseConstExpr(ad.getDesignator2(), true);
     }
     if (qt.isInvalid()) return false;
 

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -399,7 +399,7 @@ fn QualType Analyser.analyseDecl(Analyser* ma, VarDecl* vd) {
     }
 
     d.setChecked();
-    ma.has_error = ma.has_error | ma.scope.add(d);
+    ma.has_error |= ma.scope.add(d, true);
     if (has_init_call) {
         ma.analyseExpr(initExpr, false, 0);
     }

--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -78,7 +78,7 @@ fn void Analyser.analyseStructMembers(Analyser* ma, StructTypeDecl* d) {
                     return;
                 }
 
-                QualType qt2 = ma.analyseExpr(&bitfield, false, RHS);
+                QualType qt2 = ma.analyseConstExpr(&bitfield, true);
                 if (qt2.isInvalid()) return;
 
                 if (!bitfield.isCtv()) {

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -299,8 +299,7 @@ fn bool Analyser.analyseCaseExpr(Analyser* ma,
         if (!ma.checkEnumConstantCase(id, checker, etd, loc, &index, name_idxp)) return false;
     } else {
         Expr* orig = cond;
-        QualType qt = ma.analyseExpr(&cond, true, RHS);
-
+        QualType qt = ma.analyseConstExpr(&cond, true);
         if (qt.isInvalid()) return false;
         cond.setType(qt);
 

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -73,7 +73,7 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
         Expr* initval = c.getInit();
         if (initval) {
             // NOTE: associated values are analysed in a separate phase
-            QualType res = ma.analyseExpr(c.getInit2(), true, RHS);
+            QualType res = ma.analyseConstExpr(c.getInit2(), true);
             if (res.isInvalid()) return;
             initval = c.getInit();  // re-read in case of ImplicitCast has been inserted
             if (!initval.isCtv()) {
@@ -250,7 +250,7 @@ fn QualType Analyser.analyseTypeRef(Analyser* ma, TypeRef* ref) {
         bool is_enum = false;
         QualType qt = QualType_Invalid;
         if (sizeExpr) {
-            qt = ma.analyseExpr(sizeExpr_p, false, RHS);
+            qt = ma.analyseConstExpr(sizeExpr_p, false);
             if (qt.isInvalid()) return qt;
             sizeExpr = *sizeExpr_p;
             if (sizeExpr.isNValue()) {

--- a/analyser/scope.c2
+++ b/analyser/scope.c2
@@ -50,6 +50,8 @@ public type Scope struct @(opaque) {
     bool warn_on_unused;
 
     // stack scope
+    u32 stack_base;
+    u32 stack_max;
     u32 stack_count;
     u32 stack_capacity;
     u32* stack_symbols;
@@ -100,7 +102,7 @@ public fn void Scope.free(Scope* s) {
 public fn void Scope.reset(Scope* s) {
     s.lvl = 0;
     u32 first_index = s.imports.size();
-    s.stack_count = first_index;
+    s.stack_max = s.stack_base = s.stack_count = first_index;
 }
 
 fn void Scope.addImports(Scope* s) {
@@ -155,7 +157,8 @@ public fn void Scope.exit(Scope* s, bool has_error) {
     assert(s.lvl != 0);
     s.lvl--;
     u32 first = s.levels[s.lvl].first_index;
-
+    if (s.stack_max < s.stack_count)
+        s.stack_max = s.stack_count;
     if (s.warn_on_unused && !has_error) {
         u32 last = s.stack_count;
         for (u32 i=first; i<last; i++) {
@@ -254,7 +257,7 @@ public fn bool Scope.inFunction(const Scope* s) {
 }
 
 // return true if already found
-public fn bool Scope.add(Scope* s, ast.Decl* d) {
+public fn bool Scope.add(Scope* s, ast.Decl* d, bool set_offset = false) {
     assert(s.lvl);
     const u32 name_idx = d.getNameIdx();
 
@@ -273,6 +276,7 @@ public fn bool Scope.add(Scope* s, ast.Decl* d) {
         return true;
     }
 
+    if (set_offset && d.isVarDecl()) d.setOffset(s.stack_count - s.stack_base);
     s.stack_add(name_idx, d);
     return false;
 }
@@ -515,3 +519,8 @@ public fn bool Scope.checkAccess(Scope* s, ast.Decl* d, SrcLoc loc) {
     }
     return true;
 }
+
+public fn u32 Scope.getStackMax(Scope* s) {
+    return s.stack_max;
+}
+

--- a/ast/ast_evaluator.c2
+++ b/ast/ast_evaluator.c2
@@ -1,4 +1,4 @@
-/* Copyright 2022-2026 Bas van den Berg
+/* Copyright 2022-2026 Bas van den Berg, Charlie Gordon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@ const u32 Max_depth = 100;
 const u32 Max_complexity = 1000000;
 
 type Evaluator struct {
+    Value result;
     Evaluator* prev;
     FunctionDecl* fd;
-    u32 depth;
+    u16 depth;
+    u16 num_args;
     u32 complexity;
-    u32 num_args;
-    Value result;
     // TODO: tail allocate if more than 16 arguments?
     Value[16] args;
 }
@@ -47,23 +47,23 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
         const CharLiteral* c = (CharLiteral*)e;
         return c.getValue();
     case StringLiteral:
-        assert(0);
-        break;
+        return Value.error("string literals not supported");
     case Nil:
-        break;
+        return Value.error("nil not supported");
     case Identifier:
         const IdentifierExpr* i = (IdentifierExpr*)e;
         return eval.get_decl_value(i.getDecl());
     case Type:
-        // should not happen
+        assert(0); // should not happen
         break;
     case Call:
         const CallExpr* c = (CallExpr*)e;
         return eval.eval_call(c);
     case InitList:
+        return Value.error("init lists not supported");
     case FieldDesignatedInit:
     case ArrayDesignatedInit:
-        // should not happen
+        assert(0);// should not happen
         break;
     case BinaryOperator:
         return eval.get_binaryop_value((BinaryOperator*)e);
@@ -86,7 +86,7 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
 
         Value result = eval.get_value(a.getBase());
         // Dont allow negative/float
-        assert(result.isDecimal() && !result.isNegative());
+        if (!result.isDecimal() || result.isNegative()) return Value.error("invalid bitoffset");
         BitOffsetExpr* bo = (BitOffsetExpr*)index;
         Value high = eval.get_value(bo.getLHS());
         Value low = eval.get_value(bo.getRHS());
@@ -103,7 +103,7 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
         const ParenExpr* p = (ParenExpr*)e;
         return eval.get_value(p.getInner());
     case BitOffset:
-        assert(0); // TODO
+        assert(0); // Handled in ArraySubscript
         break;
     case ExplicitCast:
         const ExplicitCastExpr* i = (ExplicitCastExpr*)e;
@@ -120,14 +120,15 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
         return eval.get_value(n.getInner());
     case Alternate:
         const AlternateExpr* n = (AlternateExpr*)e;
-        return eval.get_value(n.getOriginal());
+        return eval.get_value(n.getGenerated());
     }
     return Value.error("expression is not constant");
 }
 
 fn Value Evaluator.get_binaryop_value(Evaluator* eval, const BinaryOperator* e) {
     // TODO: Do not evaluate left for Assign
-    Value left = eval.get_value(e.getLHS());
+    Expr* lhs = e.getLHS();
+    Value left = eval.get_value(lhs);
     if (left.isError())
         return left;
 
@@ -183,20 +184,40 @@ fn Value Evaluator.get_binaryop_value(Evaluator* eval, const BinaryOperator* e) 
         right = eval.get_value(e.getRHS());
         return right.toBool();
     case Assign:
+        left = eval.get_value(e.getRHS());
+        break;
     case MulAssign:
+        left = left.multiply(&right);
+        break;
     case DivAssign:
+        left = left.divide(&right);
+        break;
     case RemAssign:
+        left = left.remainder(&right);
+        break;
     case AddAssign:
+        left = left.add(&right);
+        break;
     case SubAssign:
+        left = left.minus(&right);
+        break;
     case ShlAssign:
+        left = left.left_shift(&right);
+        break;
     case ShrAssign:
+        left = left.right_shift(&right);
+        break;
     case AndAssign:
+        left = left.and(&right);
+        break;
     case XorAssign:
+        left = left.xor(&right);
+        break;
     case OrAssign:
-        assert(0);
+        left = left.or(&right);
         break;
     }
-    return Value.error("unsupported operator");
+    return eval.store_value(lhs, left);
 }
 
 fn Value Evaluator.get_unaryop_value(Evaluator* eval, const UnaryOperator* e) {
@@ -205,11 +226,21 @@ fn Value Evaluator.get_unaryop_value(Evaluator* eval, const UnaryOperator* e) {
 
     switch (e.getOpcode()) {
     case PostInc:
+        res2.incr();
+        eval.store_value(inner, res2);
+        res2.decr();
+        return res2;
     case PostDec:
+        res2.decr();
+        eval.store_value(inner, res2);
+        res2.incr();
+        return res2;
     case PreInc:
+        res2.incr();
+        return eval.store_value(inner, res2);
     case PreDec:
-        // should not happen
-        break;
+        res2.decr();
+        return eval.store_value(inner, res2);
     case AddrOf:
     case Deref:
         // Allowed?
@@ -227,7 +258,7 @@ fn Value Evaluator.get_unaryop_value(Evaluator* eval, const UnaryOperator* e) {
 }
 
 fn Value Evaluator.get_decl_value(Evaluator* eval, const Decl* d) {
-    assert(d);
+    if (!d) goto fail;
     switch (d.getKind()) {
     case EnumConstant:
         const EnumConstantDecl* ecd = (EnumConstantDecl*)d;
@@ -235,16 +266,20 @@ fn Value Evaluator.get_decl_value(Evaluator* eval, const Decl* d) {
     case Variable:
         const VarDecl* vd = (VarDecl*)d;
         switch (vd.getKind()) {
-        case GlobalVar:
-        case LocalVar:
+        case GlobalVar: // accept global const variables
+            if (!vd.getType().isConst()) break;
+        eval_init:
             const Expr* initval = vd.getInit();
-            if (!initval)
-                break;
+            if (!initval) break;
             return eval.get_value(initval);
+        case LocalVar:  // accept const static local variables
+            if (vd.getType().isConst()) goto eval_init;
+            if (vd.hasLocalQualifier()) break;
+            fallthrough;
         case FunctionParam:
             u32 off = vd.getOffset();
-            assert(off < eval.num_args);
-            return eval.args[off];
+            if (off < elemsof(eval.args)) return eval.args[off];
+            break;
         case StructMember:
             break;
         }
@@ -253,19 +288,56 @@ fn Value Evaluator.get_decl_value(Evaluator* eval, const Decl* d) {
         assert(0);
         break;
     }
+fail:
     return Value.error("not a constant value");
 }
 
-type FunII fn i32 (i32 a);
-type FunDD fn i64 (f64 a);
+fn Decl* Evaluator.get_decl(Evaluator* eval, const Expr* e) {
+    switch (e.getKind()) {
+    case Identifier:
+        const IdentifierExpr* i = (IdentifierExpr*)e;
+        return i.getDecl();
+    case Member:
+        const MemberExpr* m = (MemberExpr*)e;
+        return m.getFullDecl();
+    default:
+        return nil;
+    }
+}
 
-type Fun union {
-    void* address;
-    FunII funII;
-    FunDD funDD;
+fn Value Evaluator.store_value(Evaluator* eval, const Expr* e, Value v) {
+    return eval.set_decl_value(eval.get_decl(e), v);
+}
+
+fn Value Evaluator.set_decl_value(Evaluator* eval, const Decl* d, Value v) {
+    if (!d) goto fail;
+    switch (d.getKind()) {
+    case Variable:
+        const VarDecl* vd = (VarDecl*)d;
+        switch (vd.getKind()) {
+        case GlobalVar:
+            break;
+        case LocalVar:
+            if (vd.hasLocalQualifier()) break;
+            fallthrough;
+        case FunctionParam:
+            u32 off = vd.getOffset();
+            if (off < elemsof(eval.args)) return eval.args[off] = v;
+            break;
+        case StructMember:
+            break;
+        }
+        break;
+    default:
+        break;
+    }
+fail:
+    return Value.error("unsupported assignment");
 }
 
 fn Value Evaluator.eval_call(Evaluator* caller, const CallExpr* c) {
+    // evaluate the function call as a value
+
     if (caller.depth > Max_depth) {
         return Value.error("recursion too deep");
     }
@@ -273,17 +345,14 @@ fn Value Evaluator.eval_call(Evaluator* caller, const CallExpr* c) {
         return Value.error("expression too complex");
     }
 
-    // evaluate the function call as a number
-    u32 num_args = c.getNumArgs();
-    // Should be Expr* const* args = c.getArgs();
-    Expr** args = ((CallExpr*)c).getArgs();
-
-    //Expr* func = c.getFunc();
     FunctionDecl* fd = expr2function(c.getFunc());
+    if (!fd) return Value.error("function expressions no supported");
+
     // Note: numParams will be the same as num_args because pure functions are not vararg
+    u32 num_args = c.getNumArgs();
 
     // Create a new stack frame and link it to the caller's
-    // TODO: handle Stack frames as separate allocated objects
+    // TODO: handle Stack frames as separate allocated objects or fragments of a stack area
     Evaluator eval;
 
     if (num_args > elemsof(eval.args)) {
@@ -291,15 +360,13 @@ fn Value Evaluator.eval_call(Evaluator* caller, const CallExpr* c) {
     }
     eval.prev = caller;
     eval.fd = fd;
-    eval.num_args = num_args;
+    eval.num_args = (u16)num_args;
     eval.depth = caller.depth + 1;
     eval.complexity = caller.complexity + 1;
 
-    //VarDecl** params = fd.getParams();
-
     for (u32 i = 0; i < num_args; i++) {
         // TODO: pass actual parameter type
-        Value v = caller.get_value(args[i]);
+        Value v = caller.get_value(c.getArg(i));
         if (v.isError())
             return v;
         eval.args[i] = v;
@@ -323,46 +390,53 @@ fn Value Evaluator.eval_call(Evaluator* caller, const CallExpr* c) {
         case Error:
             return eval.result;
         }
-    } else {
-        // Support external functions such as ctype.isalpha, math.sin...
-        // cache symbol address using dlsym(RTLD_DEFAULT, fd.getCName())
-        // dispatch function call depending on function prototype
-        Fun fun = { .address = fd.getAddress() }
-        if (!fun.address) {
-            const char* cname = fd.getCName();
-            if (!cname) return Value.error("no function name");
-            fun.address = dlsym(RTLD_DEFAULT, cname);
-            if (fun.address) {
-                //fprintf(stderr, "address of %s is %p\n", cname, fun.address);
-                fd.setAddress(fun.address);
-            } else {
-                return Value.error("function not found");
-            }
-        }
-        if (fun.address) {
-            VarDecl** params = fd.getParams();
-            if (num_args == 1) {
-                Decl* d = (Decl*)params[0];
-                QualType qt1 = d.getType();
-                QualType rt = fd.getRType();
-                qt1 = qt1.getCanonicalType();
-                rt = rt.getCanonicalType();
-                if (rt.isInteger() && qt1.isInteger()) {
-                    //fprintf(stderr, "calling funII at %p\n", cname, fun.address);
-                    return Value.createSigned(fun.funII(eval.args[0].as_i32()));
-                }
-                if (rt.isFloat() && qt1.isFloat()) {
-                    //fprintf(stderr, "calling funDD at %p\n", cname, fun.address);
-                    return Value.createFloat(fun.funDD(eval.args[0].toFloat()));
-                }
-                fprintf(stderr, "function prototype not supported: %s\n", fd.getCName());
-                qt1.dump_full();
-                rt.dump_full();
-                return Value.error("function prototype not supported");
-            }
-        }
+        return Value.error("pure function evaluation error");
     }
-    return Value.error("pure function evaluation error");
+    // Support external functions such as ctype.isalpha, math.sin...
+    // cache symbol address using dlsym(RTLD_DEFAULT, fd.getCName())
+    // dispatch function call depending on function signature
+    FunctionDispatcher fun = { .address = fd.getAddress() }
+    if (!fun.address) {
+        const char* cname = fd.getCName();
+        if (!cname) return Value.error("no function name");
+        fun.address = dlsym(RTLD_DEFAULT, cname);
+        if (!fun.address) {
+            return Value.error("function not found");
+        }
+        FunctionSignature signature = fd.computeSignature();
+        //fprintf(stderr, "address of %s is %p, signature is %x\n", cname, fun.address, signature);
+        fd.setAddress(fun.address, signature);
+    }
+    Value* args = eval.args;
+    switch (fd.getSignature()) {
+    case FunII:
+        return Value.createSigned(fun.funII(args[0].as_i32()));
+    case FunIF:
+        return Value.createSigned(fun.funIF(args[0].toFloat32()));
+    case FunID:
+        return Value.createSigned(fun.funID(args[0].toFloat()));
+    case FunLL:
+        return Value.createSigned(fun.funLL(args[0].as_i64()));
+    case FunLF:
+        return Value.createSigned(fun.funLF(args[0].toFloat32()));
+    case FunLD:
+        return Value.createSigned(fun.funLD(args[0].toFloat()));
+    case FunFF:
+        return Value.createFloat(fun.funFF(args[0].toFloat32()));
+    case FunDD:
+        return Value.createFloat(fun.funDD(args[0].toFloat()));
+    case FunFFF:
+        return Value.createFloat(fun.funFFF(args[0].toFloat32(), args[1].toFloat32()));
+    case FunDDD:
+        return Value.createFloat(fun.funDDD(args[0].toFloat(), args[1].toFloat()));
+    case FunFFFF:
+        return Value.createFloat(fun.funFFFF(args[0].toFloat32(), args[1].toFloat32(), args[2].toFloat32()));
+    case FunDDDD:
+        return Value.createFloat(fun.funDDDD(args[0].toFloat(), args[1].toFloat(), args[2].toFloat()));
+    default:
+        fprintf(stderr, "unsupported function prototype: %s\n", fd.getCName());
+        return Value.error("unsupported function prototype");
+    }
 }
 
 fn FunctionDecl* expr2function(Expr* e) {
@@ -377,10 +451,8 @@ fn FunctionDecl* expr2function(Expr* e) {
         ImplicitCastExpr* ic = (ImplicitCastExpr*)e;
         return expr2function(ic.getInner());
     default:
-        assert(0);
-        break;
+        return nil;
     }
-    return nil;
 }
 
 public fn Value evalExpr(const Expr* e) {
@@ -449,20 +521,8 @@ fn Cont Expr.eval(Expr* e, Evaluator* sf) {
 }
 
 fn Cont IfStmt.eval(IfStmt* s, Evaluator* sf) {
-    Stmt* cond = s.getCond();
-    Expr* e = nil;
-    if (cond.isExpr()) {
-        e = (Expr*)cond;
-    } else
-    if (cond.isDecl()) {
-        e = ((DeclStmt*)cond).getDecl(0).getInit();
-        // TODO initialisation must assign value
-    }
-    if (!e)
-        return Abort;
-    sf.result = sf.get_value(e);
-    if (sf.result.isError())
-        return Error;
+    Cont cont = s.getCond().eval(sf);
+    if (cont != Normal) return cont;
     if (!sf.result.isZero()) {
         return s.getThen().eval(sf);
     } else {
@@ -474,23 +534,11 @@ fn Cont IfStmt.eval(IfStmt* s, Evaluator* sf) {
 
 fn Cont WhileStmt.eval(WhileStmt* s, Evaluator* sf) {
     for (;;) {
-        Stmt* cond = s.getCond();
-        Expr* e = nil;
-        if (cond.isExpr()) {
-            e = (Expr*)cond;
-        } else
-        if (cond.isDecl()) {
-            e = ((DeclStmt*)cond).getDecl(0).getInit();
-            // TODO initialisation must assign value
-        }
-        if (!e)
-            return Abort;
-        sf.result = sf.get_value(e);
-        if (sf.result.isError())
-            return Error;
+        Cont cont = s.getCond().eval(sf);
+        if (cont != Normal) return cont;
         if (sf.result.isZero())
             return Normal;
-        Cont cont = s.getBody().eval(sf);
+        cont = s.getBody().eval(sf);
         switch (cont) {
         case Normal:
         case Continue:
@@ -546,9 +594,55 @@ fn Cont ForStmt.eval(ForStmt* s, Evaluator* sf) {
     }
 }
 
+fn bool SwitchCase.match(SwitchCase* c, Evaluator* sf, Value* v) {
+    if (c.isDefault()) return true;
+    u32 num_conds = c.getNumConds();
+    for (u32 i = 0; i < num_conds; i++) {
+        Expr* e = c.getCond(i);
+        if (e.isRange()) {
+            RangeExpr* r = (RangeExpr*)e;
+            Value lo = sf.get_value(r.getLHS());
+            Value hi = sf.get_value(r.getRHS());
+            if (v.is_greater_equal(&lo) && v.is_less_equal(&hi)) return true;
+        } else {
+            Value val = sf.get_value(e);
+            if (v.is_equal(&val)) return true;
+        }
+    }
+    return false;
+}
+
 fn Cont SwitchStmt.eval(SwitchStmt* s, Evaluator* sf) {
-    // TODO support numerical switch statements
-    return sf.error("switch not supported");
+    if (s.isString()) return sf.error("string switch not supported");
+    Cont cont = s.getCond().eval(sf);
+    if (cont != Normal) return cont;
+    u32 num_cases = s.getNumCases();
+    SwitchCase** cases = s.getCases();
+    bool has_match = false;
+    for (u32 i = 0; i < num_cases; i++) {
+        SwitchCase* c = cases[i];
+        if (has_match || (has_match = c.match(sf, &sf.result))) {
+            u32 count = c.getNumStmts();
+            if (!count) continue;  // empty case has implicit fallthrough
+            Stmt** stmts = c.getStmts();
+            for (u32 j = 0; j < count; j++) {
+                cont = stmts[j].eval(sf);
+                switch (cont) {
+                case Normal:
+                    break;
+                case Break:
+                    return Normal;
+                case Continue:
+                case Return:
+                case Goto:
+                case Abort:
+                case Error:
+                    return cont;
+                }
+            }
+        }
+    }
+    return Normal;
 }
 
 fn Cont BreakStmt.eval(BreakStmt* s, Evaluator* sf) { return Break; }
@@ -577,7 +671,14 @@ fn Cont CompoundStmt.eval(CompoundStmt* body, Evaluator* sf) {
 }
 
 fn Cont DeclStmt.eval(DeclStmt* s, Evaluator* sf) {
-    return sf.error("declarations not supported");
+    for (u32 i = 0; i < s.getDeclCount(); i++) {
+        VarDecl* vd = s.getDecl(i);
+        sf.result = Value.createSigned(0);
+        if (vd.hasInit())
+            sf.result = sf.get_value(vd.getInit());
+        sf.set_decl_value(vd.asDecl(), sf.result);
+    }
+    return Normal;
 }
 
 fn Cont AsmStmt.eval(AsmStmt* s, Evaluator* sf) {

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -168,6 +168,10 @@ public fn Expr** CallExpr.getArgs(CallExpr* e) {
     return e.args;
 }
 
+fn Expr* CallExpr.getArg(const CallExpr* e, u32 i) {
+    return e.args[i];
+}
+
 fn void CallExpr.printLiteral(const CallExpr* e, string_buffer.Buf* out) {
     e.func.printLiteral(out);
     out.lparen();

--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -224,6 +224,10 @@ public fn AST* Decl.getAST(const Decl* d) { return idx2ast(d.ast_idx); }
 
 fn u32 Decl.getASTIdx(const Decl* d) { return d.ast_idx; }
 
+fn u32 Decl.getOffset(const Decl* d) @(unused) { return d.offset; }
+
+public fn void Decl.setOffset(Decl* d, u32 offset) { d.offset = (u16)offset; }
+
 public fn Module* Decl.getModule(const Decl* d) {
     const AST* a = d.getAST();
     if (!a) return nil;

--- a/ast/expr.c2
+++ b/ast/expr.c2
@@ -489,7 +489,7 @@ public fn SrcLoc Expr.getStartLoc(const Expr* e) {
     return e.base.loc;
 }
 
-public fn SrcLoc Expr.getEndLoc(const Expr* e) {
+fn SrcLoc Expr.getEndLoc(const Expr* e) {
     switch (e.getKind()) {
     case IntegerLiteral:
         return ((IntegerLiteral*)e).getEndLoc();

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -60,11 +60,12 @@ type FunctionDeclBits struct {
     u32 has_return : 1;     // if it returns something, set during analysis
     DefKind def_kind : 3;
     u32 has_body : 1;    // if function is defined in C2
+    FunctionSignature signature : 4;
 }
 
 type FunctionDeclFlags struct {
     u16 instance_ast_idx : 16;  // template function instances only
-    u32 num_auto_args : 4;
+    u32 num_auto_args : 3;      // TODO: 2 should suffice
     u32 attr_unused_params : 1;
     u32 attr_noreturn : 1;
     u32 attr_inline : 1;
@@ -242,14 +243,19 @@ public fn CompoundStmt* FunctionDecl.getBody(const FunctionDecl* d) {
     return nil;
 }
 
-fn void FunctionDecl.setAddress(FunctionDecl* d, void* address) {
+fn void FunctionDecl.setAddress(FunctionDecl* d, void* address, FunctionSignature signature) {
     d.base.functionDeclBits.has_body = 0;
+    d.base.functionDeclBits.signature = signature;
     d.address = address;
 }
 
-fn CompoundStmt* FunctionDecl.getAddress(const FunctionDecl* d) {
+fn void* FunctionDecl.getAddress(const FunctionDecl* d) {
     if (d.base.functionDeclBits.has_body) return nil;
     return d.address;
+}
+
+fn FunctionSignature FunctionDecl.getSignature(const FunctionDecl* d) {
+    return d.base.functionDeclBits.signature;
 }
 
 public fn bool FunctionDecl.isInline(const FunctionDecl* d) {
@@ -395,12 +401,20 @@ public fn VarDecl** FunctionDecl.getParams(const FunctionDecl* d) {
     return d.rtype.getPointerAfter();
 }
 
+public fn u32 FunctionDecl.getNumLocals(FunctionDecl* d) @(unused) {
+    return d.num_locals;
+}
+
+public fn void FunctionDecl.setNumLocals(FunctionDecl* d, u32 num_locals) {
+    d.num_locals = (u8)num_locals;
+}
+
 public fn u32 FunctionDecl.getNumAutoArgs(const FunctionDecl* d) {
     return d.flags.num_auto_args;
 }
 
 public fn void FunctionDecl.setNumAutoArgs(FunctionDecl* d, u32 num) {
-    assert(num < 16);
+    assert(num < 8);
     d.flags.num_auto_args = num;
 }
 

--- a/ast/function_signature.c2
+++ b/ast/function_signature.c2
@@ -1,0 +1,100 @@
+/* Copyright 2022-2026 Bas van den Berg, Charlie Gordon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+type FunII fn i32 (i32 a);
+type FunIF fn i32 (f32 a);
+type FunID fn i32 (f64 a);
+type FunLL fn i64 (i64 a);
+type FunLF fn i64 (f32 a);
+type FunLD fn i64 (f64 a);
+type FunFF fn f32 (f32 a);
+type FunDD fn f64 (f64 a);
+type FunFFF fn f32 (f32 a, f32 b);
+type FunDDD fn f64 (f64 a, f64 b);
+type FunFFFF fn f32 (f32 a, f32 b, f32 c);
+type FunDDDD fn f64 (f64 a, f64 b, f64 c);
+
+type FunctionDispatcher union @(unused) {
+    void* address;
+    FunII funII;
+    FunIF funIF;
+    FunID funID;
+    FunLL funLL;
+    FunLF funLF;
+    FunLD funLD;
+    FunFF funFF;
+    FunDD funDD;
+    FunFFF funFFF;
+    FunDDD funDDD;
+    FunFFFF funFFFF;
+    FunDDDD funDDDD;
+}
+
+type FunctionSignature enum u8 {
+    None,
+    Other,
+    FunII,
+    FunIF,
+    FunID,
+    FunLL,
+    FunLF,
+    FunLD,
+    FunFF,
+    FunDD,
+    FunFFF,
+    FunDDD,
+    FunFFFF,
+    FunDDDD,
+}
+
+fn FunctionSignature FunctionDecl.computeSignature(FunctionDecl* fd) {
+    u32 sig = 0;
+    VarDecl** params = fd.getParams();
+    QualType qt = fd.getRType();
+    u32 num_params = fd.getNumParams();
+    u32 i = 0;
+    for (;;) {
+        qt = qt.getCanonicalType();
+        if (!qt.isBuiltin()) return Other;
+        switch (qt.getBuiltinKind()) {
+        case Int32:   sig |= 1; break;
+        case Int64:   sig |= 2; break;
+        case Float32: sig |= 3; break;
+        case Float64: sig |= 4; break;
+        default: return Other;
+        }
+        if (i == num_params) break;
+        qt = ((Decl*)params[i++]).getType();
+        sig <<= 4;
+    }
+    switch (sig) {
+    case 0x11: return FunII;
+    case 0x13: return FunIF;
+    case 0x14: return FunID;
+    case 0x22: return FunLL;
+    case 0x23: return FunLF;
+    case 0x24: return FunLD;
+    case 0x33: return FunFF;
+    case 0x44: return FunDD;
+    case 0x333: return FunFFF;
+    case 0x444: return FunDDD;
+    case 0x3333: return FunFFFF;
+    case 0x4444: return FunDDDD;
+    default: return Other;
+    }
+}
+

--- a/ast/value.c2
+++ b/ast/value.c2
@@ -139,6 +139,16 @@ fn f64 Value.toFloat(const Value* v) {
     }
 }
 
+fn f32 Value.toFloat32(const Value* v) {
+    if (v.kind == Integer) {
+        // TODO: warn about loss of precision
+        f32 f = (f32)v.uvalue;
+        return (v.negative) ? -f : f;
+    } else {
+        return (f32)v.fvalue;
+    }
+}
+
 public fn u8 Value.as_u8(const Value* v) {
     assert (v.kind == Integer);
     u64 res = v.uvalue;
@@ -160,6 +170,15 @@ public fn i32 Value.as_i32(const Value* v) @(unused) {
         if (v.negative) res = ~res + 1;
     }
     return (i32)res;
+}
+
+public fn i64 Value.as_i64(const Value* v) @(unused) {
+    u64 res = 0;
+    if (v.kind == Integer) {
+        res = v.uvalue;
+        if (v.negative) res = ~res + 1;
+    }
+    return (i64)res;
 }
 
 public fn u32 Value.as_u32(const Value* v) {
@@ -862,7 +881,7 @@ public fn char *ftoa(char *dest, usize size, f64 d) {
 
 public fn const char* Value.str(const Value* v) {
     // TODO: not thread safe
-    local char[4][64] text;
+    local char[4][32] text;
     local u8 index = 0;
     char* out = text[index];
     u32 out_size = elemsof(text[0]);
@@ -872,13 +891,12 @@ public fn const char* Value.str(const Value* v) {
     case Integer:
         *out = '-';
         stdio.snprintf(out + v.negative, out_size - 1, "%d", v.uvalue);
-        break;
+        return out;
     case Float:
-        ftoa(out, 64, v.fvalue);
-        break;
-    default:
-        return "<<invalid>>";
+        return ftoa(out, out_size, v.fvalue);
+    case Error:
+        return v.error_msg;
     }
-    return out;
+    return "<<invalid>>";
 }
 

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -187,6 +187,10 @@ public fn Decl* VarDecl.asDecl(VarDecl* d) {
     return &d.base;
 }
 
+fn QualType VarDecl.getType(const VarDecl* d) {
+    return d.base.qt;
+}
+
 fn u32 VarDecl.getOffset(const VarDecl* d) {
     return d.base.offset;
 }

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -52,6 +52,7 @@ type Options struct {
     bool no_plugins;
     bool use_ir_backend;
     bool trace_calls;
+    bool use_math_library;
     const char* build_file;
     const char* other_dir;
     const char* output_name;
@@ -181,6 +182,7 @@ const char[] Usage_help =
     "  -h                print this help\n"
     "  -i                use IR backend\n"
     "  -I                use IR backend and print generated IR\n"
+    "  -lm               link the math module\n"
     "  -m                print modules\n"
     "  -o [file]         force the output name for a single target\n"
     "  -r                print reports\n"
@@ -322,7 +324,17 @@ fn void parse_arguments(ArgumentParser *ap, compiler.Options* comp_opts, Options
             if (arg[1] == '-') {
                 parse_long_opt(ap, arg, comp_opts, opts);
             } else {
-                if (strlen(arg) != 2) ap.unknownOption(arg);
+                if (strlen(arg) != 2) {
+                    switch (arg + 1) {
+                    case "help":
+                        ap.showHelp();
+                        exit(EXIT_SUCCESS);
+                    case "lm":
+                        opts.use_math_library = true;
+                        continue;
+                    }
+                    ap.unknownOption(arg);
+                }
                 switch (arg[1]) {
                 case '0':    // 'hidden' feature, print AST early after parsing, then quit
                     comp_opts.print_ast_early = true;
@@ -477,6 +489,8 @@ fn void Context.handle_args(Context* c, i32 argc, char** argv) {
         if (c.opts.use_ir_backend) backend = IR;
         build_target.Target* t = c.recipe.addTarget(target_idx, 0, Executable);
         t.setBackEnd(backend);
+        if (c.opts.use_math_library)
+            t.addLib(c.auxPool.addStr("math", true), DynamicLibrary);
 
         for (u32 i = 0; i < c.opts.files.length(); i++)
             t.addFile(c.opts.files.get_idx(i), 0);

--- a/libs/libc/stdlib.c2i
+++ b/libs/libc/stdlib.c2i
@@ -120,8 +120,8 @@ type StdlibCompareFn fn i32(const void*, const void*) @(cname="__compar_fn_t");
 void* bsearch(const void* __key, const void* __base, size_t __nmemb, size_t __size, StdlibCompareFn __compar);
 void qsort(void* __base, size_t __nmemb, size_t __size, StdlibCompareFn __compar);
 
-int abs(int __x);
-long labs(long __x);
+int abs(int __x) @(pure);
+long labs(long __x) @(pure);
 Div_t div(int __numer, int __denom);
 Ldiv_t ldiv(long __numer, long __denom);
 

--- a/libs/math/math.c2i
+++ b/libs/math/math.c2i
@@ -32,279 +32,279 @@ const int FP_SUBNORMAL  = 5;
 union FP32_ { f32 f; u32 u; }
 union FP64_ { f64 d; u64 u; }
 
-int fpclassifyf(float) @(cname="__fpclassifyf");
-int isfinitef(float) @(cname="__isfinitef");
-int isinff(float) @(cname="__isinff");
-int isnanf(float x) { return x != x; }
-int isnormalf(float) @(cname="__isnormalf");
+int fpclassifyf(float) @(pure, cname="__fpclassifyf");
+int isfinitef(float) @(pure, cname="__isfinitef");
+int isinff(float) @(pure, cname="__isinff");
+int isnanf(float x) @(pure) { return x != x; }
+int isnormalf(float) @(pure, cname="__isnormalf");
 int signbitf(float f) { FP32_ u; u.f = f; return (u.u >> 31) & 1; }
 
-int isnan(double x) { return x != x; }
+int isnan(double x) @(pure) { return x != x; }
 int signbit(double d) { FP64_ u; u.d = d; return (u.u >> 63) & 1; }
 #if SYSTEM_LINUX || SYSTEM_OPENBSD
-int fpclassify(double) @(cname="__fpclassify");
+int fpclassify(double) @(pure, cname="__fpclassify");
 #else
-int fpclassify(double) @(cname="__fpclassifyd");
+int fpclassify(double) @(pure, cname="__fpclassifyd");
 #endif
 #if SYSTEM_LINUX || SYSTEM_OPENBSD || SYSTEM_FREEBSD
-int isfinite(double) @(cname="__isfinite");
-int isinf(double) @(cname="__isinf");
-int isnormal(double) @(cname="__isnormal");
+int isfinite(double) @(pure, cname="__isfinite");
+int isinf(double) @(pure, cname="__isinf");
+int isnormal(double) @(pure, cname="__isnormal");
 #else
-int isfinite(double) @(cname="__isfinited");
-int isinf(double) @(cname="__isinfd");
-int isnormal(double) @(cname="__isnormald");
+int isfinite(double) @(pure, cname="__isfinited");
+int isinf(double) @(pure, cname="__isinfd");
+int isnormal(double) @(pure, cname="__isnormald");
 #endif
-//int fpclassifyl(long double);
-//int isfinitel(long double);
-//int isinfl(long double);
-//int isnanl(long double);
-//int isnormall(long double);
-//int signbitl(long double);
+//int fpclassifyl(long double) @(pure);
+//int isfinitel(long double) @(pure);
+//int isinfl(long double) @(pure);
+//int isnanl(long double) @(pure);
+//int isnormall(long double) @(pure);
+//int signbitl(long double) @(pure);
 
 #if 0
 //TODO: use type functions
-//fn bool f32.isnan(f32 x) { return x != x; }
-//fn bool f64.isnan(f64 x) { return x != x; }
+//fn bool f32.isnan(f32 x) @(pure) { return x != x; }
+//fn bool f64.isnan(f64 x) @(pure) { return x != x; }
 //fn bool f32.signbit(f32 f) { FP32 u; u.f = f; return (u.u >> 31) & 1; }
 //fn bool f64.signbit(f64 d) { FP64 u; u.d = d; return (u.u >> 63) & 1; }
-int float.fpclassify(float) @(cname="__fpclassifyf");
-int double.fpclassify(double) @(cname="__fpclassifyd");
-int float.isnormal(float) @(cname="__isnormalf");
-int double.isnormal(double) @(cname="__isnormald");
-int float.isfinite(float) @(cname="__isfinitef");
-int double.isfinite(double) @(cname="__isfinited");
-int float.isinf(float) @(cname="__isinff");
-int double.isinf(double) @(cname="__isinfd");
+int float.fpclassify(float) @(pure, cname="__fpclassifyf");
+int double.fpclassify(double) @(pure, cname="__fpclassifyd");
+int float.isnormal(float) @(pure, cname="__isnormalf");
+int double.isnormal(double) @(pure, cname="__isnormald");
+int float.isfinite(float) @(pure, cname="__isfinitef");
+int double.isfinite(double) @(pure, cname="__isfinited");
+int float.isinf(float) @(pure, cname="__isinff");
+int double.isinf(double) @(pure, cname="__isinfd");
 #endif
 
-float acosf(float);
-double acos(double);
-//long double acosl(long double);
+float acosf(float) @(pure);
+double acos(double) @(pure);
+//long double acosl(long double) @(pure);
 
-float asinf(float);
-double asin(double);
-//long double asinl(long double);
+float asinf(float) @(pure);
+double asin(double) @(pure);
+//long double asinl(long double) @(pure);
 
-float atanf(float);
-double atan(double);
-//long double atanl(long double);
+float atanf(float) @(pure);
+double atan(double) @(pure);
+//long double atanl(long double) @(pure);
 
-float atan2f(float, float);
-double atan2(double, double);
-//long double atan2l(long double, long double);
+float atan2f(float, float) @(pure);
+double atan2(double, double) @(pure);
+//long double atan2l(long double, long double) @(pure);
 
-float cosf(float);
-double cos(double);
-//long double cosl(long double);
+float cosf(float) @(pure);
+double cos(double) @(pure);
+//long double cosl(long double) @(pure);
 
-float sinf(float);
-double sin(double);
-//long double sinl(long double);
+float sinf(float) @(pure);
+double sin(double) @(pure);
+//long double sinl(long double) @(pure);
 
-float tanf(float);
-double tan(double);
-//long double tanl(long double);
+float tanf(float) @(pure);
+double tan(double) @(pure);
+//long double tanl(long double) @(pure);
 
-float acoshf(float);
-double acosh(double);
-//long double acoshl(long double);
+float acoshf(float) @(pure);
+double acosh(double) @(pure);
+//long double acoshl(long double) @(pure);
 
-float asinhf(float);
-double asinh(double);
-//long double asinhl(long double);
+float asinhf(float) @(pure);
+double asinh(double) @(pure);
+//long double asinhl(long double) @(pure);
 
-float atanhf(float);
-double atanh(double);
-//long double atanhl(long double);
+float atanhf(float) @(pure);
+double atanh(double) @(pure);
+//long double atanhl(long double) @(pure);
 
-float coshf(float);
-double cosh(double);
-//long double coshl(long double);
+float coshf(float) @(pure);
+double cosh(double) @(pure);
+//long double coshl(long double) @(pure);
 
-float sinhf(float);
-double sinh(double);
-//long double sinhl(long double);
+float sinhf(float) @(pure);
+double sinh(double) @(pure);
+//long double sinhl(long double) @(pure);
 
-float tanhf(float);
-double tanh(double);
-//long double tanhl(long double);
+float tanhf(float) @(pure);
+double tanh(double) @(pure);
+//long double tanhl(long double) @(pure);
 
-float expf(float);
-double exp(double);
-//long double expl(long double);
+float expf(float) @(pure);
+double exp(double) @(pure);
+//long double expl(long double) @(pure);
 
-float exp2f(float);
-double exp2(double);
-//long double exp2l(long double);
+float exp2f(float) @(pure);
+double exp2(double) @(pure);
+//long double exp2l(long double) @(pure);
 
-float expm1f(float);
-double expm1(double);
-//long double expm1l(long double);
+float expm1f(float) @(pure);
+double expm1(double) @(pure);
+//long double expm1l(long double) @(pure);
 
-float logf(float);
-double log(double);
-//long double logl(long double);
+float logf(float) @(pure);
+double log(double) @(pure);
+//long double logl(long double) @(pure);
 
-float log10f(float);
-double log10(double);
-//long double log10l(long double);
+float log10f(float) @(pure);
+double log10(double) @(pure);
+//long double log10l(long double) @(pure);
 
-float log2f(float);
-double log2(double);
-//long double log2l(long double);
+float log2f(float) @(pure);
+double log2(double) @(pure);
+//long double log2l(long double) @(pure);
 
-float log1pf(float);
-double log1p(double);
-//long double log1pl(long double);
+float log1pf(float) @(pure);
+double log1p(double) @(pure);
+//long double log1pl(long double) @(pure);
 
-float logbf(float);
-double logb(double);
-//long double logbl(long double);
+float logbf(float) @(pure);
+double logb(double) @(pure);
+//long double logbl(long double) @(pure);
 
-float modff(float, float *);
-double modf(double, double *);
-//long double modfl(long double, long double *);
+float modff(float, float *) @(pure);
+double modf(double, double *) @(pure);
+//long double modfl(long double, long double *) @(pure);
 
-float ldexpf(float, int);
-double ldexp(double, int);
-//long double ldexpl(long double, int);
+float ldexpf(float, int) @(pure);
+double ldexp(double, int) @(pure);
+//long double ldexpl(long double, int) @(pure);
 
-float frexpf(float, int *);
-double frexp(double, int *);
-//long double frexpl(long double, int *);
+float frexpf(float, int *) @(pure);
+double frexp(double, int *) @(pure);
+//long double frexpl(long double, int *) @(pure);
 
-int ilogbf(float);
-int ilogb(double);
-//int ilogbl(long double);
+int ilogbf(float) @(pure);
+int ilogb(double) @(pure);
+//int ilogbl(long double) @(pure);
 
-float scalbnf(float, int);
-double scalbn(double, int);
-//long double scalbnl(long double, int);
+float scalbnf(float, int) @(pure);
+double scalbn(double, int) @(pure);
+//long double scalbnl(long double, int) @(pure);
 
-float scalblnf(float, long int);
-double scalbln(double, long int);
-//long double scalblnl(long double, long int);
+float scalblnf(float, long int) @(pure);
+double scalbln(double, long int) @(pure);
+//long double scalblnl(long double, long int) @(pure);
 
-float fabsf(float);
-double fabs(double);
-//long double fabsl(long double);
+float fabsf(float) @(pure);
+double fabs(double) @(pure);
+//long double fabsl(long double) @(pure);
 
-float cbrtf(float);
-double cbrt(double);
-//long double cbrtl(long double);
+float cbrtf(float) @(pure);
+double cbrt(double) @(pure);
+//long double cbrtl(long double) @(pure);
 
-float hypotf(float, float);
-double hypot(double, double);
-//long double hypotl(long double, long double);
+float hypotf(float, float) @(pure);
+double hypot(double, double) @(pure);
+//long double hypotl(long double, long double) @(pure);
 
-float powf(float, float);
-double pow(double, double);
-//long double powl(long double, long double);
+float powf(float, float) @(pure);
+double pow(double, double) @(pure);
+//long double powl(long double, long double) @(pure);
 
-float sqrtf(float);
-double sqrt(double);
-//long double sqrtl(long double);
+float sqrtf(float) @(pure);
+double sqrt(double) @(pure);
+//long double sqrtl(long double) @(pure);
 
-float erff(float);
-double erf(double);
-//long double erfl(long double);
+float erff(float) @(pure);
+double erf(double) @(pure);
+//long double erfl(long double) @(pure);
 
-float erfcf(float);
-double erfc(double);
-//long double erfcl(long double);
+float erfcf(float) @(pure);
+double erfc(double) @(pure);
+//long double erfcl(long double) @(pure);
 
-float lgammaf(float);
-double lgamma(double);
-//long double lgammal(long double);
+float lgammaf(float) @(pure);
+double lgamma(double) @(pure);
+//long double lgammal(long double) @(pure);
 
-float tgammaf(float);
-double tgamma(double);
-//long double tgammal(long double);
+float tgammaf(float) @(pure);
+double tgamma(double) @(pure);
+//long double tgammal(long double) @(pure);
 
-float ceilf(float);
-double ceil(double);
-//long double ceill(long double);
+float ceilf(float) @(pure);
+double ceil(double) @(pure);
+//long double ceill(long double) @(pure);
 
-float floorf(float);
-double floor(double);
-//long double floorl(long double);
+float floorf(float) @(pure);
+double floor(double) @(pure);
+//long double floorl(long double) @(pure);
 
-float nearbyintf(float);
-double nearbyint(double);
-//long double nearbyintl(long double);
+float nearbyintf(float) @(pure);
+double nearbyint(double) @(pure);
+//long double nearbyintl(long double) @(pure);
 
-float rintf(float);
-double rint(double);
-//long double rintl(long double);
+float rintf(float) @(pure);
+double rint(double) @(pure);
+//long double rintl(long double) @(pure);
 
-long int lrintf(float);
-long int lrint(double);
-//long int lrintl(long double);
+long int lrintf(float) @(pure);
+long int lrint(double) @(pure);
+//long int lrintl(long double) @(pure);
 
-float roundf(float);
-double round(double);
-//long double roundl(long double);
+float roundf(float) @(pure);
+double round(double) @(pure);
+//long double roundl(long double) @(pure);
 
-long int lroundf(float);
-long int lround(double);
-//long int lroundl(long double);
+long int lroundf(float) @(pure);
+long int lround(double) @(pure);
+//long int lroundl(long double) @(pure);
 
-long long int llrintf(float);
-long long int llrint(double);
-//long long int llrintl(long double);
+long long int llrintf(float) @(pure);
+long long int llrint(double) @(pure);
+//long long int llrintl(long double) @(pure);
 
-long long int llroundf(float);
-long long int llround(double);
-//long long int llroundl(long double);
+long long int llroundf(float) @(pure);
+long long int llround(double) @(pure);
+//long long int llroundl(long double) @(pure);
 
-float truncf(float);
-double trunc(double);
-//long double truncl(long double);
+float truncf(float) @(pure);
+double trunc(double) @(pure);
+//long double truncl(long double) @(pure);
 
-float fmodf(float, float);
-double fmod(double, double);
-//long double fmodl(long double, long double);
+float fmodf(float, float) @(pure);
+double fmod(double, double) @(pure);
+//long double fmodl(long double, long double) @(pure);
 
-float remainderf(float, float);
-double remainder(double, double);
-//long double remainderl(long double, long double);
+float remainderf(float, float) @(pure);
+double remainder(double, double) @(pure);
+//long double remainderl(long double, long double) @(pure);
 
-float remquof(float, float, int *);
-double remquo(double, double, int *);
-//long double remquol(long double, long double, int *);
+float remquof(float, float, int *) @(pure);
+double remquo(double, double, int *) @(pure);
+//long double remquol(long double, long double, int *) @(pure);
 
-float copysignf(float, float);
-double copysign(double, double);
-//long double copysignl(long double, long double);
+float copysignf(float, float) @(pure);
+double copysign(double, double) @(pure);
+//long double copysignl(long double, long double) @(pure);
 
 float nanf(const char *);
 double nan(const char *);
 //long double nanl(const char *);
 
-float nextafterf(float, float);
-double nextafter(double, double);
-//long double nextafterl(long double, long double);
+float nextafterf(float, float) @(pure);
+double nextafter(double, double) @(pure);
+//long double nextafterl(long double, long double) @(pure);
 
-//double nexttoward(double, long double);
-//float nexttowardf(float, long double);
-//long double nexttowardl(long double, long double);
+//double nexttoward(double, long double) @(pure);
+//float nexttowardf(float, long double) @(pure);
+//long double nexttowardl(long double, long double) @(pure);
 
-float fdimf(float, float);
-double fdim(double, double);
+float fdimf(float, float) @(pure);
+double fdim(double, double) @(pure);
 //long double fdiml(long double, long double);
 
-float fmaxf(float, float);
-double fmax(double, double);
-//long double fmaxl(long double, long double);
+float fmaxf(float, float) @(pure);
+double fmax(double, double) @(pure);
+//long double fmaxl(long double, long double) @(pure);
 
-float fminf(float, float);
-double fmin(double, double);
-//long double fminl(long double, long double);
+float fminf(float, float) @(pure);
+double fmin(double, double) @(pure);
+//long double fminl(long double, long double) @(pure);
 
-float fmaf(float, float, float);
-double fma(double, double, double);
-//long double fmal(long double, long double, long double);
+float fmaf(float, float, float) @(pure);
+double fma(double, double, double) @(pure);
+//long double fmal(long double, long double, long double) @(pure);
 
 const double M_E         = 2.71828182845904523536028747135266250;   /* e */
 const double M_LOG2E     = 1.44269504088896340735992468100189214;   /* log2(e) */

--- a/recipe.txt
+++ b/recipe.txt
@@ -46,6 +46,7 @@ set ast
     ast/enum_constant_decl.c2
     ast/enum_type_decl.c2
     ast/function_decl.c2
+    ast/function_signature.c2
     ast/function_type_decl.c2
     ast/import_decl.c2
     ast/static_assert.c2
@@ -162,6 +163,7 @@ executable c2c
     $warnings unreachable-code
     #$warnings promote-to-error
     $use pthread dynamic
+    $use math dynamic
 
     $backend c
 #    $backend ir

--- a/test/init/array/init_array_designator_nonint3.c2
+++ b/test/init/array/init_array_designator_nonint3.c2
@@ -1,7 +1,10 @@
 // @warnings{no-unused}
 module test;
 
+type Enum enum u8 { Foo, Bar }
+
 i32[] array = {
-    [test] = 3, // @error{array index is not a compile-time value}
+    [test] = 3, // @error{lvalue/rvalue required}
+    [Enum] = 3, // @error{lvalue/rvalue required}
 }
 

--- a/test/vars/init_global_with_call.c2
+++ b/test/vars/init_global_with_call.c2
@@ -1,0 +1,18 @@
+// @warnings{no-unused}
+module test;
+
+fn i32 foo() { return 1; } // @note{'test.foo' is defined here}
+
+i32 a = foo();  // @error{only pure functions can be called in global initializers}
+
+fn i32 foo1() { return 1; } // @note{'test.foo1' is defined here}
+
+i32 b = 3 + foo1(); // @error{only pure functions can be called in global initializers}
+
+fn i32 foo2() { return 1; } // @note{'test.foo2' is defined here}
+
+i32 c = foo2() + foo2();  // @error{only pure functions can be called in global initializers}
+
+fn i32 foo3() { return 1; } // @note{'test.foo3' is defined here}
+
+i32[] d = { 1, foo3(), 3 } // @error{only pure functions can be called in global initializers}

--- a/test/vars/init_global_with_call2.c2
+++ b/test/vars/init_global_with_call2.c2
@@ -1,7 +1,7 @@
 // @warnings{no-unused}
 module test;
 
-fn i32 foo() { return 1; }
+fn i32 foo() { return 1; } // @note{'test.foo' is defined here}
 
-i32 b = 3 + foo(); // @error{initializer element is not a compile-time constant}
+i32 b = 3 + foo(); // @error{only pure functions can be called in global initializers}
 

--- a/test/vars/init_global_with_call3.c2
+++ b/test/vars/init_global_with_call3.c2
@@ -1,7 +1,7 @@
 // @warnings{no-unused}
 module test;
 
-fn i32 foo() { return 1; }
+fn i32 foo() { return 1; } // @note{'test.foo' is defined here}
 
-i32 c = foo() + foo();  // @error{initializer element is not a compile-time constant}
+i32 c = foo() + foo();  // @error{only pure functions can be called in global initializers}
 


### PR DESCRIPTION
* accept pure function calls in compile time constant expressions
* mark math functions as pure by default
* remove `Analyser.analysePureCallExpr`
* extend and refine dynamic function dispatcher for ast_evaluator