### PR TITLE
Analyser: improve function call rewriting

### DIFF
--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -122,12 +122,8 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         }
     }
 
-    bool rewrite = false;
     u32 num_auto_args = fd.getNumAutoArgs();
-    if (num_auto_args) {
-        call.setHasAutoArgs();
-        rewrite = true;
-    }
+    bool rewrite = num_auto_args != 0;
 
     VarDecl** func_args = fd.getParams();
     Expr** call_args = call.getArgs();
@@ -177,8 +173,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
     }
 
     //stdio.printf("CALL (%d | %d)\n", func_num_args, call_num_args);
-    u8 format_arg_idx = 0;
-    FormatAttr format_attr = fd.getFormatAttr(&format_arg_idx);
+    FormatAttr format_attr = fd.getFormatAttr();
     while (1) {
         //stdio.printf("ARG [%d | %d]\n", func_arg_index, call_arg_index);
         if (func_arg_index >= func_num_args) break;
@@ -195,7 +190,6 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         Expr* arg = call_args[call_arg_index];
         if (arg.isNamedArgument()) {
             NamedArgument* n = (NamedArgument*)arg;
-            rewrite = true;
             u32 arg_name_idx = n.getNameIdx();
             u32 param_name_idx;
             bool found = false;
@@ -208,6 +202,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
                     break;
                 if (!vd.hasInit())
                     break;
+                rewrite = true;
                 func_arg_index++;
             }
             if (!found) {
@@ -231,10 +226,11 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
     }
 
     u32 expected_args = func_num_args - num_auto_args - isTypeFuncCall;
+    u32 extra_args_count = call_num_args - call_arg_index;
     if (func_arg_index < func_num_args) {
+        rewrite = true;
         u32 missing_args = 0;
         for (u32 i = func_arg_index; i < func_num_args; i++) {
-            rewrite = true;
             if (!func_args[i].hasInit()) missing_args++;
         }
         if (missing_args) {
@@ -245,7 +241,9 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         }
     }
 
-    if (call_arg_index != call_num_args || fd.isVariadic()) {
+    Expr* new_format_arg = nil;
+
+    if (extra_args_count) {
         if (!fd.isVariadic()) {
             Expr* call_arg = call_args[call_arg_index];
             ma.error(call_arg.getLoc(), DiagTooManyArgs, fd.getDiagKind(), expected_args, call_num_args);
@@ -253,7 +251,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
             return QualType_Invalid;
         }
 
-        while (call_arg_index != call_num_args) {
+        while (call_arg_index < call_num_args) {
             QualType callType = ma.analyseExpr(&call_args[call_arg_index], true, RHS);
             if (callType.isInvalid()) return QualType_Invalid;
             if (callType.isVoid()) {
@@ -263,18 +261,17 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
             }
             call_arg_index++;
         }
-
-        if (format_attr) {
-            format_arg_idx -= num_auto_args + isTypeFuncCall;
-            u32 num_args = call_num_args - format_arg_idx - 1;
-            call.setFormatAttr(format_attr);
-            rewrite = true;
-            if (!ma.checkFormatArgs(&call_args[format_arg_idx], num_args, &call_args[format_arg_idx+1], format_attr))
-                return QualType_Invalid;
-        }
     }
 
-    if (rewrite && !ma.check_only) ma.rewriteCall(e_ptr, fd);
+    if (format_attr) {
+        u32 num_args = extra_args_count;
+        u32 format_arg_idx = call_num_args - extra_args_count - 1;
+        if (!ma.checkFormatArgs(call_args[format_arg_idx], &call_args[format_arg_idx+1], num_args, format_attr, &new_format_arg))
+            return QualType_Invalid;
+        if (new_format_arg) rewrite = true;
+    }
+
+    if (rewrite && !ma.check_only) ma.rewriteCall(e_ptr, fd, new_format_arg);
 
     return fd.getRType();
 }
@@ -574,8 +571,7 @@ fn const char* get_format(Expr* format, SrcLoc* format_loc) {
     }
 }
 
-fn bool Analyser.checkFormatArgs(Analyser* ma, Expr** format_ptr, u32 num_args, Expr** args, FormatAttr format_attr) {
-    Expr* format = *format_ptr;
+fn bool Analyser.checkFormatArgs(Analyser* ma, Expr* format, Expr** args, u32 num_args, FormatAttr format_attr, Expr** new_format_ptr) {
     SrcLoc format_loc = format.getLoc();
     const char* format_text = get_format(format, &format_loc);
     if (!format_text) {
@@ -614,11 +610,8 @@ fn bool Analyser.checkFormatArgs(Analyser* ma, Expr** format_ptr, u32 num_args, 
     const char* new_format_text = out.data();
     if (string.strcmp(format_text, new_format_text)) {
         u32 len = out.size();
-        Expr* new_format = ma.builder.actOnStringLiteral(0, len, ma.astPool.add(new_format_text, len, true), len);
-        ImplicitCastExpr* ic = (ImplicitCastExpr*)*format_ptr;
-        Expr* orig = ic.getInner();
-        ic.setInner(new_format);
-        *format_ptr = ma.builder.actOnAlternate(orig, *format_ptr);
+        *new_format_ptr = ma.builder.actOnStringLiteral(0, len, ma.astPool.add(new_format_text, len, true), len);
+        ma.builder.insertImplicitCast(ArrayToPointerDecay, new_format_ptr, format.getType());
     }
     out.free();
     return true;

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -116,7 +116,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
 
         if (FormatAttr format_attr = vd.getFormatAttr()) {
             ma.checkFormatArgument(vd, res, i, fd, format_attr);
-            fd.setFormatAttr(format_attr, (u8)i);
+            fd.setFormatAttr(format_attr);
         }
 
         // Note: we dont check the arg name for clash here, but when checking body

--- a/analyser/module_analyser_rewrite.c2
+++ b/analyser/module_analyser_rewrite.c2
@@ -20,7 +20,7 @@ import source_mgr;
 
 import string local;
 
-fn void Analyser.rewriteCall(Analyser* ma, Expr** e_ptr, FunctionDecl* fd) {
+fn void Analyser.rewriteCall(Analyser* ma, Expr** e_ptr, FunctionDecl* fd, Expr* new_format_arg) {
     Expr* e = *e_ptr;
     CallExpr* call = (CallExpr*)e;
     Expr** func = call.getFunc2();
@@ -90,14 +90,14 @@ fn void Analyser.rewriteCall(Analyser* ma, Expr** e_ptr, FunctionDecl* fd) {
     u32 func_num_args = fd.getNumParams();
     //stdio.printf("CALL %d/%d  FUNC %d/%d\n", call_arg_index, call_num_args, func_arg_index, func_num_args);
     source_mgr.Location loc;
-    if (call.hasAutoArgs()) loc = ma.diags.locate(e.getLoc());
+    if (fd.getNumAutoArgs()) loc = ma.diags.locate(e.getLoc());
     VarDecl** func_args = fd.getParams();
     while (func_arg_index < func_num_args) {
         VarDecl* vd = func_args[func_arg_index];
         if (vd.hasAutoAttr()) {
             if (vd.hasAttrAutoFile()) {
                 u32 len = (u32)strlen(loc.filename);
-                u32 value =  ma.astPool.add(loc.filename, len, true);
+                u32 value = ma.astPool.add(loc.filename, len, true);
                 Expr* arg = ma.builder.actOnStringLiteral(0, 0, value, len);
                 args.add(arg);
             }
@@ -108,7 +108,7 @@ fn void Analyser.rewriteCall(Analyser* ma, Expr** e_ptr, FunctionDecl* fd) {
             if (vd.hasAttrAutoFunc()) {
                 const char* func_name = ma.curFunction.asDecl().getFullName();
                 u32 len = (u32)strlen(func_name);
-                u32 value =  ma.astPool.add(func_name, len, true);
+                u32 value = ma.astPool.add(func_name, len, true);
                 Expr* arg = ma.builder.actOnStringLiteral(0, 0, value, len);
                 args.add(arg);
             }
@@ -116,31 +116,29 @@ fn void Analyser.rewriteCall(Analyser* ma, Expr** e_ptr, FunctionDecl* fd) {
             continue;
         }
 
+        Expr* arg;
         if (call_arg_index < call_num_args) {
-            Expr* arg = call_args[call_arg_index];
-
+            arg = call_args[call_arg_index];
             if (arg.isNamedArgument()) {
                 NamedArgument* n = (NamedArgument*)arg;
                 u32 arg_name_idx = n.getNameIdx();
                 if (((Decl*)vd).getNameIdx() == arg_name_idx) {
                     arg = n.getInner();
-                    args.add(arg);
-                    func_arg_index++;
                     call_arg_index++;
-                    continue;
+                } else {
+                    arg = vd.getInit();
+                    assert(arg);
                 }
             } else {
-                args.add(arg);
-                func_arg_index++;
                 call_arg_index++;
-                continue;
             }
+        } else {
+            // default args
+            arg = vd.getInit();
+            assert(arg);
         }
-
-        // default args
-        Expr* init = vd.getInit();
-        assert(init);
-        args.add(init);
+        if (vd.getFormatAttr() && new_format_arg) arg = new_format_arg;
+        args.add(arg);
         func_arg_index++;
     }
 
@@ -150,7 +148,6 @@ fn void Analyser.rewriteCall(Analyser* ma, Expr** e_ptr, FunctionDecl* fd) {
         args.add(arg);
         call_arg_index++;
     }
-    // TODO re-write printf/scanf formats
 
     // func
     Expr* func2;

--- a/ast/call_expr.c2
+++ b/ast/call_expr.c2
@@ -25,8 +25,6 @@ type CallExprBits struct {
     u32 calls_type_func : 1;
     u32 calls_static_sf : 1;
     u32 is_template_call : 1;
-    FormatAttr format_attr : 2;
-    u32 has_auto_args : 1;   // if c-generator needs to insert extra arguments (file, line)
     u32 is_noreturn : 1;
     u32 num_args : 8;
 }
@@ -151,22 +149,6 @@ public fn bool CallExpr.isNoreturn(const CallExpr* e) {
     return e.base.base.callExprBits.is_noreturn;
 }
 
-public fn void CallExpr.setFormatAttr(CallExpr* e, FormatAttr kind) {
-    e.base.base.callExprBits.format_attr = kind;
-}
-
-fn FormatAttr CallExpr.getFormatAttr(const CallExpr* e) {
-    return e.base.base.callExprBits.format_attr;
-}
-
-public fn void CallExpr.setHasAutoArgs(CallExpr* e) {
-    e.base.base.callExprBits.has_auto_args = 1;
-}
-
-public fn bool CallExpr.hasAutoArgs(const CallExpr* e) {
-    return e.base.base.callExprBits.has_auto_args;
-}
-
 public fn SrcLoc CallExpr.getStartLoc(const CallExpr* e) {
     return e.func.getStartLoc();
 }
@@ -202,12 +184,6 @@ fn void CallExpr.print(const CallExpr* e, string_buffer.Buf* out, u32 indent) {
     if (e.base.base.callExprBits.calls_type_func) out.add(" TF");
     if (e.base.base.callExprBits.calls_static_sf) out.add(" STF");
     if (e.base.base.callExprBits.is_noreturn) out.add(" noreturn");
-    switch (e.getFormatAttr()) {
-    case None: break;
-    case Printf: out.print(" printf"); break;
-    case Scanf: out.print(" scanf"); break;
-    }
-    if (e.hasAutoArgs()) out.add(" auto-args");
     out.newline();
     if (e.base.base.callExprBits.is_template_call) {
         out.indent(indent + 1);

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -84,7 +84,7 @@ public type FunctionDecl struct @(opaque) {
     }
     QualType rt;          // return type after analysis
     u8 num_params;
-    u8 attr_format_arg;
+    u8 num_locals;
     u16 instance_idx;     // template functions only
     u32 template_name;    // index into string pool
     SrcLoc template_loc;
@@ -120,7 +120,7 @@ public fn FunctionDecl* FunctionDecl.create(ast_context.Context* c,
     d.body = nil;
     d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
-    d.attr_format_arg = 0;
+    d.num_locals = 0;
     d.instance_idx = 0;
     d.template_name = 0;
     d.template_loc = 0;
@@ -165,7 +165,7 @@ public fn FunctionDecl* FunctionDecl.createTemplate(ast_context.Context* c,
     d.body = nil;
     d.rt = QualType_Invalid;
     d.num_params = (u8)num_params;
-    d.attr_format_arg = 0;
+    d.num_locals = 0;
     d.instance_idx = 0;
     d.template_name = template_name;
     d.template_loc = template_loc;
@@ -207,7 +207,7 @@ public fn FunctionDecl* FunctionDecl.instantiate(const FunctionDecl* fd, Instant
         fd2.body = fd.body.instantiate(inst);
     fd2.rt = QualType_Invalid;
     fd2.num_params = fd.num_params;
-    fd2.attr_format_arg = fd.attr_format_arg;
+    fd2.num_locals = fd.num_locals;
     fd2.instance_idx = 0;
     fd2.template_name = 0;
     fd2.template_loc = fd.template_loc;
@@ -460,13 +460,11 @@ public fn bool FunctionDecl.hasAttrPure(const FunctionDecl* d) {
     return d.flags.attr_pure;
 }
 
-public fn void FunctionDecl.setFormatAttr(FunctionDecl* d, FormatAttr format_attr, u8 format_arg) {
+public fn void FunctionDecl.setFormatAttr(FunctionDecl* d, FormatAttr format_attr) {
     d.flags.format_attr = format_attr;
-    d.attr_format_arg = format_arg;
 }
 
-public fn FormatAttr FunctionDecl.getFormatAttr(const FunctionDecl* d, u8 *format_arg_ptr) {
-    *format_arg_ptr = d.attr_format_arg;
+public fn FormatAttr FunctionDecl.getFormatAttr(const FunctionDecl* d) {
     return d.flags.format_attr;
 }
 
@@ -505,11 +503,10 @@ fn void FunctionDecl.print(const FunctionDecl* d, string_buffer.Buf* out, u32 in
     if (d.hasAttrNoReturn()) out.add(" noreturn");
     if (d.hasAttrInline()) out.add(" inline");
     if (d.hasAttrWeak()) out.add(" weak");
-    u8 format_arg = 0;
-    switch (d.getFormatAttr(&format_arg)) {
+    switch (d.getFormatAttr()) {
     case None: break;
-    case Printf: out.print(" printf_format=%d", format_arg); break;
-    case Scanf: out.print(" scanf_format=%d", format_arg); break;
+    case Printf: out.add(" printf_format"); break;
+    case Scanf: out.add(" scanf_format"); break;
     }
     if (d.hasAttrConstructor()) out.add(" constructor");
     if (d.hasAttrDestructor()) out.add(" destructor");

--- a/ast/implicit_cast_expr.c2
+++ b/ast/implicit_cast_expr.c2
@@ -91,10 +91,6 @@ public fn bool ImplicitCastExpr.isArrayToPointerDecay(const ImplicitCastExpr* e)
 
 public fn Expr* ImplicitCastExpr.getInner(const ImplicitCastExpr* e) { return e.inner; }
 
-public fn void ImplicitCastExpr.setInner(ImplicitCastExpr* e, Expr* inner) {
-    e.inner = inner;
-}
-
 fn SrcLoc ImplicitCastExpr.getStartLoc(const ImplicitCastExpr* e) {
     return e.getInner().getStartLoc();
 }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -848,8 +848,7 @@ fn void Generator.gen_func_proto(Generator* gen, FunctionDecl* fd, string_buffer
     if (fd.hasAttrDestructor()) out.add("__attribute__((destructor)) ");
     if (fd.hasAttrNoReturn()) out.add("__attribute__((noreturn)) ");
 
-    u8 format_arg;
-    if (FormatAttr format_attr = fd.getFormatAttr(&format_arg)) {
+    if (FormatAttr format_attr = fd.getFormatAttr()) {
         out.print("__attribute__((__format__(%s, %d, %d))) ",
                   format_attr == Printf ? "printf" :
                   format_attr == Scanf ? "scanf" :


### PR DESCRIPTION
* minimize the number of call rewrites
* no AlternateExpression for format strings and only rewrite if needed
* no rewrite for named arguments unless default arguments needed
* remove CallExpr fields: `format_attr`, `has_auto_args` and accessors
* remove FunctionDecl fields: `attr_format_arg`
* remove `ImplicitCastExpr.setInner()`