### PR TITLE
Language: add labelled break and continue statements

### DIFF
--- a/analyser/label_vector.c2
+++ b/analyser/label_vector.c2
@@ -26,6 +26,10 @@ public type Label struct {
     SrcLoc loc;
     bool used;
     bool is_label; // otherwise goto
+    bool can_break;
+    bool can_continue;
+    bool has_break;
+    bool has_continue;
     ast.LabelStmt* stmt;
 }
 

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -96,13 +96,11 @@ fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt** s_ptr, bool checkEffect) {
         flow = ma.analyseSwitchStmt(s);
         break;
     case Break:
-        ma.analyseBreakStmt(s);
-        ma.scope.setUnreachable();
-        return FlowBreak;
+        flow = ma.analyseBreakStmt(s);
+        break;
     case Continue:
-        ma.analyseContinueStmt(s);
-        ma.scope.setUnreachable();
-        return FlowContinue;
+        flow = ma.analyseContinueStmt(s);
+        break;
     case Fallthrough:
         ma.analyseFallthroughStmt(s);
         return FlowNext;
@@ -110,9 +108,8 @@ fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt** s_ptr, bool checkEffect) {
         flow = ma.analyseLabelStmt(s);
         break;
     case Goto:
-        ma.analyseGotoStmt(s);
-        ma.scope.setUnreachable();
-        return FlowGoto;
+        flow = ma.analyseGotoStmt(s);
+        break;
     case Compound:
         ma.scope.enter(scope.Decl);
         flow = ma.analyseCompoundStmt((CompoundStmt*)s);
@@ -132,16 +129,41 @@ fn FlowBits Analyser.analyseStmt(Analyser* ma, Stmt** s_ptr, bool checkEffect) {
     return flow;
 }
 
-fn void Analyser.analyseBreakStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseBreakStmt(Analyser* ma, Stmt* s) {
     if (!ma.scope.allowBreak()) {
         ma.error(s.getLoc(), "'break' statement not in loop or switch statement");
+        return FlowError;
     }
+    BreakStmt* bs = (BreakStmt*)s;
+    if (bs.hasName()) {
+        Label* label = ma.labels.find(bs.getName());
+        if (label && label.can_break) {
+            label.has_break = true;
+            label.used = true;
+            return FlowGoto;
+        }
+        ma.error(s.getLoc(), "'break' label does match an enclosing loop or switch statement");
+        return FlowError;
+    }
+    return FlowBreak;
 }
 
-fn void Analyser.analyseContinueStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseContinueStmt(Analyser* ma, Stmt* s) {
     if (!ma.scope.allowContinue()) {
         ma.error(s.getLoc(), "'continue' statement not in loop statement");
+        return FlowError;
     }
+    ContinueStmt* cs = (ContinueStmt*)s;
+    if (cs.hasName()) {
+        Label* label = ma.labels.find(cs.getName());
+        if (label && label.can_continue) {
+            label.has_continue = true;
+            label.used = true;
+            return FlowGoto;
+        }
+        ma.error(s.getLoc(), "'continue' label does match an enclosing loop statement");
+    }
+    return FlowContinue;
 }
 
 fn void Analyser.analyseFallthroughStmt(Analyser* ma, Stmt* s) {
@@ -165,15 +187,42 @@ fn FlowBits Analyser.analyseLabelStmt(Analyser* ma, Stmt* s) {
         }
     } else {
         Label lab = { .name_idx = name, .loc = s.getLoc(), .is_label = true, .used = false, .stmt = ls }
+        if (Stmt* st = ls.getStmt()) {
+            switch (st.getKind()) {
+            case For:
+            case While:
+                lab.can_continue = true;
+                fallthrough;
+            case Switch:
+                lab.can_break = true;
+                break;
+            default:
+                break;
+            }
+        }
         ma.labels.add(lab);
     }
 
     Stmt** lss = ls.getStmt2();
     if (!lss) return FlowNext;
-    return ma.analyseStmt(lss, true);
+    FlowBits flow = ma.analyseStmt(lss, true);
+    // search again because label vector may have been reallocated
+    label = ma.labels.find(name);
+    if (label.has_break) {
+        ls.setUsed();
+        ls.setBreak();
+        flow |= FlowNext;
+    }
+    if (label.has_continue) {
+        ls.setUsed();
+        ls.setContinue();
+    }
+    label.can_break = false;
+    label.can_continue = false;
+    return flow;
 }
 
