### PR TITLE
Language: add `when` statement to select code and definitions

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -511,6 +511,10 @@ fn bool Analyser.analyseGlobalDecl(Analyser* ma, Decl* d) {
     case Variable:
         ma.analyseGlobalVarDecl((VarDecl*)d);
         break;
+    case When:
+        // TODO: support this: dispatch to other lists
+        ma.error(d.getLoc(), "'when' blocks not supported at global scope");
+        break;
     }
 
     d.setChecked();

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -256,6 +256,8 @@ fn IdentifierKind Analyser.setExprFlags(Analyser* ma, Expr** e_ptr, Decl* d) {
             break;
         }
         break;
+    case When:
+        break;
     }
     return kind;
 }
@@ -650,6 +652,7 @@ fn void Analyser.get_best_match(Analyser* ma, const char* name1, usize len1, Str
     u32 num_members = s.getNumMembers();
     for (u32 i = 0; i < num_members; i++) {
         Decl* m = members[i];
+        if (m.isDisabled()) continue;
         u32 name_idx = m.getNameIdx();
         if (!name_idx) {
             // anonymous sub structure

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -410,6 +410,7 @@ fn void fillFieldInfo(StructTypeDecl* std, FillInfo* fi, u32 base_offset) {
 
     for (u32 i=0; i<num_members; i++) {
         Decl* d = members[i];
+        if (d.isDisabled()) continue;
         FieldInitField* f = &fi.fii.fields[fi.idx];
         f.member_idx = fi.member_idx;
         const StructMemberLayout* ml = &layout.members[i];
@@ -559,6 +560,7 @@ fn bool Analyser.analyseInitListStruct(Analyser* ma, InitListExpr* ile, QualType
     const StructLayout* layout = std.getLayout();
     u32 member_idx = 0;
     for (u32 i=0; i<numValues; i++) {
+        if (members[i].isDisabled()) continue;
         Expr* value = values[i];
 
         const StructMemberLayout* ml = &layout.members[member_idx];

--- a/analyser/module_analyser_member.c2
+++ b/analyser/module_analyser_member.c2
@@ -357,6 +357,7 @@ fn ValType decl2valtype(const Decl* d) {
     case EnumConstant:
     case FunctionType:
     case AliasType:
+    case When:
         break;
     case Variable:
         return LValue;

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -124,6 +124,9 @@ fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt** s_ptr, bool checkEffect) {
     case Assert:
         ma.analyseAssertStmt(s);
         return FlowNext;
+    case When:
+        flow = ma.analyseWhenStmt(s);
+        break;
     }
     if (!(flow & FlowNext)) ma.scope.setUnreachable();
     return flow;
@@ -289,6 +292,14 @@ fn QualType Analyser.analyseCondition(Analyser* ma, Stmt** s_ptr, const char* co
     return qt;
 }
 
+fn bool Analyser.checkWhen(Analyser* ma, Stmt* s) {
+    if (s.isWhen()) {
+        ma.error(s.getLoc(), "'when' statement must be braced in this context");
+        return false;
+    }
+    return true;
+}
+
 fn FlowBits Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
     FlowBits flow = FlowNext;
     IfStmt* i = (IfStmt*)s;
@@ -324,6 +335,7 @@ fn FlowBits Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
     if (!ok) goto done;
     // TODO: handle constant conditions
 
+    ma.checkWhen(i.getThen());
     ma.scope.enter(scope.Decl);
     flow = ma.analyseStmt(i.getThen2(), true);
     ma.scope.exit(ma.has_error);
@@ -331,6 +343,7 @@ fn FlowBits Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
     FlowBits flow2 = FlowNext;
     Stmt** else_stmt = i.getElse2();
     if (else_stmt) {
+        ma.checkWhen(*else_stmt);
         ma.scope.enter(scope.Decl);
         flow2 = ma.analyseStmt(else_stmt, true);
         ma.scope.exit(ma.has_error);
@@ -375,6 +388,7 @@ fn FlowBits Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
         if (qt.isInvalid()) goto done;
     }
 
+    ma.checkWhen(f.getBody());
     FlowBits flow2 = ma.analyseStmt(f.getBody2(), true);
     flow |= flow2 & (FlowReturn | FlowGoto | FlowNoReturn | FlowError);
     if (flow2 & FlowBreak) flow |= FlowNext;
@@ -402,6 +416,7 @@ fn FlowBits Analyser.analyseWhileStmt(Analyser* ma, Stmt* s) {
     }
 
     ma.scope.enter(scope.Break | scope.Continue | scope.Decl | scope.Control);
+    ma.checkWhen(w.getBody());
     FlowBits flow2 = ma.analyseStmt(w.getBody2(), true);
     ma.scope.exit(ma.has_error);
     flow |= flow2 & (FlowReturn | FlowGoto | FlowNoReturn | FlowError);
@@ -642,3 +657,38 @@ fn void Analyser.checkReturnAddrOfLocal(Analyser* ma, Expr* arg) {
     }
 }
 
+// when statement modelled after Odin and Nim
+fn FlowBits Analyser.analyseWhenStmt(Analyser* ma, Stmt* s) {
+    WhenStmt* w = (WhenStmt*)s;
+
+    QualType qt = ma.analyseConstExpr(w.getCond2(), true);
+    if (qt.isInvalid()) return FlowError;
+
+    Expr* cond = w.getCond();
+    if (!cond.isCtv()) {
+        ma.errorRange(cond.getLoc(), cond.getRange(), "'when' condition is not a compile-time value");
+        return FlowError;
+    }
+
+    Value v = ast.evalExpr(cond);
+    if (v.kind == Error) {
+        ma.errorRange(cond.getLoc(), cond.getRange(), "%s", v.error_msg);
+        return FlowError;
+    }
+    if (!v.isZero()) {
+        w.setTrue();
+        Stmt* thenStmt = w.getThen();
+        if (thenStmt.isCompound())
+            return ma.analyseCompoundStmt((CompoundStmt*)thenStmt);
+        else
+            return ma.analyseStmt(w.getThen2(), true);
+    } else
+    if (w.hasElse()) {
+        Stmt* elseStmt = w.getElse();
+        if (elseStmt.isCompound())
+            return ma.analyseCompoundStmt((CompoundStmt*)elseStmt);
+        else
+            return ma.analyseStmt(w.getElse2(), true);
+    }
+    return FlowNext;
+}

--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -27,10 +27,12 @@ fn void Analyser.analyseStructType(Analyser* ma, StructTypeDecl* d) {
         ma.checkStack[ma.checkIndex-1].usedPublic = false;
         ma.usedPublic = false;
     }
+
+    // Handle 'when' blocks: disable unselected members
+    if (d.hasWhen() && !ma.analyseStructTypeWhenBlocks(d)) return;
+
     NameMap names.init(d.getNumMembers());
-
     ma.analyseStructNames(d, &names);
-
     names.free();
 
     ma.analyseStructMembers(d);
@@ -59,6 +61,7 @@ fn void Analyser.analyseStructMembers(Analyser* ma, StructTypeDecl* d) {
 
     for (u32 i=0; i<count; i++) {
         Decl* member = members[i];
+        if (member.isDisabled()) continue;
         if (member.isVariable()) {
             VarDecl* vd = (VarDecl*)member;
             // Note: dont push to stack, because can self-ref to StructType
@@ -170,21 +173,19 @@ fn void Analyser.analyseStructMember(Analyser* ma, VarDecl* v) {
 }
 
 fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, NameMap* names) {
-    // note: already checked that struct doesn't have 0 members
     u32 count = d.getNumMembers();
     Decl** members = d.getMembers();
 
     for (u32 i=0; i<count; i++) {
         // there can more members in anonymous sub-structs
         Decl* member = members[i];
+        if (member.isDisabled()) continue;
         u32 name_idx = member.getNameIdx();
-
-        StructTypeDecl* sub = nil;
-        if (member.isStructType()) sub = (StructTypeDecl*)member;
 
         if (name_idx == 0) {
             // can be anonymous sub-struct/union or anonymous bit-field
             if (member.isStructType()) {
+                StructTypeDecl* sub = (StructTypeDecl*)member;
                 ma.analyseStructNames(sub, names);
             }
         } else {
@@ -197,6 +198,7 @@ fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, NameMap* na
             names.add(name_idx, member.getLoc());
 
             if (member.isStructType()) {
+                StructTypeDecl* sub = (StructTypeDecl*)member;
                 NameMap sub_names.init(sub.getNumMembers());
                 ma.analyseStructNames(sub, &sub_names);
                 sub_names.free();
@@ -205,3 +207,51 @@ fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, NameMap* na
     }
 }
 
+fn bool Analyser.resolveWhenDecl(Analyser* ma, WhenDecl* wd) {
+    QualType qt = ma.analyseConstExpr(wd.getCond2(), true);
+    if (qt.isInvalid()) return false;
+    Expr* cond = wd.getCond();
+    if (!cond.isCtv()) {
+        ma.errorRange(cond.getLoc(), cond.getRange(), "'when' condition is not a compile-time value");
+        return false;
+    }
+    Value v = ast.evalExpr(cond);
+    if (v.kind == Error) {
+        ma.errorRange(cond.getLoc(), cond.getRange(), "%s", v.error_msg);
+        return false;
+    }
+    if (!v.isZero()) wd.setTrue();
+    return true;
+}
+
+fn bool Analyser.analyseStructTypeWhenBlocks(Analyser* ma, StructTypeDecl* d) {
+    bool ok = true;
+    u32 count = d.getNumMembers();
+    Decl** members = d.getMembers();
+
+    for (u32 i = 0; i < count; i++) {
+        Decl* member = members[i];
+        if (member.isDisabled()) continue;
+        if (member.isStructType()) {
+            StructTypeDecl* sub = (StructTypeDecl*)member;
+            if (!ma.analyseStructTypeWhenBlocks(sub)) return false;
+        }
+        if (member.isWhenDecl()) {
+            WhenDecl* wd = (WhenDecl*)member;
+            if (!ma.resolveWhenDecl(wd)) return false;
+            member.setDisabled();
+            u32 then_count = wd.getThenCount();
+            u32 else_count = wd.getElseCount();
+            u32 from = i + 1;
+            u32 end1 = from + then_count;
+            if (wd.isTrue()) {
+                from += then_count;
+                end1 += else_count;
+            }
+            for (u32 j = from; j < end1; j++) {
+                members[j].setDisabled();
+            }
+        }
+    }
+    return ok;
+}

--- a/analyser/size_analyser.c2
+++ b/analyser/size_analyser.c2
@@ -37,6 +37,7 @@ fn void sizeOfUnion(StructTypeDecl* s) {
     Decl** members = s.getMembers();
     for (u32 i = 0; i < num_members; i++) {
         Decl* d = members[i];
+        if (d.isDisabled()) continue;
         TypeSize member = sizeOfType(d.getType());
         // TODO handle un-packed sub-structs
         u32 size = member.size;     // byte size of the current member
@@ -83,6 +84,7 @@ public fn void sizeOfStruct(StructTypeDecl* s) {
 
     for (u32 i = 0; i < num_members; i++) {
         Decl* d = members[i];
+        if (d.isDisabled()) continue;
         // Note: doesn't analyze the bit-field
         TypeSize member = sizeOfType(d.getType());
         StructMemberLayout* ml = &layout.members[i];

--- a/analyser/unused_checker.c2
+++ b/analyser/unused_checker.c2
@@ -108,6 +108,8 @@ fn void Checker.check(void* arg, Decl* d) {
     case Variable:
         if (c.warnings.no_unused_variable) return;
         break;
+    case When:
+        return;
     }
     if (!used && !d.hasAttrUnused() && !d.isExported()) {
         c.diags.warn(d.getLoc(), "unused %s '%s'", d.getKindName(), c.getFullName(d));
@@ -156,6 +158,7 @@ fn void Checker.checkStructMembers(Checker* c, Decl* d) {
     Decl** members = std.getMembers();
     for (u32 i=0; i<num_members; i++) {
         Decl* member = members[i];
+        if (member.isDisabled()) continue;
         if (member.isStructType()) {
             c.checkStructMembers(member);
         } else {

--- a/ast/ast_evaluator.c2
+++ b/ast/ast_evaluator.c2
@@ -549,6 +549,7 @@ fn Cont Stmt.eval(Stmt* s, Evaluator* sf) {
     case Decl:        return ((DeclStmt*)s).eval(sf);
     case Asm:         return ((AsmStmt*)s).eval(sf);
     case Assert:      return ((AssertStmt*)s).eval(sf);
+    case When:        return ((WhenStmt*)s).eval(sf);
     }
     return Abort;
 }
@@ -752,5 +753,11 @@ fn Cont AssertStmt.eval(AssertStmt* s, Evaluator* sf) {
         // TODO assertion string should be computed at parse time
         return sf.error("assertion failed");
     }
+    return Normal;
+}
+
+fn Cont WhenStmt.eval(WhenStmt* s, Evaluator* sf) {
+    if (s.isTrue()) return s.getThen().eval(sf);
+    if (s.hasElse()) return s.getElse().eval(sf);
     return Normal;
 }

--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -31,6 +31,7 @@ public type DeclKind enum u8 (const char* const name) {
     FunctionType  : { "FunctionType" },
     AliasType     : { "AliasTypeDecl" },
     Variable      : { "VarDecl" },
+    When          : { "When" },
 }
 
 public type DeclCheckState enum u8 (const char* const name) {
@@ -51,9 +52,9 @@ type DeclBits struct {
     u32 is_external : 1;    // in external lib
     u32 is_generated : 1;   // for globals, can be used by generators
     u32 has_gen_idx : 1;
+    u32 is_disabled : 1;    // potentially merge with check_state
 }
-
-const u32 NumDeclBits = 15;  // should match bitfields above
+const u32 NumDeclBits = 16;  // should match bitfields above
 
 public type Decl struct @(opaque) {
     union {
@@ -64,6 +65,7 @@ public type Decl struct @(opaque) {
         EnumTypeDeclBits enumTypeDeclBits;
         EnumConstantDeclBits enumConstantDeclBits;
         VarDeclBits varDeclBits;
+        WhenDeclBits whenDeclBits;
         u32 bits;
     }
     union {
@@ -118,6 +120,9 @@ public fn bool Decl.isCheckInProgress(const Decl* d) {
 
 public fn void Decl.setChecked(Decl* d) { d.declBits.check_state = Checked; }
 public fn void Decl.setCheckInProgress(Decl* d) { d.declBits.check_state = InProgress; }
+
+public fn void Decl.setDisabled(Decl* d) { d.declBits.is_disabled = true; }
+public fn bool Decl.isDisabled(const Decl* d) { return d.declBits.is_disabled; }
 
 public fn void Decl.setHasAttr(Decl* d) { d.declBits.has_attr = 1; }
 public fn bool Decl.hasAttr(const Decl* d) { return d.declBits.has_attr; }
@@ -175,6 +180,10 @@ public fn bool Decl.isFunctionType(const Decl* d) {
 
 public fn bool Decl.isVariable(const Decl* d) {
     return d.getKind() == Variable;
+}
+
+public fn bool Decl.isWhenDecl(const Decl* d) {
+    return d.getKind() == When;
 }
 
 fn const char* Decl.getName(const Decl* d) {
@@ -255,6 +264,7 @@ public fn bool Decl.isTypeDecl(const Decl* d) {
     case FunctionType: return true;
     case AliasType:    return true;
     case Variable:     break;
+    case When:         break;
     }
     return false;
 }
@@ -273,6 +283,7 @@ public fn const char* Decl.getKindName(const Decl* d) {
     case FunctionType: return "type";
     case AliasType:    return "type";
     case Variable:     return "variable";
+    case When:         return "when";
     }
     return "";
 }
@@ -360,6 +371,9 @@ fn void Decl.print(const Decl* d, string_buffer.Buf* out, u32 indent) {
         break;
     case Variable:
         VarDecl.print((VarDecl*)d, out, indent);
+        break;
+    case When:
+        WhenDecl.print((WhenDecl*)d, out, indent);
         break;
     }
 }

--- a/ast/decl_list.c2
+++ b/ast/decl_list.c2
@@ -72,6 +72,11 @@ public fn Decl* DeclList.get(const DeclList* l, u32 idx) @(unused) {
     return l.data[idx];
 }
 
+public fn void DeclList.set(const DeclList* l, u32 idx, Decl* d) {
+    assert(idx < l.count);
+    l.data[idx] = d;
+}
+
 public fn Decl** DeclList.getData(const DeclList* l) {
     return l.data;
 }

--- a/ast/member_expr.c2
+++ b/ast/member_expr.c2
@@ -217,6 +217,7 @@ public fn IdentifierKind MemberExpr.getIdentifierKind(const MemberExpr* e) {
     case FunctionType:  return Type;
     case AliasType:     return Type;
     case Variable:      return Var;
+    case When:          break;
     }
 
     return Unresolved;

--- a/ast/stmt.c2
+++ b/ast/stmt.c2
@@ -34,6 +34,7 @@ public type StmtKind enum u8 (const char* const name) {
     Decl         : { "DeclStmt" },
     Asm          : { "Asm" },
     Assert       : { "AssertStmt" },
+    When         : { "When" },
 }
 
 type StmtBits struct {
@@ -54,6 +55,7 @@ public type Stmt struct @(opaque) {
         LabelStmtBits labelStmtBits;
         ReturnStmtBits returnStmtBits;
         SwitchStmtBits switchStmtBits;
+        WhenStmtBits whenStmtBits;
 
         ExprBits exprBits;
         ArrayDesignatedInitExprBits arrayDesignatedInitExprBits;
@@ -116,6 +118,8 @@ fn Stmt* Stmt.instantiate(Stmt* s, Instantiator* inst) {
         return AsmStmt.instantiate((AsmStmt*)s, inst);
     case Assert:
         return AssertStmt.instantiate((AssertStmt*)s, inst);
+    case When:
+        return WhenStmt.instantiate((WhenStmt*)s, inst);
     }
     s.dump();
     assert(0);
@@ -143,6 +147,10 @@ public fn bool Stmt.isDecl(const Stmt* s) {
 
 public fn bool Stmt.isLabel(const Stmt* s) {
     return s.getKind() == Label;
+}
+
+public fn bool Stmt.isWhen(const Stmt* s) {
+    return s.getKind() == When;
 }
 
 public fn SrcLoc Stmt.getLoc(const Stmt* s) {
@@ -201,6 +209,9 @@ fn void Stmt.print(const Stmt* s, string_buffer.Buf* out, u32 indent) {
         break;
     case Assert:
         AssertStmt.print((AssertStmt*)s, out, indent);
+        break;
+    case When:
+        WhenStmt.print((WhenStmt*)s, out, indent);
         break;
     }
 }

--- a/ast/struct_type_decl.c2
+++ b/ast/struct_type_decl.c2
@@ -28,6 +28,7 @@ type StructTypeDeclBits struct {
     u32 attr_packed : 1;
     u32 attr_opaque : 1;
     u32 attr_notypedef : 1;
+    u32 has_when : 1;
 }
 
 public type FieldInitInfo struct {
@@ -109,6 +110,7 @@ public fn StructTypeDecl* StructTypeDecl.create(ast_context.Context* c,
                                                   u32 ast_idx,
                                                   bool is_struct,
                                                   bool is_global,
+                                                  bool has_when,
                                                   Decl** members,
                                                   u32 num_members)
 {
@@ -122,6 +124,7 @@ public fn StructTypeDecl* StructTypeDecl.create(ast_context.Context* c,
     d.base.init(StructType, name, loc, is_public, qt, ast_idx);
     d.base.structTypeDeclBits.is_struct = is_struct;
     d.base.structTypeDeclBits.is_global = is_global;
+    d.base.structTypeDeclBits.has_when = has_when;
 
     if (!is_global) d.base.setUsed(); // set sub-structs to used
 
@@ -154,8 +157,12 @@ public fn u32 StructTypeDecl.getNumMembers(const StructTypeDecl* d) {
 }
 
 public fn Decl** StructTypeDecl.getMembers(StructTypeDecl* d) {
-    // NOTE: doesn't check if present!
     return d.members;
+}
+
+public fn Decl* StructTypeDecl.getMember(const StructTypeDecl* d, u32 i) {
+    // NOTE: doesn't check if present!
+    return d.members[i];
 }
 
 public fn bool StructTypeDecl.isStruct(const StructTypeDecl* d) {
@@ -164,6 +171,10 @@ public fn bool StructTypeDecl.isStruct(const StructTypeDecl* d) {
 
 public fn bool StructTypeDecl.isUnion(const StructTypeDecl* d) {
     return !d.base.structTypeDeclBits.is_struct;
+}
+
+public fn bool StructTypeDecl.hasWhen(const StructTypeDecl* d) {
+    return d.base.structTypeDeclBits.has_when;
 }
 
 fn FunctionDecl* StructTypeDecl.getStructFunction(const StructTypeDecl* d, u32 i) {
@@ -239,6 +250,7 @@ public fn Decl* StructTypeDecl.findAny(const StructTypeDecl* s, u32 name_idx) {
     u32 count = num_members;
     for (u32 i=0; i<num_members; i++) {
         Decl* d = s.members[i];
+        if (d.isDisabled()) continue;
         u32 member_name = d.getNameIdx();
 
         if (member_name == name_idx) {
@@ -268,6 +280,7 @@ public fn Decl* StructTypeDecl.findMember(const StructTypeDecl* s, u32 name_idx,
     u32 count = s.getNumMembers();
     for (u32 i=0; i<count; i++) {
         Decl* d = s.members[i];
+        if (d.isDisabled()) continue;
         u32 member_name = d.getNameIdx();
 
         if (member_name == name_idx) {
@@ -314,6 +327,7 @@ public fn u32 StructTypeDecl.getDesigMemberCount(const StructTypeDecl* d) {
 
     for (u32 i=0; i<d.num_members; i++) {
         Decl* m = d.members[i];
+        if (m.isDisabled()) continue;
         u32 member_name = m.getNameIdx();
         if (member_name == 0) {
             count--;
@@ -357,15 +371,20 @@ fn void StructTypeDecl.print(const StructTypeDecl* d, string_buffer.Buf* out, u3
     out.newline();
 
     for (u32 i=0; i<d.num_members; i++) {
+        Decl* m = d.members[i];
         out.indent(indent + 1);
         out.color(col_Calc);
-        const StructMemberLayout* ml = &layout.members[i];
-        out.print("offset=%d size=%d", ml.offset, ml.size);
-        if (ml.is_bitfield) {
-            out.print(" bitfield(%d, %d, %d)", ml.bitfield_offset, ml.bitfield_width, ml.bitfield_signed);
+        if (m.isDisabled()) {
+            out.add("disabled");
+        } else {
+            const StructMemberLayout* ml = &layout.members[i];
+            out.print("offset=%d size=%d", ml.offset, ml.size);
+            if (ml.is_bitfield) {
+                out.print(" bitfield(%d, %d, %d)", ml.bitfield_offset, ml.bitfield_width, ml.bitfield_signed);
+            }
         }
         out.newline();
-        d.members[i].print(out, indent + 1);
+        m.print(out, indent + 1);
     }
 
 #if 1

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -53,6 +53,7 @@ static_assert(8, sizeof(CompoundStmt));
 static_assert(8, sizeof(ContinueStmt));
 static_assert(8, sizeof(FallthroughStmt));
 static_assert(8, sizeof(ReturnStmt));
+static_assert(24, sizeof(WhenStmt));
 
 static_assert(16, sizeof(Expr));
 static_assert(16, sizeof(BooleanLiteral));

--- a/ast/when_decl.c2
+++ b/ast/when_decl.c2
@@ -1,0 +1,68 @@
+/* Copyright 2022-2026 Bas van den Berg, Charlie Gordon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+import ast_context;
+import src_loc local;
+import string_buffer;
+
+type WhenDeclBits struct {
+    u32 : NumDeclBits;
+    u32 is_true : 1;
+}
+
+public type WhenDecl struct @(opaque) {
+    Decl base;
+    Expr* cond;
+    u32 then_count;
+    u32 else_count;
+}
+
+public fn WhenDecl* WhenDecl.create(ast_context.Context* c, SrcLoc loc, u32 ast_idx, Expr* cond, u32 then_count, u32 else_count)
+{
+    u32 size = sizeof(WhenDecl);
+    WhenDecl* d = c.alloc(size);
+    d.base.init(When, 0, loc, false, {}, ast_idx);
+    d.cond = cond;
+    d.then_count = then_count;
+    d.else_count = else_count;
+
+    //if (!is_global) d.base.setUsed(); // set sub-structs to used
+#if AstStatistics
+    Stats.addDecl(StructType, size);
+#endif
+    return d;
+}
+
+public fn Decl* WhenDecl.asDecl(WhenDecl* d) {
+    return &d.base;
+}
+
+public fn void WhenDecl.setTrue(WhenDecl* d) { d.base.whenDeclBits.is_true = true; }
+public fn bool WhenDecl.isTrue(const WhenDecl* d) { return d.base.whenDeclBits.is_true; }
+
+public fn Expr* WhenDecl.getCond(const WhenDecl* d) { return d.cond; }
+public fn Expr** WhenDecl.getCond2(WhenDecl* d) { return &d.cond; }
+public fn u32 WhenDecl.getThenCount(const WhenDecl* d) { return d.then_count; }
+public fn u32 WhenDecl.getElseCount(const WhenDecl* d) { return d.else_count; }
+
+fn void WhenDecl.print(const WhenDecl* d, string_buffer.Buf* out, u32 indent) {
+    d.base.printKind(out, indent, false);
+    d.base.printBits(out);
+    out.color(col_Calc);
+    out.print("true: %d, then: %d, else: %d\n", d.isTrue(), d.then_count, d.else_count);
+}
+

--- a/ast/when_stmt.c2
+++ b/ast/when_stmt.c2
@@ -1,0 +1,91 @@
+/* Copyright 2022-2026 Bas van den Berg, Charlie Gordon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+import ast_context;
+import src_loc local;
+import string_buffer;
+
+type WhenStmtBits struct {
+    u32 : NumStmtBits;
+    u32 is_true : 1;
+    u32 has_else : 1;
+}
+
+public type WhenStmt struct @(opaque) {
+    Stmt base;
+    Expr* cond;
+    Stmt* then;
+    Stmt*[0] else_stmt; // tail-allocated
+}
+
+public fn WhenStmt* WhenStmt.create(ast_context.Context* c, SrcLoc loc, Expr* cond, Stmt* then, Stmt* else_stmt) {
+    u32 size = sizeof(WhenStmt);
+    if (else_stmt) size += sizeof(Stmt*);
+
+    WhenStmt* s = c.alloc(size);
+    s.base.init(When, loc);
+    s.cond = cond;
+    s.then = then;
+
+    if (else_stmt) {
+        s.base.whenStmtBits.has_else = 1;
+        s.else_stmt[0] = else_stmt;
+    }
+#if AstStatistics
+    Stats.addStmt(When, size);
+#endif
+    return s;
+}
+
+fn Stmt* WhenStmt.instantiate(WhenStmt* s, Instantiator* inst) {
+    Expr* cond2 = s.cond.instantiate(inst);
+    Stmt* then2 = s.then.instantiate(inst);
+    Stmt* else2 = nil;
+    if (s.base.whenStmtBits.has_else) else2 = s.else_stmt[0].instantiate(inst);
+
+    return (Stmt*)WhenStmt.create(inst.c, s.base.loc, cond2, then2, else2);
+}
+
+public fn void WhenStmt.setTrue(WhenStmt* s) { s.base.whenStmtBits.is_true = true; }
+public fn bool WhenStmt.isTrue(const WhenStmt* s) { return s.base.whenStmtBits.is_true; }
+
+public fn Expr* WhenStmt.getCond(const WhenStmt* s) { return s.cond; }
+public fn Expr** WhenStmt.getCond2(WhenStmt* s) { return &s.cond; }
+
+public fn Stmt* WhenStmt.getThen(const WhenStmt* s) { return s.then; }
+public fn Stmt** WhenStmt.getThen2(WhenStmt* s) { return &s.then; }
+
+public fn bool WhenStmt.hasElse(const WhenStmt* s) { return s.base.whenStmtBits.has_else; }
+public fn Stmt* WhenStmt.getElse(const WhenStmt* s) {
+    if (s.base.whenStmtBits.has_else) return s.else_stmt[0];
+    return nil;
+}
+
+public fn Stmt** WhenStmt.getElse2(WhenStmt* s) {
+    if (s.base.whenStmtBits.has_else) return &s.else_stmt[0];
+    return nil;
+}
+
+fn void WhenStmt.print(const WhenStmt* s, string_buffer.Buf* out, u32 indent) {
+    s.base.printKind(out, indent);
+    out.newline();
+
+    s.cond.print(out, indent + 1);
+    s.then.print(out, indent + 1);
+    if (s.base.whenStmtBits.has_else) s.else_stmt[0].print(out, indent + 1);
+}
+

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -187,9 +187,9 @@ public fn void Buf.vprintf(Buf* buf, const char* format, va_list args) {
     buf.add2(tmp, (u32)len);
 }
 
-public fn void Buf.unindent(Buf* buf) {
-    u32 i = buf.indent_step;
-    while (i-- > 0 && buf.size_ && buf.data_[buf.size_ - 1] == ' ') buf.size_--;
+public fn void Buf.unindent(Buf* buf, u32 indent = 1) {
+    indent *= buf.indent_step;
+    while (indent-- > 0 && buf.size_ && buf.data_[buf.size_ - 1] == ' ') buf.size_--;
 }
 
 public fn void Buf.indent(Buf* buf, u32 indent) {

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -1257,3 +1257,6 @@ public fn Expr* Builder.actOnAlternate(Builder* b, Expr* original, Expr* generat
     return (Expr*)AlternateExpr.create(b.context, original, generated);
 }
 
+public fn Stmt* Builder.actOnWhenStmt(Builder* b, SrcLoc loc, Expr* cond, Stmt* then, Stmt* else_stmt) {
+    return (Stmt*)WhenStmt.create(b.context, loc, cond, then, else_stmt);
+}

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -246,6 +246,7 @@ public fn StructTypeDecl* Builder.actOnStructType(Builder* b,
                                                     bool is_public,
                                                     bool is_struct,
                                                     bool is_global,
+                                                    bool has_when,
                                                     Decl** members,
                                                     u32 num_members)
 {
@@ -257,6 +258,7 @@ public fn StructTypeDecl* Builder.actOnStructType(Builder* b,
                                               b.ast_idx,
                                               is_struct,
                                               is_global,
+                                              has_when,
                                               members,
                                               num_members);
     if (is_global) {
@@ -1259,4 +1261,8 @@ public fn Expr* Builder.actOnAlternate(Builder* b, Expr* original, Expr* generat
 
 public fn Stmt* Builder.actOnWhenStmt(Builder* b, SrcLoc loc, Expr* cond, Stmt* then, Stmt* else_stmt) {
     return (Stmt*)WhenStmt.create(b.context, loc, cond, then, else_stmt);
+}
+
+public fn WhenDecl* Builder.actOnWhenDecl(Builder* b, SrcLoc loc, Expr* cond, u32 then_count, u32 else_count) {
+    return WhenDecl.create(b.context, loc, b.ast_idx, cond, then_count, else_count);
 }

--- a/generator/ast_visitor.c2
+++ b/generator/ast_visitor.c2
@@ -226,6 +226,15 @@ fn void Visitor.handleStmt(Visitor* v, Stmt* s) {
         Expr* call = a.getCall();
         if (call) v.handleExpr(call);
         break;
+    case When:
+        WhenStmt* w = (WhenStmt*)s;
+        if (w.isTrue()) {
+            v.handleStmt(w.getThen());
+        } else
+        if (w.hasElse()) {
+            v.handleStmt(w.getElse());
+        }
+        break;
     }
 }
 

--- a/generator/ast_visitor.c2
+++ b/generator/ast_visitor.c2
@@ -58,6 +58,7 @@ public fn void Visitor.handle(Visitor* v, Decl* d) {
         u32 num_members = s.getNumMembers();
         Decl** members = s.getMembers();
         for (u32 i=0; i<num_members; i++) {
+            if (members[i].isDisabled()) continue;
             v.handle(members[i]);
         }
         break;
@@ -78,6 +79,8 @@ public fn void Visitor.handle(Visitor* v, Decl* d) {
         break;
     case Variable:
         v.handleVarDecl((VarDecl*)d);
+        break;
+    case When:
         break;
     }
 }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -443,6 +443,7 @@ fn void Generator.emitStruct(Generator* gen, string_buffer.Buf* out, Decl* d, u3
     u32 num_members = std.getNumMembers();
     Decl** members = std.getMembers();
     for (u32 i=0; i<num_members; i++) {
+        if (members[i].isDisabled()) continue;
         gen.emitStructMember(out, members[i], indent+1);
     }
 
@@ -789,6 +790,9 @@ fn void Generator.emitGlobalDecl(Generator* gen, Decl* d) {
         bool in_header = gen.emitGlobalVarDecl(f.buf, d);
         gen.addFragment(f, in_header);
         break;
+    case When:
+        // Should have been dispatched to other lists
+        break;
     }
 
     d.setGenerated();
@@ -1086,6 +1090,9 @@ fn void Generator.emitHeaderDecl(Generator* gen, string_buffer.Buf* out, Decl* d
         break;
     case Variable:
         gen.emitGlobalVarDecl(out, d);
+        break;
+    case When:
+        // Should have been dispatched to other lists
         break;
     }
 }

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -302,6 +302,9 @@ fn void Generator.emitMemberDecl(Generator* gen, string_buffer.Buf* out, Decl* d
         mc.need_dot = true;
         mc.is_local = true;
         break;
+    case When:
+        assert(0);
+        break;
     }
 }
 

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -198,6 +198,27 @@ fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 
         }
         out.add(";\n");
         break;
+    case When:
+        WhenStmt* w = (WhenStmt*)s;
+        Stmt* s1 = w.isTrue() ? w.getThen() : w.getElse();
+        if (s1) {
+            out.unindent(indent);
+            // do not create a block
+            if (s1.isCompound()) {
+                CompoundStmt* c = (CompoundStmt*)s1;
+                u32 count = c.getCount();
+                Stmt** stmts = c.getStmts();
+                for (u32 i = 0; i < count; i++) {
+                    gen.emitStmt(out, stmts[i], indent, true);
+                }
+            } else {
+                gen.emitStmt(out, s1, indent, true);
+            }
+        } else {
+            // no need for an empty statement because 'when' cannot appear as
+            // single statements in an `if`, `else`, `for` or `while` statement.
+        }
+        break;
     }
 }
 

--- a/generator/c/dep_finder.c2
+++ b/generator/c/dep_finder.c2
@@ -64,6 +64,8 @@ public fn void Finder.check(Finder* s, Decl* d) {
     case Variable:
         s.handleVarDecl((VarDecl*)d);
         break;
+    case When:
+        break;
     }
 }
 
@@ -99,6 +101,7 @@ fn void Finder.handleStruct(Finder* s, StructTypeDecl* d) {
     Decl** members = d.getMembers();
     for (u32 i=0; i<num_members; i++) {
         Decl* m = members[i];
+        if (m.isDisabled()) continue;
         if (m.isStructType()) {
             s.handleStruct((StructTypeDecl*)m);
         } else {

--- a/generator/c2i/c2i_generator_decl.c2
+++ b/generator/c2i/c2i_generator_decl.c2
@@ -101,6 +101,9 @@ fn void Generator.emitGlobalDecl(Generator* gen, Decl* d) {
     case Variable:
         gen.emitGlobalVarDecl(out, d);
         break;
+    case When:
+        // Should have been dispatched to other lists
+        return;
     }
     out.newline();
 }
@@ -285,15 +288,39 @@ fn void Generator.emitAliasTypeDecl(Generator* gen, string_buffer.Buf* out, cons
     out.add(";\n");
 }
 
-fn void Generator.emitStructMember(Generator* gen, string_buffer.Buf* out, Decl* d, u32 indent) {
-    if (d.isVariable()) {
-        out.indent(indent);
-        gen.emitVarDecl(out, (VarDecl*)d, true);
-        if (!out.endsWith('}')) out.add1(';');
-        out.newline();
-    } else {
-        assert(d.isStructType());
-        gen.emitStruct(out, d, indent);
+fn void Generator.emitStructBlock(Generator* gen, string_buffer.Buf* out, u32 indent,
+                                  Decl** members, u32 num_members)
+{
+    for (u32 i = 0; i < num_members; i++) {
+        Decl* d = members[i];
+        //if (d.isDisabled()) continue;
+        if (d.isWhenDecl()) {
+            WhenDecl* wd = (WhenDecl*)d;
+            out.indent(indent);
+            out.add("when (");
+            gen.emitExpr(out, wd.getCond());
+            out.add(") {\n");
+            u32 then_count = wd.getThenCount();
+            gen.emitStructBlock(out, indent+1, &members[i + 1], then_count);
+            u32 else_count = wd.getElseCount();
+            if (else_count) {
+                out.indent(indent);
+                out.add("} else {\n");
+                gen.emitStructBlock(out, indent+1, &members[i + 1 + then_count], else_count);
+            }
+            out.indent(indent);
+            out.add("}\n");
+            i += then_count + else_count;
+        } else
+        if (d.isVariable()) {
+            out.indent(indent + 1);
+            gen.emitVarDecl(out, (VarDecl*)d, true);
+            if (!out.endsWith('}')) out.add1(';');
+            out.newline();
+        } else {
+            assert(d.isStructType());
+            gen.emitStruct(out, d, indent+1);
+        }
     }
 }
 
@@ -314,13 +341,7 @@ fn void Generator.emitStruct(Generator* gen, string_buffer.Buf* out, const Decl*
         out.add(" @(opaque) {}\n");
     } else {
         out.add(" {\n");
-
-        u32 num_members = std.getNumMembers();
-        Decl** members = std.getMembers();
-        for (u32 i=0; i<num_members; i++) {
-            gen.emitStructMember(out, members[i], indent+1);
-        }
-
+        gen.emitStructBlock(out, indent, std.getMembers(), std.getNumMembers());
         out.indent(indent);
         out.add("}\n");
     }

--- a/generator/c2i/c2i_generator_stmt.c2
+++ b/generator/c2i/c2i_generator_stmt.c2
@@ -166,6 +166,46 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         gen.emitExpr(out, a.getInner());
         out.add(");\n");
         break;
+    case When:
+        WhenStmt* w = (WhenStmt*)s;
+#if 0
+        Stmt* s1 = w.isTrue() ? w.getThen() : w.getElse();
+        if (s1) {
+            out.unindent(indent);
+            // do not create a block
+            if (s1.isCompound()) {
+                CompoundStmt* c = (CompoundStmt*)s1;
+                u32 count = c.getCount();
+                Stmt** stmts = c.getStmts();
+                for (u32 i = 0; i < count; i++) {
+                    gen.emitStmt(stmts[i], indent, true);
+                }
+            } else {
+                gen.emitStmt(s1, indent, true);
+            }
+        } else {
+            // no need for an empty statement because 'when' cannot appear as
+            // single statements in an `if`, `else`, `for` or `while` statement.
+        }
+#else
+        out.add("when (");
+        gen.emitExpr(out, w.getCond());
+        out.add(") ");
+        Stmt* thenStmt = w.getThen();
+        gen.emitStmt(thenStmt, indent, true);
+        Stmt* elseStmt = w.getElse();
+        if (elseStmt) {
+            if (thenStmt.isCompound()) {
+                out.trim(1);
+                out.space();
+            } else {
+                out.indent(indent);
+            }
+            out.add("else ");
+            gen.emitStmt(elseStmt, indent, true);
+        }
+#endif
+        break;
     }
 }
 

--- a/generator/ir/field_struct_layouter.c2
+++ b/generator/ir/field_struct_layouter.c2
@@ -181,6 +181,7 @@ fn void FieldStructLayouter.finalizeExpr(FieldStructLayouter* l, const ast.Struc
     Ref dest_ref = base_ref;
 
     for (u32 i = 0; i < num_members; i++) {
+        if (std.getMember(i).isDisabled()) continue;
         const ast.StructMemberLayout* ml = &layout.members[i];
         //printf(" [%d|%d] offset %d  size %d\n", i, init_idx, ml.offset, ml.size);
 

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -727,6 +727,15 @@ fn void Generator.collectLocalVars(Generator* gen, Stmt* s) {
             }
         }
         break;
+    case When:
+        const WhenStmt* w = (WhenStmt*)s;
+        if (w.isTrue()) {
+            gen.collectLocalVars(w.getThen());
+        } else
+        if (w.hasElse()) {
+            gen.collectLocalVars(w.getElse());
+        }
+        break;
     default:
         break;
     }

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -594,6 +594,7 @@ fn void Generator.emitStructInitExpr(Generator* gen, const StackVar* var, const 
     u32 offset = 0;
     ir.Ref dest_ref = var.ref;
     for (i = 0; i < num_values; i++) {
+        if (std.getMember(i).isDisabled()) continue;
         const StructMemberLayout* ml = &layout.members[i];
         ir.Ref value_ref;
         gen.emitExpr(&value_ref, values[i]);
@@ -603,11 +604,11 @@ fn void Generator.emitStructInitExpr(Generator* gen, const StackVar* var, const 
             dest_ref = gen.ctx.addBinaryInstr(InstrKind.Add, dest_ref, offset_ref);
         }
         gen.ctx.addStoreInstr(size2type(ml.size), value_ref, dest_ref);
-
     }
 
     ir.Ref value_ref = gen.ctx.addIntegerConstant(0);
-    while (i < num_members) {
+    for (; i < num_members; i++) {
+        if (std.getMember(i).isDisabled()) continue;
         const StructMemberLayout* ml = &layout.members[i];
         if (ml.offset != 0) {
             ir.Ref offset_ref = gen.ctx.addIntegerConstant(ml.offset - offset);
@@ -615,7 +616,6 @@ fn void Generator.emitStructInitExpr(Generator* gen, const StackVar* var, const 
             dest_ref = gen.ctx.addBinaryInstr(InstrKind.Add, dest_ref, offset_ref);
         }
         gen.ctx.addStoreInstr(size2type(ml.size), value_ref, dest_ref);
-        i++;
     }
 }
 

--- a/generator/ir/ir_generator_stmt.c2
+++ b/generator/ir/ir_generator_stmt.c2
@@ -109,6 +109,15 @@ fn bool Generator.emitStmt(Generator* gen, const Stmt* s) {
     case Assert:
         //if (gen.enable_asserts) gen.emitAssertStmt(s);
         return true;
+    case When:
+        WhenStmt* w = (WhenStmt*)s;
+        if (w.isTrue()) {
+            gen.emitStmt(w.getThen());
+        } else
+        if (w.hasElse()) {
+            gen.emitStmt(w.getElse());
+        }
+        return true;
     }
     s.dump();
     assert(0); // TODO

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -63,6 +63,8 @@ fn Stmt* Parser.parseStmt(Parser* p) {
     case KW_void:
         // checkSemi, allowLocal, !isCondition
         return p.parseDeclStmt(true, true, false);
+    case KW_when:
+        return p.parseWhenStmt();
     case KW_while:
         return p.parseWhileStmt();
     default:
@@ -660,3 +662,20 @@ fn bool Parser.isDeclaration(Parser* p) {
     return false;
 }
 
+fn Stmt* Parser.parseWhenStmt(Parser* p) {
+    SrcLoc loc = p.tok.loc;
+    p.consumeToken();
+
+    p.expectAndConsume(LParen);
+    Expr* cond = p.parseExpr(); // p.parseConstantExpr()
+    p.expectAndConsume(RParen);
+    Stmt* then = p.parseStmt();
+
+    Stmt* else_stmt = nil;
+    if (p.tok.kind == KW_else) {
+        p.consumeToken();
+        else_stmt = p.parseStmt();
+    }
+
+    return p.builder.actOnWhenStmt(loc, cond, then, else_stmt);
+}

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -79,9 +79,10 @@ fn void Parser.parseStructType(Parser* p, bool is_struct, u32 name, SrcLoc loc, 
     u32 num_attr = p.parseOptionalAttributes();
 
     DeclList members.init();
+    bool has_when = false;
 
     if (p.tok.kind == LBrace) {
-        p.parseStructBlock(&members, is_public);
+        p.parseStructBlock(&members, is_public, true, &has_when);
     } else if (p.tok.kind == Semicolon) {
         if (!p.is_interface) p.error("undefined structs are only allowed in interface files");
         if (!p.builder.hasOpaqueAttr()) p.error("undefined structs must have the opaque attribute");
@@ -92,6 +93,7 @@ fn void Parser.parseStructType(Parser* p, bool is_struct, u32 name, SrcLoc loc, 
                                                   is_public,
                                                   is_struct,
                                                   true,
+                                                  has_when,
                                                   members.getData(),
                                                   members.size());
     members.free();
@@ -110,8 +112,9 @@ fn void Parser.checkMemberName(Parser* p) {
     }
 }
 
-fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
-    p.expectAndConsume(LBrace);
+fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public, bool need_braces, bool* has_whenp) {
+    if (p.tok.kind == LBrace) need_braces = true;
+    if (need_braces) p.expectAndConsume(LBrace);
 
     while (1) {
         //Syntax:
@@ -119,7 +122,13 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
         // struct_member ::= STRUCT <IDENTIFIER> LBRACE struct_block RBRACE.
         // struct_member ::= UNION <IDENTIFIER> LBRACE struct_block RBRACE.
 
-        if (p.tok.kind == RBrace) break;
+        if (need_braces && p.tok.kind == RBrace) break;
+
+        if (p.tok.kind == KW_when) {
+            *has_whenp = true;
+            p.parseStructWhenBlock(members, is_public, has_whenp);
+            goto next;
+        }
 
         if (p.tok.kind == KW_union || p.tok.kind == KW_struct) {
             bool is_struct = p.tok.kind == KW_struct;
@@ -136,18 +145,20 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             }
 
             DeclList sub_members.init();
+            bool has_when = false;
 
-            p.parseStructBlock(&sub_members, is_public);
+            p.parseStructBlock(&sub_members, is_public, true, &has_when);
             StructTypeDecl* member = p.builder.actOnStructType(name,
                                                                loc,
                                                                is_public,
                                                                is_struct,
                                                                false,
+                                                               has_when,
                                                                sub_members.getData(),
                                                                sub_members.size());
             sub_members.free();
             members.add(member.asDecl());
-            continue;
+            goto next;
         }
 
         if (p.tok.kind == KW_fn) {
@@ -218,11 +229,13 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             if (ref.isPointer() || ref.isArray())
                 p.error("pointer and array members must be defined separately");
         }
-semi_colon:
+    semi_colon:
         p.expectAndConsume(Semicolon);
+    next:
+        if (!need_braces) return;
     }
 
-    p.expectAndConsume(RBrace);
+    if (need_braces) p.expectAndConsume(RBrace);
 }
 
 fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
@@ -517,4 +530,25 @@ fn void Parser.parseTypedef(Parser* p, bool is_public) {
     u32 num_attr = p.parseOptionalAttributes();
     p.expectAndConsume(Semicolon);
     p.applyAttributes(d, num_attr);
+}
+
+fn void Parser.parseStructWhenBlock(Parser* p, DeclList* members, bool is_public, bool *has_whenp) {
+    SrcLoc loc = p.tok.loc;
+    p.consumeToken();
+
+    p.expectAndConsume(LParen);
+    Expr* cond = p.parseExpr(); // p.parseConstantExpr()
+    p.expectAndConsume(RParen);
+    u32 when_pos = members.size();
+    members.add(nil);
+    p.parseStructBlock(members, is_public, false, has_whenp);
+    u32 then_count = members.size() - when_pos - 1;
+    u32 else_count = 0;
+    if (p.tok.kind == KW_else) {
+        p.consumeToken();
+        p.parseStructBlock(members, is_public, false, has_whenp);
+        else_count = members.size() - then_count - when_pos - 1;
+    }
+    WhenDecl* wd = p.builder.actOnWhenDecl(loc, cond, then_count, else_count);
+    members.set(when_pos, wd.asDecl());
 }

--- a/parser/keywords.c2
+++ b/parser/keywords.c2
@@ -21,8 +21,8 @@ import token local;
 import string;
 
 public type Info struct {
-    // Note: should be big enough to hold all keywords (4+436+220 with alignment)
-    Kind[660] indexes;
+    // Note: should be big enough to hold all keywords (4+436+232 with alignment)
+    Kind[672] indexes;
     u32 max_index;
 }
 

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -145,6 +145,7 @@ public type Kind enum u8 (public const char* const name) {
     KW_type              : { "type" },
     KW_union             : { "union" },
     KW_volatile          : { "volatile" },
+    KW_when              : { "when" },
     KW_while             : { "while" },
     // only in raw mode
     Feat_if              : { "#if" },

--- a/plugins/deps_generator.c2
+++ b/plugins/deps_generator.c2
@@ -142,6 +142,7 @@ fn const char* Generator.getPrefixedName(const Generator* gen, const Decl* d) {
     case FunctionType:
     case AliasType:
     case Variable:
+    case When:
         break;
     }
     return gen.getName(d);
@@ -162,6 +163,7 @@ fn void Generator.on_decl(void* arg, Decl* d, bool global) {
         u32 num_members = s.getNumMembers();
         Decl** members = s.getMembers();
         for (u32 i=0; i<num_members; i++) {
+            if (members[i].isDisabled()) continue;
             Generator.on_decl(arg, members[i], false);
         }
         break;
@@ -188,6 +190,8 @@ fn void Generator.on_decl(void* arg, Decl* d, bool global) {
         VarDecl* v = (VarDecl*)d;
         gen.handleTypeRef(v.getTypeRef());
         break;
+    case When:
+        break;
     }
 
     gen.visitor.handle(d);
@@ -209,6 +213,7 @@ fn bool isGlobal(const Decl* d) {
     case FunctionType:
     case AliasType:
         return true;
+    case When:
     case Import:
         break;
     case StructType:

--- a/plugins/deps_generator_utils.c2
+++ b/plugins/deps_generator_utils.c2
@@ -1,0 +1,79 @@
+/* Copyright 2022-2026 Bas van den Berg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module deps_generator_utils;
+
+import ast local;
+
+import stdio local;
+
+public fn const char* getPrefixedName(const Decl* d) {
+    switch (d.getKind()) {
+    case Function:
+        const FunctionDecl* fd = (FunctionDecl*)d;
+        if (fd.hasPrefix()) {
+            static char[64] fullname;
+            snprintf(fullname, elemsof(fullname), "%s.%s", fd.getPrefixName(), d.getName());
+            return fullname;
+        }
+        break;
+    case Import:
+        break;
+    case StructType:
+        break;
+    case EnumType:
+        break;
+    case EnumConstant:
+        // TODO
+        break;
+    case FunctionType:
+        break;
+    case AliasType:
+        break;
+    case Variable:
+        break;
+    case When:
+        break;
+    }
+    return d.getName();
+}
+
+public fn bool isGlobal(const Decl* d) @(unused) {
+    switch (d.getKind()) {
+    case Function:
+        break;
+    case Import:
+        return false;
+    case StructType:
+        const StructTypeDecl* std = (StructTypeDecl*)d;
+        return std.isGlobal();
+    case EnumType:
+        break;
+    case EnumConstant:
+        break;
+    case FunctionType:
+        break;
+    case AliasType:
+        break;
+    case Variable:
+        const VarDecl* vd = (VarDecl*)d;
+        return vd.isGlobal();
+    case When:
+        // TODO: support global when blocks
+        return false;
+    }
+    return true;
+}
+

--- a/plugins/refs_generator.c2
+++ b/plugins/refs_generator.c2
@@ -166,6 +166,8 @@ fn void Generator.on_decl(void* arg, Decl* d, bool global) {
         break;
     case Variable:
         break;
+    case When:
+        break;
     }
 
     gen.visitor.handle(d);

--- a/recipe.txt
+++ b/recipe.txt
@@ -55,6 +55,7 @@ set ast
     ast/struct_type_decl.c2
     ast/var_decl.c2
     ast/var_decl_list.c2
+    ast/when_decl.c2
 
     # ast statements
     ast/stmt.c2

--- a/recipe.txt
+++ b/recipe.txt
@@ -71,6 +71,7 @@ set ast
     ast/return_stmt.c2
     ast/switch_case.c2
     ast/switch_stmt.c2
+    ast/when_stmt.c2
     ast/while_stmt.c2
 
     # ast expressions

--- a/test/c_generator/stmts/when_ok.c2t
+++ b/test/c_generator/stmts/when_ok.c2t
@@ -1,0 +1,33 @@
+// @recipe bin
+    $warnings no-unused
+    $backend c
+
+// @file{file1}
+module test;
+
+const i32 C = 10;
+
+public fn i32 main() {
+    // using compound statements
+    when (C == 10) {
+        i32 i = 10;
+    } else {
+        const char* p = nil;
+        const char* p = nil;    // duplicate definition not analysed
+    }
+    // using single statements
+    when (sizeof(i) == 4)
+        return 0;
+    else
+        return p * p;    // invalid operands not analysed
+}
+
+// @expect{atleast, cgen/build.c}
+int main(void);
+
+int main(void)
+{
+    int i = 10;
+    return 0;
+}
+

--- a/test/stmt/when_bad1.c2
+++ b/test/stmt/when_bad1.c2
@@ -1,0 +1,10 @@
+module test;
+
+i32 c = 10;
+
+public fn i32 main() {
+    when (c == 10) {    // @error{'when' condition is not a compile-time value}
+        i32 i = 10;
+    }
+    return 0;
+}

--- a/test/stmt/when_bad2.c2
+++ b/test/stmt/when_bad2.c2
@@ -1,0 +1,9 @@
+module test;
+
+public fn i32 main() {
+    if (true)
+        when (true)    // @error{'when' statement must be braced in this context}
+            i32 j = 10;
+
+    return 0;
+}


### PR DESCRIPTION
* `when` has the same syntax as `if` but with these restrictions:
  * condition must be a compile time constant value
  * if true, only the *then* branch is analysed and generated
  * otherwise, only the *else* branch, if present, is analysed and generated
  * `when` blocks do not start a new scope
  * `when` cannot appear as the sole statement in `if`, `else`, `for` or `while`