### PR TITLE
C-generator: use c2 types in C code generated

### DIFF
--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -239,14 +239,14 @@ fn void Generator.emitEnumType(Generator* gen, string_buffer.Buf* out, Decl* d) 
 
 const char*[BuiltinKind] builtinType_cnames = {
     "char",
-    "int8_t",
-    "int16_t",
-    "int32_t",
-    "int64_t",
-    "uint8_t",
-    "uint16_t",
-    "uint32_t",
-    "uint64_t",
+    "i8",
+    "i16",
+    "int",
+    "i64",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
     "float",
     "double",
     "ssize_t",
@@ -254,7 +254,7 @@ const char*[BuiltinKind] builtinType_cnames = {
     "bool",
 }
 
-fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType qt) {
+fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType qt, bool bitfield = false) {
     Decl* decl = nil;
 
     if (qt.isConst()) out.add("const ");
@@ -263,6 +263,8 @@ fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType q
     switch (qt.getKind()) {
     case Builtin:
         BuiltinType* bt = (BuiltinType*)qt.getType();
+        // special case to ensure signed behavior
+        if (bitfield && bt.getKind() == Int32) out.add("signed  ");
         out.add(builtinType_cnames[bt.getKind()]);
         return;
     case Pointer:
@@ -385,13 +387,14 @@ fn void Generator.emitStructMember(Generator* gen, string_buffer.Buf* out, Decl*
         }
         gen.genTypeIfNeeded(qt, true);
 
-        gen.emitTypePre(out, qt);
+        VarDecl* vd = (VarDecl*)d;
+        Expr* bitfield = vd.getBitfield();
+
+        gen.emitTypePre(out, qt, bitfield != nil);
         out.space();
         if (d.getNameIdx()) out.add(d.getName());
         gen.emitTypePost(out, qt);
 
-        VarDecl* vd = (VarDecl*)d;
-        Expr* bitfield = vd.getBitfield();
         if (bitfield) {
             out.add(" : ");
             // C does not allow using constants here, so generate CTV Value
@@ -861,7 +864,7 @@ fn void Generator.gen_func_proto(Generator* gen, FunctionDecl* fd, string_buffer
     }
 
     if (d == gen.mainFunc) {
-        out.add("int32_t main");
+        out.add("int main");
     } else {
         // 2 options:
         // - external .c2i files
@@ -1435,12 +1438,11 @@ const char[] C_types =
     #define true 1
     #define false 0
     #endif
-    typedef signed char int8_t;
-    typedef unsigned char uint8_t;
-    typedef signed short int16_t;
-    typedef unsigned short uint16_t;
-    typedef signed int int32_t;
-    typedef unsigned int uint32_t;
+    typedef signed char i8;
+    typedef unsigned char u8;
+    typedef signed short i16;
+    typedef unsigned short u16;
+    typedef unsigned int u32;
     ```;
 const char[] C_defines =
     ```c
@@ -1493,24 +1495,24 @@ fn void Generator.emit_external_header(Generator* gen, bool enable_asserts, cons
     if (ast.getWordSize() == 4) {
         // ILP32 (32-bit int, long and pointers)
         out.add(```c
-                typedef signed long long int64_t;
-                typedef unsigned long long uint64_t;
+                typedef signed long long i64;
+                typedef unsigned long long u64;
                 typedef signed long ssize_t;
                 typedef unsigned long size_t;
                 ```);
     } else {
         // LP64 (64-bit long and pointers)
         out.add(```c
-                typedef signed long int64_t;
-                typedef unsigned long uint64_t;
+                typedef signed long i64;
+                typedef unsigned long u64;
                 typedef signed long ssize_t;
                 typedef unsigned long size_t;
                 ```);
 #if 0
         // TODO support LLP64 (64-bit long long and pointers, but 32-bit long)
         out.add(```c
-                typedef signed long long int64_t;
-                typedef unsigned long long uint64_t;
+                typedef signed long long i64;
+                typedef unsigned long long u64;
                 typedef signed long long ssize_t;
                 typedef unsigned long long size_t;
                 ```);

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -290,14 +290,14 @@ const char[] C2_types_header =
     #define to_container(type, member, ptr) ((type *)((char *)(ptr)-offsetof(type, member)))
 
     // NOTE: 64-bit only for now
-    typedef signed char int8_t;
-    typedef unsigned char uint8_t;
-    typedef signed short int int16_t;
-    typedef unsigned short int uint16_t;
-    typedef signed int int32_t;
-    typedef unsigned int uint32_t;
-    typedef signed long int64_t;
-    typedef unsigned long uint64_t;
+    typedef signed char i8;
+    typedef unsigned char u8;
+    typedef signed short int i16;
+    typedef unsigned short int u16;
+    typedef signed int i32;
+    typedef unsigned int u32;
+    typedef signed long i64;
+    typedef unsigned long u64;
 
     #ifdef __cplusplus
     }

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -471,10 +471,7 @@ fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) 
     }
 
     const u32 num_stmts = c.getNumStmts();
-    if (num_stmts == 0) {
-        //out.indent(indent+1);
-        //out.add("fallthrough;\n");
-    } else {
+    if (num_stmts > 0) {
         Stmt** stmts = c.getStmts();
         for (u32 i=0; i<num_stmts; i++) {
             gen.emitStmt(stmts[i], indent+1, true);

--- a/generator/c/c_generator_trace.c2
+++ b/generator/c/c_generator_trace.c2
@@ -193,10 +193,10 @@ fn void Generator.writeCalls(Generator* gen, string_buffer.Buf* out) {
     }
     out.add("};\n\n");
 
-    out.add("uint32_t c2_trace_length = sizeof(c2_trace_data) / sizeof(c2_trace_data[0]);\n"
-            "uint32_t c2_trace_counts[sizeof(c2_trace_data) / sizeof(c2_trace_data[0])];\n\n");
+    out.add("u32 c2_trace_length = sizeof(c2_trace_data) / sizeof(c2_trace_data[0]);\n"
+            "u32 c2_trace_counts[sizeof(c2_trace_data) / sizeof(c2_trace_data[0])];\n\n");
 }
 
 fn void Generator.writeCallExterns(Generator* gen, string_buffer.Buf* out) {
-    out.add("extern uint32_t c2_trace_counts[];\n");
+    out.add("extern u32 c2_trace_counts[];\n");
 }

--- a/libs/io_uring/io_uring.c2i
+++ b/libs/io_uring/io_uring.c2i
@@ -694,7 +694,7 @@ static inline bool io_uring_cq_eventfd_enabled(const struct io_uring *ring)
 static inline int io_uring_cq_eventfd_toggle(struct io_uring *ring,
 					     bool enabled)
 {
-	uint32_t flags;
+	u32 flags;
 
 	if (!!enabled == io_uring_cq_eventfd_enabled(ring))
 		return 0;

--- a/test/auto_args/auto_arg_callback_ok.c2t
+++ b/test/auto_args/auto_arg_callback_ok.c2t
@@ -27,13 +27,13 @@ public fn i32 main() {
 
 // @expect{atleast, cgen/build.c}
 
-typedef void (*test_Func)(const char* file, uint32_t line);
+typedef void (*test_Func)(const char* file, u32 line);
 
-static void test_impl(const char* file, uint32_t line);
+static void test_impl(const char* file, u32 line);
 static void test_test1(test_Func f);
 static void test_test2(void);
 
-static void test_impl(const char* file, uint32_t line)
+static void test_impl(const char* file, u32 line)
 {
 }
 

--- a/test/auto_args/auto_file_ok.c2t
+++ b/test/auto_args/auto_file_ok.c2t
@@ -18,13 +18,13 @@ public fn i32 main() {
 
 // @expect{atleast, cgen/build.c}
 
-static void test_test2(const char* file, uint32_t line);
+static void test_test2(const char* file, u32 line);
 
-static void test_test2(const char* file, uint32_t line)
+static void test_test2(const char* file, u32 line)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
    test_test2("file1.c2", 7);
    test_test2("file1.c2", 8);

--- a/test/auto_args/multi_file.c2t
+++ b/test/auto_args/multi_file.c2t
@@ -25,7 +25,7 @@ public fn i32 main() {
 
 // @expect{atleast, cgen/test.c}
 
-int32_t main(void)
+int main(void)
 {
    foo_Foo* f = NULL;
    foo_Foo_test(f, "file2.c2", 7, NULL);

--- a/test/auto_args/static_lib.c2t
+++ b/test/auto_args/static_lib.c2t
@@ -19,6 +19,6 @@ fn void Foo.test(Foo* f, const char* file @(auto_file), u32 line @(auto_line), v
 
 // @expect{atleast, foo.h}
 
-void foo_Foo_test(foo_Foo* f, const char* file, uint32_t line, void* p);
+void foo_Foo_test(foo_Foo* f, const char* file, u32 line, void* p);
 
 

--- a/test/auto_args/struct_function_before_self.c2t
+++ b/test/auto_args/struct_function_before_self.c2t
@@ -19,13 +19,13 @@ public fn i32 main() {
 }
 
 // @expect{atleast, cgen/build.c}
-static void test_Foo_test(const char* file, uint32_t line, test_Foo* f, void* p);
-int32_t main(void);
-static void test_Foo_test(const char* file, uint32_t line, test_Foo* f, void* p)
+static void test_Foo_test(const char* file, u32 line, test_Foo* f, void* p);
+int main(void);
+static void test_Foo_test(const char* file, u32 line, test_Foo* f, void* p)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
    test_Foo f;
    test_Foo_test("file1.c2", 11, &f, NULL);

--- a/test/auto_args/struct_function_ok.c2t
+++ b/test/auto_args/struct_function_ok.c2t
@@ -19,13 +19,13 @@ public fn i32 main() {
 }
 
 // @expect{atleast, cgen/build.c}
-static void test_Foo_test(test_Foo* f, const char* file, uint32_t line, void* p);
-int32_t main(void);
-static void test_Foo_test(test_Foo* f, const char* file, uint32_t line, void* p)
+static void test_Foo_test(test_Foo* f, const char* file, u32 line, void* p);
+int main(void);
+static void test_Foo_test(test_Foo* f, const char* file, u32 line, void* p)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
    test_Foo f;
    test_Foo_test(&f, "file1.c2", 11, NULL);

--- a/test/auto_args/template_function.c2t
+++ b/test/auto_args/template_function.c2t
@@ -15,16 +15,16 @@ public fn i32 main() {
 }
 
 // @expect{atleast, cgen/build.c}
-int32_t main(void);
+int main(void);
 
-static int32_t test_test1_0_(const uint32_t line, int32_t x)
+static int test_test1_0_(const u32 line, int x)
 {
-    return (int32_t)(x + line);
+    return (int)(x + line);
 }
 
-int32_t main(void)
+int main(void)
 {
-   int32_t a = test_test1_0_(8, 20);
+   int a = test_test1_0_(8, 20);
    return 0;
 }
 

--- a/test/auto_args/varargs.c2t
+++ b/test/auto_args/varargs.c2t
@@ -15,13 +15,13 @@ public fn i32 main() {
 
 // @expect{atleast, cgen/build.c}
 
-static void test_log(uint32_t line, const char* filename, const char* fmt, ...);
+static void test_log(u32 line, const char* filename, const char* fmt, ...);
 
-static void test_log(uint32_t line, const char* filename, const char* fmt, ...)
+static void test_log(u32 line, const char* filename, const char* fmt, ...)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
    test_log(7, "file1.c2", "hello %s", "C2");
    return 0;

--- a/test/c_generator/asm/gen_asm.c2t
+++ b/test/c_generator/asm/gen_asm.c2t
@@ -40,24 +40,24 @@ fn void basic_asm() {
 }
 
 // @expect{atleast, cgen/build.c}
-static int32_t test_add(int32_t x, int32_t y);
+static int test_add(int x, int y);
 static void test_clobbers(void);
 static inline
-uint64_t test_rdtsc(void);
+u64 test_rdtsc(void);
 static void test_basic_asm(void);
 
-static int32_t test_add(int32_t x, int32_t y)
+static int test_add(int x, int y)
 {
-  int32_t result;
+  int result;
   __asm__ volatile ("add %[Rd], %[Rm], %[Rn]" : [Rd] "=r" (result) : [Rm] "r" (x), [Rn] "r" (y));
   return result;
 }
 
 static void test_clobbers(void)
 {
-  int32_t from;
-  int32_t to;
-  int32_t count;
+  int from;
+  int to;
+  int count;
   __asm__ volatile ("movc3 %0, %1, %2"
             :
             : "g" (from), "g" (to), "g" (count)
@@ -65,12 +65,12 @@ static void test_clobbers(void)
 }
 
 static inline
-uint64_t test_rdtsc(void)
+u64 test_rdtsc(void)
 {
-  uint32_t lo;
-  uint32_t hi;
+  u32 lo;
+  u32 hi;
   __asm__ volatile ("rdtsc" : "=a" (lo), "=d" (hi));
-  uint64_t res = hi;
+  u64 res = hi;
   res <<= 32;
   res |= lo;
   return res;

--- a/test/c_generator/attributes/exported_not_static.c2t
+++ b/test/c_generator/attributes/exported_not_static.c2t
@@ -20,9 +20,9 @@ public fn i32 main(i32 argc, const i8** argv)
 
 // @expect{atleast, cgen/build.c}
 
-static int32_t file1_a = 0;
-int32_t file1_b = 0;
-static int32_t file1_c = 0;
+static int file1_a = 0;
+int file1_b = 0;
+static int file1_c = 0;
 
 static void file1_f(void);
 void file1_g(void);

--- a/test/c_generator/attributes/func_attributes.c2t
+++ b/test/c_generator/attributes/func_attributes.c2t
@@ -19,19 +19,19 @@ public fn i32 main(i32 argc, const i8** argv)
 
 // @expect{atleast, cgen/build.c}
 __attribute__((section("ctest")))
-static int32_t test_foo(void);
+static int test_foo(void);
 
 __attribute__((section("ctest")))
-static int32_t test_bar(void);
+static int test_bar(void);
 
 __attribute__((section("ctest")))
-static int32_t test_foo(void)
+static int test_foo(void)
 {
     return 1;
 }
 
 __attribute__((section("ctest")))
-static int32_t test_bar(void)
+static int test_bar(void)
 {
     return 2;
 }

--- a/test/c_generator/attributes/func_inline.c2t
+++ b/test/c_generator/attributes/func_inline.c2t
@@ -21,17 +21,17 @@ public fn i32 main(i32 argc, const i8** argv)
 // @expect{atleast, cgen/build.c}
 
 static inline
-int32_t test_foo(void)
+int test_foo(void)
 {
     return 1;
 }
 
 static inline
-int32_t test_bar(void);
+int test_bar(void);
 
 
 static inline
-int32_t test_bar(void)
+int test_bar(void)
 {
     return 2;
 }

--- a/test/c_generator/attributes/noreturn.c2t
+++ b/test/c_generator/attributes/noreturn.c2t
@@ -23,13 +23,13 @@ public fn i32 main() {
 // @expect{atleast, cgen/build.c}
 
 __attribute__((noreturn))
-void exit(int32_t __status);
+void exit(int __status);
 
 // --- module file1 ---
 __attribute__((noreturn))
 static void file1_test1(void);
-static int32_t file1_test2(void);
-int32_t main(void);
+static int file1_test2(void);
+int main(void);
 
 __attribute__((noreturn))
 static void file1_test1(void)
@@ -37,7 +37,7 @@ static void file1_test1(void)
    exit(-1);
 }
 
-static int32_t file1_test2(void)
+static int file1_test2(void)
 {
    file1_test1();
 }

--- a/test/c_generator/attributes/packed_struct.c2t
+++ b/test/c_generator/attributes/packed_struct.c2t
@@ -20,7 +20,7 @@ public fn i32 main(i32 argc, const i8** argv)
 typedef struct test_Struct_ test_Struct;
 
 struct test_Struct_ {
-      int32_t x;
-         int8_t y;
+   int x;
+   i8 y;
 } __attribute__((packed));
 

--- a/test/c_generator/attributes/printf_format.c2t
+++ b/test/c_generator/attributes/printf_format.c2t
@@ -21,19 +21,19 @@ public fn i32 main()
 
 __attribute__((__format__(printf, 1, 2)))
 static void file1_log(const char* format, ...);
-int32_t main(void);
+int main(void);
 
 __attribute__((__format__(printf, 1, 2)))
 static void file1_log(const char* format, ...)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
-   int32_t i = -20;
-   uint32_t u = 10;
-   int64_t li = -33333;
-   uint64_t lu = 444444;
+   int i = -20;
+   u32 u = 10;
+   i64 li = -33333;
+   u64 lu = 444444;
    file1_log("A %d B %u %+4d %06u C %ld D %lu E", i, u, i, u, li, lu);
    return 0;
 }

--- a/test/c_generator/attributes/section_attribute.c2t
+++ b/test/c_generator/attributes/section_attribute.c2t
@@ -15,7 +15,7 @@ public fn i32 main(i32 argc, const i8** argv)
 }
 
 // @expect{atleast, cgen/build.c}
-static int32_t test_x __attribute__((section("test"))) = 123;
+static int test_x __attribute__((section("test"))) = 123;
 
 __attribute__((section("test")))
 static void test_foo(void);

--- a/test/c_generator/attributes/weak_attribute.c2t
+++ b/test/c_generator/attributes/weak_attribute.c2t
@@ -16,7 +16,7 @@ public fn i32 main(i32 argc, const i8** argv)
 }
 
 // @expect{atleast, cgen/build.c}
-int32_t test_x __attribute__((weak)) = 123;
+int test_x __attribute__((weak)) = 123;
 
 __attribute__((weak))
 void test_foo(void);

--- a/test/c_generator/builtin/min_max.c2t
+++ b/test/c_generator/builtin/min_max.c2t
@@ -80,26 +80,26 @@ static void test_foo_char(void)
 
 static void test_foo_i8(void)
 {
-   int8_t min = i8_min;
-   int8_t max = i8_max;
+   i8 min = i8_min;
+   i8 max = i8_max;
 }
 
 static void test_foo_i16(void)
 {
-   int16_t min = i16_min;
-   int16_t max = i16_max;
+   i16 min = i16_min;
+   i16 max = i16_max;
 }
 
 static void test_foo_i32(void)
 {
-   int32_t min = i32_min;
-   int32_t max = i32_max;
+   int min = i32_min;
+   int max = i32_max;
 }
 
 static void test_foo_i64(void)
 {
-   int64_t min = i64_min;
-   int64_t max = i64_max;
+   i64 min = i64_min;
+   i64 max = i64_max;
 }
 
 static void test_foo_isize(void)
@@ -110,26 +110,26 @@ static void test_foo_isize(void)
 
 static void test_foo_u8(void)
 {
-   uint8_t min = u8_min;
-   uint8_t max = u8_max;
+   u8 min = u8_min;
+   u8 max = u8_max;
 }
 
 static void test_foo_u16(void)
 {
-   uint16_t min = u16_min;
-   uint16_t max = u16_max;
+   u16 min = u16_min;
+   u16 max = u16_max;
 }
 
 static void test_foo_u32(void)
 {
-   uint32_t min = u32_min;
-   uint32_t max = u32_max;
+   u32 min = u32_min;
+   u32 max = u32_max;
 }
 
 static void test_foo_u64(void)
 {
-   uint64_t min = u64_min;
-   uint64_t max = u64_max;
+   u64 min = u64_min;
+   u64 max = u64_max;
 }
 
 static void test_foo_usize(void)

--- a/test/c_generator/builtin/offsetof_struct.c2t
+++ b/test/c_generator/builtin/offsetof_struct.c2t
@@ -170,22 +170,22 @@ fn void test1() {
 
 // @expect{atleast, cgen/build.c}
 
-static uint32_t test_s1_offs[5] = { 0, 4, 8, 12, 16 };
-static uint32_t test_s2_offs[6] = { 0, 2, 4, 8, 16, 20 };
-static uint32_t test_s2p_offs[6] = { 0, 1, 3, 7, 15, 18 };
-static uint32_t test_s3_offs[4] = { 0, 40, 44, 60 };
-static uint32_t test_s4_offs[5] = { 4, 4, 6, 8, 12 };
-static uint32_t test_s5_offs[3] = { 12, 4, 8 };
-static uint32_t test_s6_offs[3] = { 6, 2, 4 };
+static u32 test_s1_offs[5] = { 0, 4, 8, 12, 16 };
+static u32 test_s2_offs[6] = { 0, 2, 4, 8, 16, 20 };
+static u32 test_s2p_offs[6] = { 0, 1, 3, 7, 15, 18 };
+static u32 test_s3_offs[4] = { 0, 40, 44, 60 };
+static u32 test_s4_offs[5] = { 4, 4, 6, 8, 12 };
+static u32 test_s5_offs[3] = { 12, 4, 8 };
+static u32 test_s6_offs[3] = { 6, 2, 4 };
 
 static void test_test1(void)
 {
-    uint32_t s1_offs_local[5] = { 0, 4, 8, 12, 16 };
-    uint32_t s2_offs_local[6] = { 0, 2, 4, 8, 16, 20 };
-    uint32_t s2p_offs_local[6] = { 0, 1, 3, 7, 15, 18 };
-    uint32_t s3_offs_local[4] = { 0, 40, 44, 60 };
-    uint32_t s4_offs_local[5] = { 4, 4, 6, 8, 12 };
-    uint32_t s5_offs_local[3] = { 12, 4, 8 };
-    uint32_t s6_offs_local[3] = { 6, 2, 4 };
+    u32 s1_offs_local[5] = { 0, 4, 8, 12, 16 };
+    u32 s2_offs_local[6] = { 0, 2, 4, 8, 16, 20 };
+    u32 s2p_offs_local[6] = { 0, 1, 3, 7, 15, 18 };
+    u32 s3_offs_local[4] = { 0, 40, 44, 60 };
+    u32 s4_offs_local[5] = { 4, 4, 6, 8, 12 };
+    u32 s5_offs_local[3] = { 12, 4, 8 };
+    u32 s6_offs_local[3] = { 6, 2, 4 };
 }
 

--- a/test/c_generator/constants/constants_first.c2t
+++ b/test/c_generator/constants/constants_first.c2t
@@ -18,10 +18,10 @@ const i32 C = 30;
 typedef struct test_Foo_ test_Foo;
 
 struct test_Foo_ {
-   int32_t x;
+   int x;
 };
 
-static int32_t test_a = 10;
+static int test_a = 10;
 
 #define test_B 20
 

--- a/test/c_generator/constants/init_const_enum.c2t
+++ b/test/c_generator/constants/init_const_enum.c2t
@@ -16,16 +16,16 @@ public fn i32 main() { return My_Zero2; }
 
 // @expect{atleast, cgen/build.c}
 
-typedef uint8_t test_Enum;
+typedef u8 test_Enum;
 enum test_Enum {
    test_Enum_Zero,
 };
 
 #define test_My_Zero test_Enum_Zero
 #define test_My_Zero2 test_My_Zero
-int32_t main(void);
+int main(void);
 
-int32_t main(void)
+int main(void)
 {
    return test_My_Zero2;
 }

--- a/test/c_generator/expr/cast_expr.c2t
+++ b/test/c_generator/expr/cast_expr.c2t
@@ -22,17 +22,17 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 10;
-    int32_t b1 = (int8_t)(20);
-    int32_t b2 = (int8_t)20;
-    int32_t b3 = (int8_t)+20;
-    int32_t b4 = (int8_t)-20;
-    int32_t c = (int8_t)a;
-    int32_t c1 = (int8_t)(a);
-    int32_t c2 = (int8_t)a;
-    int32_t c3 = (int8_t)+a;
-    int32_t c4 = (int8_t)-a;
+    int a = 10;
+    int b1 = (i8)(20);
+    int b2 = (i8)20;
+    int b3 = (i8)+20;
+    int b4 = (i8)-20;
+    int c = (i8)a;
+    int c1 = (i8)(a);
+    int c2 = (i8)a;
+    int c3 = (i8)+a;
+    int c4 = (i8)-a;
     return 0;
 }

--- a/test/c_generator/expr/check_shift.c2t
+++ b/test/c_generator/expr/check_shift.c2t
@@ -14,11 +14,11 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 1 << (2 + 1);
-    int32_t b = (1 << 2) + 1;
-    int32_t c = (1 >> 2) + 1;
+    int a = 1 << (2 + 1);
+    int b = (1 << 2) + 1;
+    int c = (1 >> 2) + 1;
 
     return 0;
 }

--- a/test/c_generator/expr/prec_expr.c2t
+++ b/test/c_generator/expr/prec_expr.c2t
@@ -28,9 +28,9 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a;
+    int a;
 
     a = (1 << 2) + 3;
     a = ((1 ^ 2) | 3) & 4;

--- a/test/c_generator/expr/sizeof_expr.c2t
+++ b/test/c_generator/expr/sizeof_expr.c2t
@@ -42,23 +42,23 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 8;
-    int32_t b = 4;
-    //int32_t c = 8;
-    int32_t d = 4;
-    int32_t e = 8;
-    //int32_t f = 12;
-    int32_t g = 24;
-    int32_t h = 4;
-    int32_t i = 8;
-    int32_t j = 24;
-    int32_t k = 4;
-    int32_t l = 8;
-    int32_t o1 = 10;
-    int32_t o2 = 20;
-    int32_t o3 = 40;
+    int a = 8;
+    int b = 4;
+    //int c = 8;
+    int d = 4;
+    int e = 8;
+    //int f = 12;
+    int g = 24;
+    int h = 4;
+    int i = 8;
+    int j = 24;
+    int k = 4;
+    int l = 8;
+    int o1 = 10;
+    int o2 = 20;
+    int o3 = 40;
 
     return 0;
 }

--- a/test/c_generator/functions/inline/inline_stmts.c2t
+++ b/test/c_generator/functions/inline/inline_stmts.c2t
@@ -112,7 +112,7 @@ next:
 // @expect{atleast, test1.h}
 
 static inline
-int32_t test1_test_fn(const char* format, ...)
+int test1_test_fn(const char* format, ...)
 {
   const char* p;
   {
@@ -153,7 +153,7 @@ int32_t test1_test_fn(const char* format, ...)
   for (;;) {
       break;
   }
-  for (uint32_t i = 0; format[i]; i++) {
+  for (u32 i = 0; format[i]; i++) {
     break;
   }
   goto next;

--- a/test/c_generator/functions/inline/lib_public_inline.c2t
+++ b/test/c_generator/functions/inline/lib_public_inline.c2t
@@ -36,12 +36,12 @@ fn i32 test_fn(Handler a, i32** b) {
 
 // @expect{atleast, test1.h}
 
-typedef void (*test1_Handler)(int32_t* _arg0);
+typedef void (*test1_Handler)(int* _arg0);
 
 static inline
-int32_t test1_test_fn(test1_Handler a, int32_t** b)
+int test1_test_fn(test1_Handler a, int** b)
 {
-  int32_t c[4];
+  int c[4];
   a(*b);
   return 123;
 }

--- a/test/c_generator/functions/single_module.c2t
+++ b/test/c_generator/functions/single_module.c2t
@@ -45,7 +45,7 @@ static void test1_nonpub1(void)
 {
 }
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
     return 0;
 }

--- a/test/c_generator/functions/struct_functions/assign_to_functype.c2t
+++ b/test/c_generator/functions/struct_functions/assign_to_functype.c2t
@@ -24,7 +24,7 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t x;
+  int x;
 };
 
 typedef void (*test_Func)(test_Type* _arg0);
@@ -35,7 +35,7 @@ static void test_Type_init(test_Type* _arg0)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Func f = test_Type_init;
   f = test_Type_init;

--- a/test/c_generator/functions/struct_functions/chained_struct_calls.c2t
+++ b/test/c_generator/functions/struct_functions/chained_struct_calls.c2t
@@ -40,7 +40,7 @@ typedef struct test_B_ test_B;
 typedef struct test_C_ test_C;
 
 struct test_A_ {
-    int32_t x;
+    int x;
 };
 
 struct test_B_ {
@@ -51,12 +51,12 @@ struct test_C_ {
   test_B b;
 };
 
-static uint32_t test_A_run(test_A* a);
+static u32 test_A_run(test_A* a);
 static test_A* test_B_getA(test_B* b);
 static test_B* test_C_getB(test_C* c);
 static void test_test1(void);
 
-static uint32_t test_A_run(test_A* a)
+static u32 test_A_run(test_A* a)
 {
   return 10;
 }
@@ -74,6 +74,6 @@ static test_B* test_C_getB(test_C* c)
 static void test_test1(void)
 {
   test_C c;
-  uint32_t n = test_A_run(test_B_getA(test_C_getB(&c)));
+  u32 n = test_A_run(test_B_getA(test_C_getB(&c)));
 }
 

--- a/test/c_generator/functions/struct_functions/global.c2t
+++ b/test/c_generator/functions/struct_functions/global.c2t
@@ -22,7 +22,7 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t member;
+  int member;
 };
 
 static test_Type test_t = { };
@@ -31,7 +31,7 @@ static void test_Type_init(test_Type* _arg0)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Type_init(&test_t);
   return 0;

--- a/test/c_generator/functions/struct_functions/local.c2t
+++ b/test/c_generator/functions/struct_functions/local.c2t
@@ -22,7 +22,7 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t member;
+  int member;
 };
 
 static void test_Type_init(test_Type* _arg0);
@@ -31,7 +31,7 @@ static void test_Type_init(test_Type* _arg0)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Type t;
   test_Type_init(&t);

--- a/test/c_generator/functions/struct_functions/local_arg.c2t
+++ b/test/c_generator/functions/struct_functions/local_arg.c2t
@@ -22,16 +22,16 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t member;
+  int member;
 };
 
-static void test_Type_init(test_Type* _arg0, int32_t _arg1);
+static void test_Type_init(test_Type* _arg0, int _arg1);
 
-static void test_Type_init(test_Type* _arg0, int32_t _arg1)
+static void test_Type_init(test_Type* _arg0, int _arg1)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Type t;
   test_Type_init(&t, 4);

--- a/test/c_generator/functions/struct_functions/local_member.c2t
+++ b/test/c_generator/functions/struct_functions/local_member.c2t
@@ -29,7 +29,7 @@ static void test_Type_init(test_Type* _arg0)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Outer o;
   test_Type_init(&o.t);

--- a/test/c_generator/functions/struct_functions/local_normal_callback.c2t
+++ b/test/c_generator/functions/struct_functions/local_normal_callback.c2t
@@ -20,13 +20,13 @@ public fn i32 main() {
 // @expect{atleast, cgen/build.c}
 typedef struct test_Type_ test_Type;
 
-typedef void (*test_Func)(int32_t n);
+typedef void (*test_Func)(int n);
 
 struct test_Type_ {
     test_Func init;
 };
 
-int32_t main(void)
+int main(void)
 {
   test_Type t;
   t.init(1);

--- a/test/c_generator/functions/struct_functions/local_ptr.c2t
+++ b/test/c_generator/functions/struct_functions/local_ptr.c2t
@@ -22,7 +22,7 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t member;
+  int member;
 };
 
 static void test_Type_init(test_Type* _arg0);
@@ -31,7 +31,7 @@ static void test_Type_init(test_Type* _arg0)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Type* t;
   test_Type_init(t);

--- a/test/c_generator/functions/struct_functions/local_static.c2t
+++ b/test/c_generator/functions/struct_functions/local_static.c2t
@@ -20,14 +20,14 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t member;
+  int member;
 };
 
-static void test_Type_init(int32_t n)
+static void test_Type_init(int n)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Type_init(1);
   return 0;

--- a/test/c_generator/functions/struct_functions/local_static_noarg.c2t
+++ b/test/c_generator/functions/struct_functions/local_static_noarg.c2t
@@ -20,14 +20,14 @@ public fn i32 main() {
 typedef struct test_Type_ test_Type;
 
 struct test_Type_ {
-  int32_t member;
+  int member;
 };
 
 static void test_Type_init(void)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
   test_Type_init();
   return 0;

--- a/test/c_generator/functions/struct_functions/opaque.c2t
+++ b/test/c_generator/functions/struct_functions/opaque.c2t
@@ -39,7 +39,7 @@ public fn i32 main() {
 // @expect{atleast, cgen/build.c}
 
 struct foo_Type_ {
-  int32_t x;
+  int x;
 };
 
 static void foo_Type_internal(foo_Type* t);
@@ -60,7 +60,7 @@ static void foo_Type_init(foo_Type* t)
   foo_Type_internal(t);
 }
 
-int32_t main(void)
+int main(void)
 {
   foo_Type* t = foo_Type_create();
   foo_Type_init(t);

--- a/test/c_generator/hello_world.c2t
+++ b/test/c_generator/hello_world.c2t
@@ -13,7 +13,7 @@ public fn i32 main(i32 argc, const char** argv) {
 }
 
 // @expect{atleast, cgen/build.c}
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
     printf("Hello World!\n");
     return 0;

--- a/test/c_generator/module/generate_single_module.c2t
+++ b/test/c_generator/module/generate_single_module.c2t
@@ -17,16 +17,16 @@ fn i32 sum(i32 c, i32 d) {
 }
 
 // @expect{atleast, cgen/build.c}
-static int32_t mod1_sum(int32_t a, int32_t b);
+static int mod1_sum(int a, int b);
 
-static int32_t mod1_sum(int32_t a, int32_t b)
+static int mod1_sum(int a, int b)
 {
     return a + b;
 }
 
-static int32_t mod2_sum(int32_t c, int32_t d);
+static int mod2_sum(int c, int d);
 
-static int32_t mod2_sum(int32_t c, int32_t d)
+static int mod2_sum(int c, int d)
 {
     return c + d;
 }

--- a/test/c_generator/module/static_single_module.c2t
+++ b/test/c_generator/module/static_single_module.c2t
@@ -17,8 +17,8 @@ public i32 y2;
 
 // @expect{atleast, cgen/build.c}
 
-static int32_t test1_x1 = 0;
-int32_t test1_y1 = 0;
+static int test1_x1 = 0;
+int test1_y1 = 0;
 
 // test2 symbols are not generated, because they are unused
 

--- a/test/c_generator/module/variable_fast_build.c2t
+++ b/test/c_generator/module/variable_fast_build.c2t
@@ -13,12 +13,12 @@ public char[] y2 = { 1, 2, 3, 4 }
 // @expect{atleast, cgen/test1.c}
 #include "test1.h"
 
-static int32_t test1_x1 = 0;
-int32_t test1_y1 = 0;
+static int test1_x1 = 0;
+int test1_y1 = 0;
 char test1_y2[4] = { 1, 2, 3, 4 };
 
 // @expect{atleast, cgen/test1.h}
 
-extern int32_t test1_y1;
+extern int test1_y1;
 extern char test1_y2[4];
 

--- a/test/c_generator/reorder_decls.c2t
+++ b/test/c_generator/reorder_decls.c2t
@@ -21,7 +21,7 @@ public fn i32 main() {
 typedef struct test_Foo_ test_Foo;
 
 struct test_Foo_ {
-   int32_t x;
+   int x;
 };
 
 typedef void (*test_Fn)(test_Foo* t);

--- a/test/c_generator/stmts/assert.c2t
+++ b/test/c_generator/stmts/assert.c2t
@@ -15,9 +15,9 @@ public fn i32 main() {
 }
 
 // @expect{atleast, cgen/build.c}
-int32_t main(void);
+int main(void);
 
-int32_t main(void)
+int main(void)
 {
    (test_a) || c2_assert("file1.c2", 7, "test.main", "a");
    (test_p) || c2_assert("file1.c2", 8, "test.main", "p");

--- a/test/c_generator/stmts/case_body.c2t
+++ b/test/c_generator/stmts/case_body.c2t
@@ -47,11 +47,11 @@ fn void nested_body(i32 arg) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
     switch (argc) {
     case 1: {
-        int32_t a = 10;
+        int a = 10;
         return a;
     }
     case 2:
@@ -62,24 +62,24 @@ int32_t main(int32_t argc, const char** argv)
     return 0;
 }
 
-static int32_t test_default_body(int32_t arg)
+static int test_default_body(int arg)
 {
     switch (arg) {
     case 1:
         break;
     default: {
-        int32_t a = 10;
+        int a = 10;
         return a;
      }
     }
     return 0;
 }
 
-static void test_nested_body(int32_t arg)
+static void test_nested_body(int arg)
 {
     switch (arg) {
     case 1: {
-        int32_t a = 10;
+        int a = 10;
         switch (a) {
         case 1:
             break;

--- a/test/c_generator/stmts/for_loop_ok.c2t
+++ b/test/c_generator/stmts/for_loop_ok.c2t
@@ -23,7 +23,7 @@ public fn i32 main(i32 argc, const char** argv) {
 // @expect{atleast, cgen/build.c}
 
 static void test_forever(void);
-int32_t main(int32_t argc, const char** argv);
+int main(int argc, const char** argv);
 
 static void test_forever(void)
 {
@@ -31,13 +31,13 @@ static void test_forever(void)
     }
 }
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 0;
+    int a = 0;
     for (a = 0; a < 10; a++) {
     }
 
-    for (int32_t b = 0; b < 10; b++) {
+    for (int b = 0; b < 10; b++) {
     }
 
     test_forever();

--- a/test/c_generator/stmts/if_stmt_expr.c2t
+++ b/test/c_generator/stmts/if_stmt_expr.c2t
@@ -24,14 +24,14 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 0;
+    int a = 0;
     if (a) {
     }
 
     if (a) {
-        int32_t b = 10;
+        int b = 10;
         if (b) return 0;
         else return 1;
     }

--- a/test/c_generator/stmts/local_array_decl.c2t
+++ b/test/c_generator/stmts/local_array_decl.c2t
@@ -20,12 +20,12 @@ public fn i32 main() {
 
 #define test_Size 20
 
-static int32_t test_board[20][20] = { };
+static int test_board[20][20] = { };
 
 static void test_func1(void);
 
 static void test_func1(void)
 {
-  int32_t board2[20][20];
+  int board2[20][20];
 }
 

--- a/test/c_generator/stmts/multi_condition_switch.c2t
+++ b/test/c_generator/stmts/multi_condition_switch.c2t
@@ -40,7 +40,7 @@ static void test_test1(test_Foo f)
    }
 }
 
-int32_t main(void)
+int main(void)
 {
     return 0;
 }

--- a/test/c_generator/stmts/multi_condition_switch_incr.c2t
+++ b/test/c_generator/stmts/multi_condition_switch_incr.c2t
@@ -39,7 +39,7 @@ static void test_test1(test_Foo f)
    }
 }
 
-int32_t main(void)
+int main(void)
 {
     return 0;
 }

--- a/test/c_generator/stmts/multi_def.c2t
+++ b/test/c_generator/stmts/multi_def.c2t
@@ -37,32 +37,32 @@ public fn i32 main() {
 typedef struct test_Point_ test_Point;
 
 struct test_Point_ {
-   int32_t x;
-   int32_t y;
+   int x;
+   int y;
 };
 
 static void test_Point_print(const test_Point* p);
-static void test_test1(int32_t i);
-int32_t main(void);
+static void test_test1(int i);
+int main(void);
 
 static void test_Point_print(const test_Point* p)
 {
 }
 
-static void test_test1(int32_t i)
+static void test_test1(int i)
 {
 }
 
-int32_t main(void)
+int main(void)
 {
-   int32_t x = 1, y = 2;
+   int x = 1, y = 2;
    test_Point p1 = { 1, 2 }, p2 = { 3, 4 };
    if (x > y) {
-      int32_t z = 1;
+      int z = 1;
       if (z) test_Point_print(&p1);
       else test_Point_print(&p2);
    }
 
-   for (int32_t i = 0, n = 32; i < n; i++) test_test1(i);
+   for (int i = 0, n = 32; i < n; i++) test_test1(i);
    return 0;
 }

--- a/test/c_generator/stmts/switch_stmt.c2t
+++ b/test/c_generator/stmts/switch_stmt.c2t
@@ -68,7 +68,7 @@ public fn i32 main(i32 argc, const char** argv) {
 // @expect{atleast, cgen/build.c}
 
 
-static void test_test1(int32_t i)
+static void test_test1(int i)
 {
     switch (i) {
     case 1:
@@ -92,7 +92,7 @@ static void test_test1(int32_t i)
     }
 }
 
-static void test_test2(int32_t i)
+static void test_test2(int i)
 {
     while (1) {
         switch (i) {
@@ -105,18 +105,18 @@ static void test_test2(int32_t i)
 }
 
 
-static void test_test3(int32_t i)
+static void test_test3(int i)
 {
    switch (i) {
    case 0:
       break;
    case 1: {
-      int32_t a = 10;
+      int a = 10;
       break;
    }
    case 2:
    {
-      int32_t b = 20;
+      int b = 20;
       break;
    }
    default:
@@ -124,9 +124,9 @@ static void test_test3(int32_t i)
    }
 }
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 0;
+    int a = 0;
     switch (a) {
     default:
         break;

--- a/test/c_generator/stmts/switch_string.c2t
+++ b/test/c_generator/stmts/switch_string.c2t
@@ -42,10 +42,10 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-static int32_t test_test1(char* str);
+static int test_test1(char* str);
 static void test_test2(char* str);
 
-static int32_t test_test1(char* str)
+static int test_test1(char* str)
 {
    switch (c2_strswitch(str, "\001a" "\002aa" "\003aaa" "\003bbb")) {
    case 2: // "a"

--- a/test/c_generator/stmts/while_stmt_expr.c2t
+++ b/test/c_generator/stmts/while_stmt_expr.c2t
@@ -21,16 +21,16 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-int32_t main(int32_t argc, const char** argv)
+int main(int argc, const char** argv)
 {
-    int32_t a = 0;
+    int a = 0;
     while (a) {
         if (argc == 1) continue;
         if (argc == 2) break;
     }
 
     {
-        int32_t b;
+        int b;
         while ((b = 0)) {
         }
     }

--- a/test/c_generator/types/alias_type.c2t
+++ b/test/c_generator/types/alias_type.c2t
@@ -16,7 +16,7 @@ type A struct {
 typedef struct test_A_ test_A;
 
 struct test_A_ {
-  int32_t x;
+  int x;
 };
 
 typedef test_A test_B;

--- a/test/c_generator/types/builtins.c2t
+++ b/test/c_generator/types/builtins.c2t
@@ -26,17 +26,17 @@ type S struct {
 typedef struct test_S_ test_S;
 struct test_S_ {
     bool b;
-    int8_t i_8;
-    int16_t i_16;
-    int32_t i_32;
-    int64_t i_64;
-    uint8_t u_8;
-    uint16_t u_16;
-    uint32_t u_32;
-    uint64_t u_64;
-    volatile uint8_t r_8;
-    volatile uint16_t r_16;
-    volatile uint32_t r_32;
-    volatile uint64_t r_64;
+    i8 i_8;
+    i16 i_16;
+    int i_32;
+    i64 i_64;
+    u8 u_8;
+    u16 u_16;
+    u32 u_32;
+    u64 u_64;
+    volatile u8 r_8;
+    volatile u16 r_16;
+    volatile u32 r_32;
+    volatile u64 r_64;
 };
 

--- a/test/c_generator/types/enum_func.c2t
+++ b/test/c_generator/types/enum_func.c2t
@@ -51,7 +51,7 @@ fn void test3() {
 
 // @expect{atleast, cgen/build.c}
 
-typedef uint8_t test_Foo;
+typedef u8 test_Foo;
 enum test_Foo {
    test_Foo_A,
    test_Foo_B,

--- a/test/c_generator/types/full_enum.c2t
+++ b/test/c_generator/types/full_enum.c2t
@@ -21,7 +21,7 @@ fn void test1() {
 
 // @expect{atleast, cgen/build.c}
 
-typedef uint8_t file1_State;
+typedef u8 file1_State;
 enum file1_State {
     file1_State_A,
     file1_State_B,

--- a/test/c_generator/types/func_types_full_struct.c2t
+++ b/test/c_generator/types/func_types_full_struct.c2t
@@ -15,7 +15,7 @@ type Struct struct {
 typedef struct test_Struct_ test_Struct;
 
 struct test_Struct_ {
-  int32_t x;
+  int x;
 };
 
 typedef test_Struct (*test_Callback)(void);

--- a/test/c_generator/types/keep_same_order.c2t
+++ b/test/c_generator/types/keep_same_order.c2t
@@ -16,13 +16,13 @@ type State enum i8 { A, B, C }
 // @expect{atleast, cgen/build.c}
 typedef struct test_Point_ test_Point;
 
-typedef int32_t test_Number;
+typedef int test_Number;
 
 struct test_Point_ {
-    int32_t x;
+    int x;
 };
 
-typedef int8_t test_State;
+typedef i8 test_State;
 enum test_State {
   test_State_A,
   test_State_B,

--- a/test/c_generator/types/nested_structs.c2t
+++ b/test/c_generator/types/nested_structs.c2t
@@ -24,18 +24,18 @@ type Outer struct {
 // @expect{atleast, cgen/build.c}
 typedef struct test_Outer_ test_Outer;
 struct test_Outer_ {
-    int32_t x;
+    int x;
     struct {
-        int32_t x;
-        int32_t y;
+        int x;
+        int y;
     } a;
     struct {
-        int32_t z;
+        int z;
     };
     union {
-        int32_t c;
-        int16_t d;
-        int8_t e;
+        int c;
+        i16 d;
+        i8 e;
     };
 };
 

--- a/test/c_generator/types/nodeps_before_deps.c2t
+++ b/test/c_generator/types/nodeps_before_deps.c2t
@@ -16,11 +16,11 @@ type Faa i16;
 // @expect{atleast, cgen/build.c}
 typedef struct test_Foo_ test_Foo;
 
-typedef int32_t test_Bar;
+typedef int test_Bar;
 
 struct test_Foo_ {
     test_Bar b;
 };
 
-typedef int16_t test_Faa;
+typedef i16 test_Faa;
 

--- a/test/c_generator/types/opaque_order.c2t
+++ b/test/c_generator/types/opaque_order.c2t
@@ -18,7 +18,7 @@ typedef struct test_Priv_ test_Priv;
 typedef struct test_Public_ test_Public;
 
 struct test_Priv_ {
-    int32_t x;
+    int x;
 };
 
 struct test_Public_ {

--- a/test/c_generator/types/opaque_order_rev.c2t
+++ b/test/c_generator/types/opaque_order_rev.c2t
@@ -18,7 +18,7 @@ typedef struct test_Public_ test_Public;
 typedef struct test_Priv_ test_Priv;
 
 struct test_Priv_ {
-    int32_t x;
+    int x;
 };
 
 struct test_Public_ {

--- a/test/c_generator/types/opaque_struct.c2t
+++ b/test/c_generator/types/opaque_struct.c2t
@@ -13,6 +13,6 @@ public type Struct struct @(opaque) {
 typedef struct test_Struct_ test_Struct;
 
 struct test_Struct_ {
-    int32_t x;
+    int x;
 };
 

--- a/test/c_generator/types/public_before_non_public.c2t
+++ b/test/c_generator/types/public_before_non_public.c2t
@@ -10,7 +10,7 @@ type Foo i32;
 public type Bar i16;
 
 // @expect{atleast, cgen/build.c}
-typedef int32_t test_Foo;
+typedef int test_Foo;
 
-typedef int16_t test_Bar;
+typedef i16 test_Bar;
 

--- a/test/c_generator/types/qualifiers.c2t
+++ b/test/c_generator/types/qualifiers.c2t
@@ -12,6 +12,6 @@ const volatile u32 C = 2;
 // @expect{atleast, cgen/build.c}
 
 #define test_A 1
-static volatile uint16_t test_b = 0;
-static const volatile uint32_t test_C = 2;
+static volatile u16 test_b = 0;
+static const volatile u32 test_C = 2;
 

--- a/test/c_generator/types/should_reorder.c2t
+++ b/test/c_generator/types/should_reorder.c2t
@@ -27,7 +27,7 @@ typedef struct test_A_ test_A;
 typedef struct test_B_ test_B;
 
 struct test_B_ {
-    int32_t x;
+    int x;
 };
 
 typedef test_B test_C;

--- a/test/c_generator/types/struct_function_member.c2t
+++ b/test/c_generator/types/struct_function_member.c2t
@@ -22,16 +22,16 @@ fn void test1() {
 typedef struct test_Foo_ test_Foo;
 
 struct test_Foo_ {
-   int32_t a;
-   void (*cb1)(void* arg, int32_t a);
+   int a;
+   void (*cb1)(void* arg, int a);
 };
 
-static void test_callback(void* arg, int32_t a);
+static void test_callback(void* arg, int a);
 static test_Foo test_foo = { 3, test_callback };
 
 static void test_test1(void);
 
-static void test_callback(void* arg, int32_t a)
+static void test_callback(void* arg, int a)
 {
 }
 

--- a/test/c_generator/types/union.c2t
+++ b/test/c_generator/types/union.c2t
@@ -14,7 +14,7 @@ type Data union {
 typedef union test_Data_ test_Data;
 
 union test_Data_ {
-    int32_t a;
-    int8_t* b;
+    int a;
+    i8* b;
 };
 

--- a/test/c_generator/variables/elemsof.c2t
+++ b/test/c_generator/variables/elemsof.c2t
@@ -11,7 +11,7 @@ const i32 Amount = elemsof(numbers);
 
 // @expect{atleast, cgen/build.c}
 
-static int32_t test_numbers[4] = { 1, 2, 3, 4 };
+static int test_numbers[4] = { 1, 2, 3, 4 };
 
 #define test_Amount 4
 

--- a/test/c_generator/variables/init_with_array.c2t
+++ b/test/c_generator/variables/init_with_array.c2t
@@ -22,11 +22,11 @@ const i32[] N1 = { 1, 2, 3, 4 }
 typedef struct test_List_ test_List;
 
 struct test_List_ {
-  const int32_t* x;
-  uint32_t len;
+  const int* x;
+  u32 len;
 };
 
-static const int32_t test_N1[4] = { 1, 2, 3, 4 };
+static const int test_N1[4] = { 1, 2, 3, 4 };
 
 static const test_List test_Lists[1] = {
   { test_N1, 4 }

--- a/test/c_generator/variables/initialize_2d_array.c2t
+++ b/test/c_generator/variables/initialize_2d_array.c2t
@@ -8,5 +8,5 @@ module test;
 i32[3][2] a;
 
 // @expect{atleast, cgen/build.c}
-static int32_t test_a[3][2] = { };
+static int test_a[3][2] = { };
 

--- a/test/c_generator/variables/local_variable.c2t
+++ b/test/c_generator/variables/local_variable.c2t
@@ -13,6 +13,6 @@ fn void test1() {
 
 static void test_test1(void)
 {
-    static int32_t a = 10;
+    static int a = 10;
 }
 

--- a/test/c_generator/variables/should_initalize_globals.c2t
+++ b/test/c_generator/variables/should_initalize_globals.c2t
@@ -22,16 +22,16 @@ i32[2] is;
 typedef struct test_Foo_ test_Foo;
 
 struct test_Foo_ {
-    int32_t i;
-    int8_t* cp;
+    int i;
+    i8* cp;
     bool b;
 };
 
 static test_Foo test_f = { };
 
-static int32_t test_i = 0;
+static int test_i = 0;
 
 static test_Foo test_fs[2] = { };
 
-static int32_t test_is[2] = { };
+static int test_is[2] = { };
 

--- a/test/expr/assign_enum.c2t
+++ b/test/expr/assign_enum.c2t
@@ -23,7 +23,7 @@ public fn i32 main() {
 
 static test_State test_s0 = test_State_ON;
 
-int32_t main(void)
+int main(void)
 {
     test_State s1 = test_State_ON;
     if (s1 > test_State_OFF && s1 >= test_State_ON && s1 <= test_State_ON && s1 < test_State_OTHER && s1 == test_State_ON && s1 != test_State_OFF) s1 = test_State_OFF;

--- a/test/expr/assign_list.c2t
+++ b/test/expr/assign_list.c2t
@@ -36,12 +36,12 @@ public fn i32 main() {
 
 // @expect{atleast, cgen/build.c}
 
-static test_Point test_new_point(int32_t x, int32_t y)
+static test_Point test_new_point(int x, int y)
 {
     return (test_Point){ x, y };
 }
 
-int32_t main(void)
+int main(void)
 {
     printf("p0={ %d, %d }\n", test_p0.x, test_p0.y);
     test_Point p1;

--- a/test/functions/default_arguments.c2t
+++ b/test/functions/default_arguments.c2t
@@ -71,25 +71,25 @@ public fn void test1() {
 typedef struct test_S_ test_S;
 
 struct test_S_ {
-   int32_t x;
-   int32_t y;
+   int x;
+   int y;
 };
 
 static const char test_Str[13] = "dummy string";
 
 #define test_Default_bar 43
-static uint8_t test_bar_array[7] = "abcdef";
+static u8 test_bar_array[7] = "abcdef";
 
-static int32_t test_add(int32_t x, int32_t y);
+static int test_add(int x, int y);
 static void test_output(const char* msg);
 static void test_foo(const char* msg);
-static uint32_t test_bar1(uint32_t val);
-static uint32_t test_bar2(uint32_t val);
-static void test_S_init(test_S* s, int32_t x, int32_t y);
+static u32 test_bar1(u32 val);
+static u32 test_bar2(u32 val);
+static void test_S_init(test_S* s, int x, int y);
 static void test_S_print(test_S* s);
 static void test_test1(void);
 
-static int32_t test_add(int32_t x, int32_t y)
+static int test_add(int x, int y)
 {
    return x + y;
 }
@@ -104,17 +104,17 @@ static void test_foo(const char* msg)
    printf("%s\n", msg);
 }
 
-static uint32_t test_bar1(uint32_t val)
+static u32 test_bar1(u32 val)
 {
    return val;
 }
 
-static uint32_t test_bar2(uint32_t val)
+static u32 test_bar2(u32 val)
 {
    return val;
 }
 
-static void test_S_init(test_S* s, int32_t x, int32_t y)
+static void test_S_init(test_S* s, int x, int y)
 {
    s->x = x;
    s->y = y;

--- a/test/functions/func_param.c2t
+++ b/test/functions/func_param.c2t
@@ -20,16 +20,16 @@ public fn void test2() {
 }
 
 // @expect{atleast, cgen/build.c}
-static void test_test1(void* arg, void (*cb)(void* arg, int32_t a), int32_t a);
-static void test_callback(void* arg, int32_t a);
+static void test_test1(void* arg, void (*cb)(void* arg, int a), int a);
+static void test_callback(void* arg, int a);
 static void test_test2(void);
 
-static void test_test1(void* arg, void (*cb)(void* arg, int32_t a), int32_t a)
+static void test_test1(void* arg, void (*cb)(void* arg, int a), int a)
 {
    cb(arg, a);
 }
 
-static void test_callback(void* arg, int32_t a)
+static void test_callback(void* arg, int a)
 {
 }
 

--- a/test/functions/func_param_nested.c2t
+++ b/test/functions/func_param_nested.c2t
@@ -30,26 +30,26 @@ fn void test2() {
     test1(nil, nil, nil, 10);
 }
 // @expect{atleast, cgen/build.c}
-typedef void (*test_Cb1)(void* _arg0,  _arg1, int32_t _arg2);
-typedef bool (*test_Cb2)(int32_t _arg0, int32_t _arg1);
+typedef void (*test_Cb1)(void* _arg0,  _arg1, int _arg2);
+typedef bool (*test_Cb2)(int _arg0, int _arg1);
 
-static void test_callback1(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a);
+static void test_callback1(void* arg, bool (*_arg1)(int _arg0, int _arg1), int a);
 static test_Cb1 test_cb1 = test_callback1;
-static bool test_callback2(int32_t a, int32_t b);
+static bool test_callback2(int a, int b);
 static test_Cb2 test_cb2 = test_callback2;
-static void test_test1(void* arg, void (*cb)(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a), bool (*inner)(int32_t _arg0, int32_t _arg1), int32_t a);
+static void test_test1(void* arg, void (*cb)(void* arg, bool (*_arg1)(int _arg0, int _arg1), int a), bool (*inner)(int _arg0, int _arg1), int a);
 static void test_test2(void);
 
-static void test_callback1(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a)
+static void test_callback1(void* arg, bool (*_arg1)(int _arg0, int _arg1), int a)
 {
 }
 
-static bool test_callback2(int32_t a, int32_t b)
+static bool test_callback2(int a, int b)
 {
    return true;
 }
 
-static void test_test1(void* arg, void (*cb)(void* arg, bool (*_arg1)(int32_t _arg0, int32_t _arg1), int32_t a), bool (*inner)(int32_t _arg0, int32_t _arg1), int32_t a)
+static void test_test1(void* arg, void (*cb)(void* arg, bool (*_arg1)(int _arg0, int _arg1), int a), bool (*inner)(int _arg0, int _arg1), int a)
 {
    cb(arg, test_callback2, a);
    cb(arg, inner, a);

--- a/test/functions/func_param_unnamed.c2t
+++ b/test/functions/func_param_unnamed.c2t
@@ -13,5 +13,5 @@ fn void test1(void* arg,
 }
 
 // @expect{atleast, cgen/build.c}
-static void test_test1(void* arg, void (*_arg1)(void* arg, int32_t a), bool (*_arg2)(void* _arg0, char _arg1), int32_t a);
+static void test_test1(void* arg, void (*_arg1)(void* arg, int a), bool (*_arg2)(void* _arg0, char _arg1), int a);
 

--- a/test/functions/func_param_variadic.c2t
+++ b/test/functions/func_param_variadic.c2t
@@ -21,16 +21,16 @@ public fn void test2() {
 }
 
 // @expect{atleast, cgen/build.c}
-static void test_test1(void* arg, void (*cb)(void* arg, int32_t a, ...), int32_t a, ...);
-static void test_callback(void* arg, int32_t a, ...);
+static void test_test1(void* arg, void (*cb)(void* arg, int a, ...), int a, ...);
+static void test_callback(void* arg, int a, ...);
 static void test_test2(void);
 
-static void test_test1(void* arg, void (*cb)(void* arg, int32_t a, ...), int32_t a, ...)
+static void test_test1(void* arg, void (*cb)(void* arg, int a, ...), int a, ...)
 {
    cb(arg, a);
 }
 
-static void test_callback(void* arg, int32_t a, ...)
+static void test_callback(void* arg, int a, ...)
 {
 }
 

--- a/test/functions/named_arg.c2t
+++ b/test/functions/named_arg.c2t
@@ -56,7 +56,7 @@ static void test_foo1(const char* s);
 static void test_foo2(const char* s);
 static void test_foo3(const char* s);
 static void test_test1(const char* s);
-int32_t main(int32_t argc, char** argv);
+int main(int argc, char** argv);
 
 static bool test_check_case(const char* s, bool is_upper)
 {
@@ -96,7 +96,7 @@ static void test_test1(const char* s)
    printf("check_case(\"%s\", is_upper: false) -> %d\n", s, test_check_case(s, false));
 }
 
-int32_t main(int32_t argc, char** argv)
+int main(int argc, char** argv)
 {
    test_test1("Hello");
    test_test1("world");

--- a/test/init/init_call_ok.c2t
+++ b/test/init/init_call_ok.c2t
@@ -19,18 +19,18 @@ public fn i32 main() {
 typedef struct test_Foo_ test_Foo;
 
 struct test_Foo_ {
-   int32_t v;
+   int v;
 };
 
-static void test_Foo_init(test_Foo* f, int32_t v);
-int32_t main(void);
+static void test_Foo_init(test_Foo* f, int v);
+int main(void);
 
-static void test_Foo_init(test_Foo* f, int32_t v)
+static void test_Foo_init(test_Foo* f, int v)
 {
    f->v = v;
 }
 
-int32_t main(void)
+int main(void)
 {
    test_Foo foo; test_Foo_init(&foo, 1);
    return foo.v;

--- a/test/interface/incremental_array.c2t
+++ b/test/interface/incremental_array.c2t
@@ -22,7 +22,7 @@ i32[3] b;
 const u32 Size = 3;
 
 // @expect{atleast, aa.h}
-extern int32_t aa_b[3];
+extern int aa_b[3];
 
 #define aa_Size 3
 

--- a/test/interface/incremental_enum.c2t
+++ b/test/interface/incremental_enum.c2t
@@ -27,7 +27,7 @@ const u32 Size = 3;
 
 // @expect{atleast, aa.h}
 
-typedef uint8_t aa_Enum;
+typedef u8 aa_Enum;
 enum aa_Enum {
    aa_Enum_A,
    aa_Enum_B,

--- a/test/interface/multi_dimension_array.c2t
+++ b/test/interface/multi_dimension_array.c2t
@@ -21,7 +21,7 @@ const u32 Columns = 20;
 
 // @expect{atleast, aa.h}
 
-extern int32_t aa_array[10][20];
+extern int aa_array[10][20];
 
 #define aa_Rows 10
 #define aa_Columns 20

--- a/test/interface/multi_export.c2t
+++ b/test/interface/multi_export.c2t
@@ -51,7 +51,7 @@ aa.AA a1;
 typedef struct aa_AA_ aa_AA;
 
 struct aa_AA_ {
-    int32_t x;
+    int x;
 };
 
 void aa_foo(void);

--- a/test/interface/multi_file_module.c2t
+++ b/test/interface/multi_file_module.c2t
@@ -32,7 +32,7 @@ aa.Number n2;
 
 // @expect{atleast, aa.h}
 
-typedef int32_t aa_Number;
+typedef int aa_Number;
 
 // @expect{atleast, bb.h}
 

--- a/test/interface/multi_module.c2t
+++ b/test/interface/multi_module.c2t
@@ -44,12 +44,12 @@ type Enum enum i8 {
 fn aa.AA bb1(aa.AA* arg1);
 
 // @expect{atleast, aa.h}
-typedef int32_t aa_AA;
+typedef int aa_AA;
 
 #define aa_FIRST 1
 
 // @expect{atleast, bb.h}
-typedef int8_t bb_Enum;
+typedef i8 bb_Enum;
 enum bb_Enum {
     bb_Enum_One = aa_FIRST,
     bb_Enum_Two,

--- a/test/interface/multi_module_as.c2t
+++ b/test/interface/multi_module_as.c2t
@@ -45,12 +45,12 @@ fn aa.AA bb1(aa.AA* arg1);
 
 // @expect{atleast, aa.h}
 
-typedef int32_t aa_AA;
+typedef int aa_AA;
 
 #define aa_FIRST 1
 
 // @expect{atleast, bb.h}
-typedef int8_t bb_Enum;
+typedef i8 bb_Enum;
 enum bb_Enum {
     bb_Enum_One = aa_FIRST,
     bb_Enum_Two,

--- a/test/interface/multi_module_local.c2t
+++ b/test/interface/multi_module_local.c2t
@@ -44,12 +44,12 @@ type Enum enum i8 {
 fn aa.AA bb1(aa.AA* arg1);
 
 // @expect{atleast, aa.h}
-typedef int32_t aa_AA;
+typedef int aa_AA;
 
 #define aa_FIRST 1
 
 // @expect{atleast, bb.h}
-typedef int8_t bb_Enum;
+typedef i8 bb_Enum;
 enum bb_Enum {
     bb_Enum_One = aa_FIRST,
     bb_Enum_Two,

--- a/test/interface/nonpublic_by_nonconst_init.c2t
+++ b/test/interface/nonpublic_by_nonconst_init.c2t
@@ -19,5 +19,5 @@ module bb;
 i32 b;
 
 // @expect{atleast, bb.h}
-extern int32_t bb_b;
+extern int bb_b;
 

--- a/test/interface/public_by_array_expr.c2t
+++ b/test/interface/public_by_array_expr.c2t
@@ -26,7 +26,7 @@ const u32 Size = 10;
 // @expect{atleast, bb.h}
 #include "aa.h"
 
-extern int32_t bb_b[10];
+extern int bb_b[10];
 
 #define bb_Size 10
 

--- a/test/interface/public_by_enum_init.c2t
+++ b/test/interface/public_by_enum_init.c2t
@@ -26,7 +26,7 @@ type BB enum i8 {
 // @expect{atleast, bb.h}
 #include "aa.h"
 
-typedef int8_t bb_BB;
+typedef i8 bb_BB;
 enum bb_BB {
     bb_BB_BB1 = aa_AA,
 };

--- a/test/libs/source_lib/happy_flow.c2t
+++ b/test/libs/source_lib/happy_flow.c2t
@@ -14,15 +14,15 @@ public fn i32 main(i32 argc, const char** argv) {
 
 // @expect{atleast, cgen/build.c}
 
-static int32_t foo_test4(int32_t a);
-static int32_t foo_internal(int32_t a);
+static int foo_test4(int a);
+static int foo_internal(int a);
 
-static int32_t foo_test4(int32_t a)
+static int foo_test4(int a)
 {
    return 4 * foo_internal(a);
 }
 
-static int32_t foo_internal(int32_t a)
+static int foo_internal(int a)
 {
    return a + 1;
 }

--- a/test/types/incr_array_multifile.c2t
+++ b/test/types/incr_array_multifile.c2t
@@ -28,4 +28,4 @@ public fn i32 main()
 
 // @expect{atleast, cgen/build.c}
 
-static const int32_t foo_List[4] = { 10, 20, 30, 40 };
+static const int foo_List[4] = { 10, 20, 30, 40 };


### PR DESCRIPTION
* no longer use `int32_t` etc. in generated C code to avoid naming conflicts. Use `i8`, u8`, `i16`, `u16`, `int`, `u32`, `i64`, `u64`, `ssize_t`, `size_t`, `float` and `double` instead.
* use explicit `signed int` for bitfields to avoid implementation defined behavior on `int` bitfields