-fn void Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {
+fn FlowBits Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {
     GotoStmt* gs = (GotoStmt*)s;
     u32 name = gs.getNameIdx();
 
@@ -185,6 +234,7 @@ fn void Analyser.analyseGotoStmt(Analyser* ma, Stmt* s) {
         Label lab = { .name_idx = name, .loc = s.getLoc(), .is_label = false, .used = true, .stmt = nil }
         ma.labels.add(lab);
     }
+    return FlowGoto;
 }
 
 fn FlowBits Analyser.analyseCompoundStmt(Analyser* ma, CompoundStmt* c) {

--- a/ast/break_stmt.c2
+++ b/ast/break_stmt.c2
@@ -19,21 +19,43 @@ import ast_context;
 import string_buffer;
 import src_loc local;
 
-public type BreakStmt struct @(opaque) {
-    Stmt base;
+type BreakStmtBits struct {
+    u32 : NumStmtBits;
+    u32 has_name: 1;
 }
 
-public fn BreakStmt* BreakStmt.create(ast_context.Context* c, SrcLoc loc) {
-    BreakStmt* s = c.alloc(sizeof(BreakStmt));
+public type BreakStmt struct @(opaque) {
+    Stmt base;
+    u32[0] name_idx;
+}
+
+public fn BreakStmt* BreakStmt.create(ast_context.Context* c, SrcLoc loc, u32 name_idx) {
+    u32 size = sizeof(BreakStmt);
+    if (name_idx) size += sizeof(u32);
+    BreakStmt* s = c.alloc(size);
     s.base.init(Break, loc);
+    if (name_idx) {
+        s.base.breakStmtBits.has_name = true;
+        s.name_idx[0] = name_idx;
+    }
 #if AstStatistics
-    Stats.addStmt(Break, sizeof(BreakStmt));
+    Stats.addStmt(Break, size);
 #endif
     return s;
 }
 
+public fn bool BreakStmt.hasName(const BreakStmt* s) {
+    return s.base.breakStmtBits.has_name;
+}
+
+public fn u32 BreakStmt.getName(const BreakStmt* s) {
+    if (s.base.breakStmtBits.has_name) return s.name_idx[0];
+    return 0;
+}
+
 fn void BreakStmt.print(const BreakStmt* s, string_buffer.Buf* out, u32 indent) {
     s.base.printKind(out, indent);
+    if (s.hasName()) out.print(" %s", ast.idx2name(s.name_idx[0]));
     out.newline();
 }
 

--- a/ast/continue_stmt.c2
+++ b/ast/continue_stmt.c2
@@ -19,21 +19,43 @@ import ast_context;
 import string_buffer;
 import src_loc local;
 
-public type ContinueStmt struct @(opaque) {
-    Stmt base;
+type ContinueStmtBits struct {
+    u32 : NumStmtBits;
+    u32 has_name: 1;
 }
 
-public fn ContinueStmt* ContinueStmt.create(ast_context.Context* c, SrcLoc loc) {
-    ContinueStmt* s = c.alloc(sizeof(ContinueStmt));
+public type ContinueStmt struct @(opaque) {
+    Stmt base;
+    u32[0] name_idx;
+}
+
+public fn ContinueStmt* ContinueStmt.create(ast_context.Context* c, SrcLoc loc, u32 name_idx) {
+    u32 size = sizeof(ContinueStmt);
+    if (name_idx) size += sizeof(u32);
+    ContinueStmt* s = c.alloc(size);
     s.base.init(Continue, loc);
+    if (name_idx) {
+        s.base.breakStmtBits.has_name = true;
+        s.name_idx[0] = name_idx;
+    }
 #if AstStatistics
-    Stats.addStmt(Continue, sizeof(ContinueStmt));
+    Stats.addStmt(Continue, size);
 #endif
     return s;
 }
 
+public fn bool ContinueStmt.hasName(const ContinueStmt* s) {
+    return s.base.continueStmtBits.has_name;
+}
+
+public fn u32 ContinueStmt.getName(const ContinueStmt* s) {
+    if (s.base.continueStmtBits.has_name) return s.name_idx[0];
+    return 0;
+}
+
 fn void ContinueStmt.print(const ContinueStmt* s, string_buffer.Buf* out, u32 indent) {
     s.base.printKind(out, indent);
+    if (s.hasName()) out.print(" %s", ast.idx2name(s.name_idx[0]));
     out.newline();
 }
 

--- a/ast/label_stmt.c2
+++ b/ast/label_stmt.c2
@@ -22,6 +22,8 @@ import src_loc local;
 type LabelStmtBits struct {
     u32 : NumStmtBits;
     u32 is_used : 1;
+    u32 has_break : 1;
+    u32 has_continue : 1;
 }
 
 public type LabelStmt struct @(opaque) {
@@ -56,6 +58,22 @@ public fn bool LabelStmt.isUsed(const LabelStmt* s) {
     return s.base.labelStmtBits.is_used;
 }
 
+public fn bool LabelStmt.hasBreak(const LabelStmt* s) {
+    return s.base.labelStmtBits.has_break;
+}
+
+public fn void LabelStmt.setBreak(LabelStmt* s) {
+    s.base.labelStmtBits.has_break = true;
+}
+
+public fn bool LabelStmt.hasContinue(const LabelStmt* s) {
+    return s.base.labelStmtBits.has_continue;
+}
+
+public fn void LabelStmt.setContinue(LabelStmt* s) {
+    s.base.labelStmtBits.has_continue = true;
+}
+
 public fn const char* LabelStmt.getName(const LabelStmt* s) {
     return idx2name(s.name);
 }
@@ -78,11 +96,10 @@ fn void LabelStmt.print(const LabelStmt* s, string_buffer.Buf* out, u32 indent) 
     out.color(col_Value);
     out.space();
     out.add(idx2name(s.name));
-    if (!s.isUsed()) {
-        out.space();
-        out.color(col_Attr);
-        out.add("unused");
-    }
+    out.color(col_Attr);
+    if (!s.isUsed()) out.add(" unused");
+    if (s.hasBreak()) out.add(" has_break");
+    if (s.hasContinue()) out.add(" has_continue");
 
     out.newline();
     if (s.stmt)

--- a/ast/stmt.c2
+++ b/ast/stmt.c2
@@ -46,7 +46,9 @@ public type Stmt struct @(opaque) {
     union {
         StmtBits stmtBits;
         AsmStmtBits asmStmtBits;
+        BreakStmtBits breakStmtBits;
         CompoundStmtBits compoundStmtBits;
+        ContinueStmtBits continueStmtBits;
         DeclStmtBits declStmtBits;
         IfStmtBits ifStmtBits;
         LabelStmtBits labelStmtBits;

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -1034,12 +1034,12 @@ public fn Stmt* Builder.actOnAssertStmt(Builder* b, SrcLoc loc, Expr* inner, Exp
     return (Stmt*)AssertStmt.create(b.context, loc, inner, call);
 }
 
-public fn Stmt* Builder.actOnBreakStmt(Builder* b, SrcLoc loc) {
-    return (Stmt*)BreakStmt.create(b.context, loc);
+public fn Stmt* Builder.actOnBreakStmt(Builder* b, SrcLoc loc, u32 name_idx) {
+    return (Stmt*)BreakStmt.create(b.context, loc, name_idx);
 }
 
-public fn Stmt* Builder.actOnContinueStmt(Builder* b, SrcLoc loc) {
-    return (Stmt*)ContinueStmt.create(b.context, loc);
+public fn Stmt* Builder.actOnContinueStmt(Builder* b, SrcLoc loc, u32 name_idx) {
+    return (Stmt*)ContinueStmt.create(b.context, loc, name_idx);
 }
 
 public fn Stmt* Builder.actOnFallthroughStmt(Builder* b, SrcLoc loc) {

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -104,68 +104,27 @@ fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 
         }
         break;
     case While:
-        WhileStmt* w = (WhileStmt*)s;
-        Stmt* cond = w.getCond();
-        bool is_decl = cond.isDecl();
-        if (is_decl) {
-            out.add("{\n");
-            indent++;
-            DeclStmt* ds = (DeclStmt*)cond;
-            VarDecl* vd = ds.getDecl(0);
-            out.indent(indent);
-            gen.emitVarDecl(vd, out, false, true);
-            out.add(";\n");
-            out.indent(indent);
-            out.add("while ((");
-            out.add(vd.asDecl().getName());
-            // add init part
-            out.add(" = ");
-            Expr* ie = vd.getInit();
-            assert(ie);
-            gen.emitExpr(out, ie);
-            out.add(")) ");
-        } else {
-            assert(cond.isExpr());
-            out.add("while (");
-            gen.emitExpr(out, (Expr*)cond);
-            out.add(") ");
-        }
-        gen.emitStmt(out, w.getBody(), indent, true);
-        if (is_decl) {
-            indent--;
-            out.indent(indent);
-            out.add("}\n");
-        }
+        gen.emitWhileStmt(out, (WhileStmt*)s, indent);
         break;
     case For:
-        ForStmt* f = (ForStmt*)s;
-        out.add("for (");
-        Stmt* initStmt = f.getInit();
-        if (initStmt) {
-            gen.emitStmt(out, initStmt, 0, false);
-        }
-        out.add1(';');
-        if (f.getCond()) {
-            out.space();
-            gen.emitExpr(out, f.getCond());
-        }
-        out.add1(';');
-        Expr* cont = f.getCont();
-        if (cont) {
-            out.space();
-            gen.emitExpr(out, cont);
-        }
-        out.add(") ");
-        gen.emitStmt(out, f.getBody(), indent, true);
+        gen.emitForStmt(out, (ForStmt*)s, indent);
         break;
     case Switch:
         gen.emitSwitchStmt(out, (SwitchStmt*)s, indent);
         break;
     case Break:
-        out.add("break;\n");
+        BreakStmt* bs = (BreakStmt*)s;
+        if (bs.hasName())
+            out.print("goto break__%s;\n", gen.astPool.idx2str(bs.getName()));
+        else
+            out.add("break;\n");
         break;
     case Continue:
-        out.add("continue;\n");
+        ContinueStmt* cs = (ContinueStmt*)s;
+        if (cs.hasName())
+            out.print("goto continue__%s;\n", gen.astPool.idx2str(cs.getName()));
+        else
+            out.add("continue;\n");
         break;
     case Fallthrough:
         out.add("fallthrough;\n");
@@ -174,13 +133,32 @@ fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 
         out.unindent();
         LabelStmt* ls = (LabelStmt*)s;
         Stmt* stmt = ls.getStmt();
+        // TODO only if used
         out.add(ls.getName());
         out.add1(':');
         if (!stmt || stmt.isDecl()) {
             out.add1(';');
         }
         out.newline();
-        if (stmt) gen.emitStmt(out, stmt, indent, true);
+        if (stmt) {
+            switch (stmt.getKind()) {
+            case For:
+                out.indent(indent);
+                gen.emitForStmt(out, (ForStmt*)stmt, indent, ls);
+                break;
+            case While:
+                out.indent(indent);
+                gen.emitWhileStmt(out, (WhileStmt*)stmt, indent, ls);
+                break;
+            case Switch:
+                out.indent(indent);
+                gen.emitSwitchStmt(out, (SwitchStmt*)stmt, indent, ls);
+                break;
+            default:
+                gen.emitStmt(out, stmt, indent, true);
+                break;
+            }
+        }
         break;
     case Goto:
         GotoStmt* g = (GotoStmt*)s;
@@ -196,7 +174,6 @@ fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 
         for (u32 i=0; i<count; i++) {
             gen.emitStmt(out, stmts[i], indent+1, true);
         }
-
         out.indent(indent);
         out.add("}\n");
         break;
@@ -227,6 +204,117 @@ fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 
         }
         out.add(";\n");
         break;
+    }
+}
+
+fn void Generator.emitWhileStmt(Generator* gen, string_buffer.Buf* out, WhileStmt* w, u32 indent, LabelStmt* ls = nil) {
+    u32 break_name = 0;
+    u32 continue_name = 0;
+    if (ls) {
+        if (ls.hasBreak()) break_name = ls.getNameIdx();
+        if (ls.hasContinue()) continue_name = ls.getNameIdx();
+    }
+    Stmt* cond = w.getCond();
+    bool is_decl = cond.isDecl();
+    if (is_decl || break_name) {
+        out.add("{\n");
+        indent++;
+        out.indent(indent);
+    }
+    if (is_decl) {
+        DeclStmt* ds = (DeclStmt*)cond;
+        VarDecl* vd = ds.getDecl(0);
+        gen.emitVarDecl(vd, out, false, true);
+        out.add(";\n");
+        out.indent(indent);
+        out.add("while ((");
+        out.add(vd.asDecl().getName());
+        // add init part
+        out.add(" = ");
+        Expr* ie = vd.getInit();
+        assert(ie);
+        gen.emitExpr(out, ie);
+        out.add(")) ");
+    } else {
+        assert(cond.isExpr());
+        out.add("while (");
+        gen.emitExpr(out, (Expr*)cond);
+        out.add(") ");
+    }
+    gen.emitLoopBody(out, w.getBody(), indent, break_name, continue_name);
+    if (is_decl || break_name) {
+        indent--;
+        out.indent(indent);
+        out.add("}\n");
+    }
+}
+
+fn void Generator.emitForStmt(Generator* gen, string_buffer.Buf* out, ForStmt* f, u32 indent, LabelStmt* ls = nil) {
+    u32 break_name = 0;
+    u32 continue_name = 0;
+    if (ls) {
+        if (ls.hasBreak()) break_name = ls.getNameIdx();
+        if (ls.hasContinue()) continue_name = ls.getNameIdx();
+    }
+    if (break_name) {
+        out.add("{\n");
+        indent++;
+        out.indent(indent);
+    }
+    out.add("for (");
+    Stmt* initStmt = f.getInit();
+    if (initStmt) {
+        gen.emitStmt(out, initStmt, 0, false);
+    }
+    out.add1(';');
+    if (f.getCond()) {
+        out.space();
+        gen.emitExpr(out, f.getCond());
+    }
+    out.add1(';');
+    Expr* cont = f.getCont();
+    if (cont) {
+        out.space();
+        gen.emitExpr(out, cont);
+    }
+    out.add(") ");
+    gen.emitLoopBody(out, f.getBody(), indent, break_name, continue_name);
+    if (break_name) {
+        indent--;
+        out.indent(indent);
+        out.add("}\n");
+    }
+}
+
+fn void Generator.emitLoopBody(Generator* gen, string_buffer.Buf* out, Stmt* body,
+                               u32 indent, u32 break_name, u32 continue_name)
+{
+    u32 count = 1;
+    Stmt** stmts = &body;
+
+    if (body.isCompound()) {
+        CompoundStmt* c = (CompoundStmt*)body;
+        count = c.getCount();
+        stmts = c.getStmts();
+    } else {
+        if (!continue_name) {
+            gen.emitStmt(out, body, indent, true);
+            return;
+        }
+    }
+    out.add("{\n");
+    for (u32 i = 0; i < count; i++) {
+        gen.emitStmt(out, stmts[i], indent+1, true);
+    }
+    if (continue_name) {
+        out.indent(indent);
+        out.print("continue__%s:;\n", gen.astPool.idx2str(continue_name));
+    }
+    out.indent(indent);
+    out.add("}\n");
+    if (break_name) {
+        out.indent(indent - 1);
+        out.print("break__%s:;\n", gen.astPool.idx2str(break_name));
     }
 }
 
@@ -297,12 +385,14 @@ fn void Generator.emitAsmStmt(Generator* gen, string_buffer.Buf* out, AsmStmt* a
     out.add(";\n");
 }
 
-fn void Generator.emitSwitchStmt(Generator* gen, string_buffer.Buf* out, SwitchStmt* sw, u32 indent) {
+fn void Generator.emitSwitchStmt(Generator* gen, string_buffer.Buf* out, SwitchStmt* sw, u32 indent, LabelStmt* ls = nil) {
+    u32 break_name = 0;
+    if (ls && ls.hasBreak()) break_name = ls.getNameIdx();
     bool is_decl = sw.hasDecl();
-    if (is_decl) {
+    if (is_decl || break_name) {
         out.add("{\n");
         indent++;
-        gen.emitStmt(out, sw.getDecl(), indent, true);
+        if (is_decl) gen.emitStmt(out, sw.getDecl(), indent, true);
         out.indent(indent);
     }
     out.add("switch (");
@@ -318,8 +408,12 @@ fn void Generator.emitSwitchStmt(Generator* gen, string_buffer.Buf* out, SwitchS
     }
     out.indent(indent);
     out.add("}\n");
-    if (is_decl) {
+    if (is_decl || break_name) {
         indent--;
+        if (break_name) {
+            out.indent(indent);
+            out.print("break__%s:;\n", gen.astPool.idx2str(break_name));
+        }
         out.indent(indent);
         out.add("}\n");
     }

--- a/generator/c2i/c2i_generator_stmt.c2
+++ b/generator/c2i/c2i_generator_stmt.c2
@@ -94,10 +94,18 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         gen.emitSwitchStmt((SwitchStmt*)s, indent);
         break;
     case Break:
-        out.add("break;\n");
+        BreakStmt* bs = (BreakStmt*)s;
+        if (bs.hasName())
+            out.print("break %s;\n", gen.astPool.idx2str(bs.getName()));
+        else
+            out.add("break;\n");
         break;
     case Continue:
-        out.add("continue;\n");
+        ContinueStmt* cs = (ContinueStmt*)s;
+        if (cs.hasName())
+            out.print("continue %s;\n", gen.astPool.idx2str(cs.getName()));
+        else
+            out.add("continue;\n");
         break;
     case Fallthrough:
         out.add("fallthrough;\n");

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -386,17 +386,25 @@ fn Stmt* Parser.parseAssertStmt(Parser* p) {
 fn Stmt* Parser.parseBreakStmt(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
-
+    u32 name_idx = 0;
+    if (p.tok.kind == Identifier) {
+        name_idx = p.tok.name_idx;
+        p.consumeToken();
+    }
     p.expectAndConsume(Semicolon);
-    return p.builder.actOnBreakStmt(loc);
+    return p.builder.actOnBreakStmt(loc, name_idx);
 }
 
 fn Stmt* Parser.parseContinueStmt(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
-
+    u32 name_idx = 0;
+    if (p.tok.kind == Identifier) {
+        name_idx = p.tok.name_idx;
+        p.consumeToken();
+    }
     p.expectAndConsume(Semicolon);
-    return p.builder.actOnContinueStmt(loc);
+    return p.builder.actOnContinueStmt(loc, name_idx);
 }
 
 fn Stmt* Parser.parseFallthroughStmt(Parser* p) {

--- a/test/c_generator/stmts/label_break.c2t
+++ b/test/c_generator/stmts/label_break.c2t
@@ -1,0 +1,64 @@
+// @recipe bin
+    $warnings no-unused
+    $backend c
+
+// @file{file1}
+module test;
+
+fn void foo(i32 x) {
+top:
+    for (;;) {
+        for (;;) {
+            if (x) continue top;
+            break top;
+        }
+    }
+second:
+    while (1) {
+    third:
+        switch (x) {
+        case 0:
+        fourth:
+            for (;;) {
+                if (x) continue second;
+                break third;
+            }
+        }
+    }
+}
+
+// @expect{atleast, cgen/build.c}
+
+static void test_foo(int x);
+
+static void test_foo(int x)
+{
+top:
+   {
+      for (;;) {
+         for (;;) {
+            if (x) goto continue__top;
+            goto break__top;
+         }
+      continue__top:;
+      }
+   break__top:;
+   }
+second:
+   while (1) {
+   third:
+      {
+         switch (x) {
+         case 0:
+         fourth:
+            for (;;) {
+               if (x) goto continue__second;
+               goto break__third;
+            }
+         }
+      break__third:;
+      }
+   continue__second:;
+   }
+}
+

--- a/test/stmt/label_break_bad.c2
+++ b/test/stmt/label_break_bad.c2
@@ -1,0 +1,51 @@
+module test;
+
+fn void foo(i32 x) {
+top:
+    for (;;) {
+        for (;;) {
+            if (x) continue top2; // @error{'continue' label does match an enclosing loop statement}
+            break second;
+        }
+    }
+second:
+    while (1) {
+    third:
+        switch (x) {
+        case 0:
+        fourth:
+            for (;;) {
+                if (x) continue third;
+                break top;
+            }
+        }
+    }
+}
+
+fn void foo2(i32 x) {
+top:
+    while (x) {
+        for (;;) {
+            goto top;
+        }
+    }
+second: // unused label error not fagged because of other errors
+    for (;;) {
+        for (;;) {
+            break top; // @error{'break' label does match an enclosing loop or switch statement}
+        }
+    }
+}
+
+fn void foo3(i32 x) {
+    while (1) {
+    third:
+        switch (x) {
+        case 0:
+            for (;;) {
+                continue third; // @error{'continue' label does match an enclosing loop statement}
+            }
+            break;
+        }
+    }
+}


### PR DESCRIPTION
* `break` and `continue` can take the label of an enclosing statement to break or continue directly, bypassing the nested code flow.
* simplified flow analysis
* add tests