### PR TITLE
C-Generator: simplify output handling

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -714,7 +714,7 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
 
         // open file, copy contents to StringPool and close
         const char* filename = ma.astPool.idx2str(embed.value.text);
-        file_utils.File reader.init("", filename);
+        file_utils.File reader.init(filename);
         if (!reader.load()) {
             ma.error(embed.loc, "error opening embedded file '%s': %s", filename, reader.getError());
             return;

--- a/common/file/copy.c2
+++ b/common/file/copy.c2
@@ -30,12 +30,12 @@ public fn i32 copy_file(const char* source, const char* dest) {
     }
 
     // copy file
-    File src.init("", source);
+    File src.init(source);
 
     // TODO just open both and copy page-by-page (dont use reader/writer)
     if (!src.load()) return -1;
 
-    File dst.init("", dest);
+    File dst.init(dest);
     bool ok = dst.write(src.contents, src.contents_size);
 
     dst.close();

--- a/common/file/file_utils.c2
+++ b/common/file/file_utils.c2
@@ -65,50 +65,35 @@ fn usize copy_dirname(char *buf, usize size, const char* dir) {
     return pos;
 }
 
-// construct a path in a buffer from a directory name and a filename
+// construct a path in a buffer from a pathname, a filename and an extension
 // if the path fits in the destination array, a pointer to it is returned.
 // otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
-public fn const char* make_path(char *buf, usize size, const char* dir, const char* filename) {
+// both the filename and the extension can be nil or omitted
+public fn const char* make_path(char *buf, usize size, const char* path, const char* filename = nil, const char* ext = nil) {
     usize pos = 0;
-    if (*filename != '/') pos = copy_dirname(buf, size, dir);
-    if (pos < size) {
+    if (filename) {
+        if (*filename != '/') pos = copy_dirname(buf, size, path);
         pos += pstrcpy(buf + pos, size - pos, filename);
-        if (pos < size) return buf;
+        if (ext) pos += pstrcpy(buf + pos, size - pos, ext);
+    } else {
+        pos = pstrcpy(buf, size, path);
     }
+    if (pos < size) return buf;
     errno = ENAMETOOLONG;
     return nil;
 }
 
-// construct a path in a buffer from a directory name, a filename and an extension
-// if the path fits in the destination array, a pointer to it is returned.
-// otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
-public fn const char* make_path_ext(char *buf, usize size, const char* dir, const char* filename, const char* ext) {
-    usize pos = 0;
-    if (*filename != '/') pos = copy_dirname(buf, size, dir);
-    if (pos < size) {
-        pos += pstrcpy(buf + pos, size - pos, filename);
-        if (pos < size) {
-            pos += pstrcpy(buf + pos, size - pos, ext);
-            if (pos < size) return buf;
-        }
-    }
-    errno = ENAMETOOLONG;
-    return nil;
-}
-
-// construct a path in a buffer from a directory name, a subdirectory name and an extension
+// construct a path in a buffer from a directory name, a subdirectory name and a filename
 // if the path fits in the destination array, a pointer to it is returned.
 // otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
 public fn const char* make_path3(char *buf, usize size, const char* dir, const char* subdir, const char* filename) {
     usize pos = 0;
     if (*filename != '/') {
         if (*subdir != '/') pos = copy_dirname(buf, size, dir);
-        if (pos < size) pos += copy_dirname(buf + pos, size - pos, subdir);
+        pos += copy_dirname(buf + pos, size - pos, subdir);
     }
-    if (pos < size) {
-        pos += pstrcpy(buf + pos, size - pos, filename);
-        if (pos < size) return buf;
-    }
+    pos += pstrcpy(buf + pos, size - pos, filename);
+    if (pos < size) return buf;
     errno = ENAMETOOLONG;
     return nil;
 }
@@ -162,23 +147,12 @@ public type File struct @(unused) {
     void* contents;
 }
 
-public fn bool File.init(File* file, const char* dir, const char* filename) {
+public fn bool File.init(File* file, const char* dir, const char* filename = nil, const char* ext = nil) {
     file.handle = 0;
     file.error = 0;
     file.contents_size = 0;
     file.contents = nil;
-    if (!make_path(file.path, elemsof(file.path), dir, filename)) {
-        file.error = ENAMETOOLONG;
-        return false;
-    }
-    return true;
-}
-
-public fn bool File.init_ext(File* file, const char* dir, const char* filename, const char* ext) @(unused) {
-    if (!file.init(dir, filename)) return false;
-    u32 len = (u32)strlen(file.path);
-    len += pstrcpy(file.path + len, elemsof(file.path) - len, ext);
-    if (len >= elemsof(file.path)) {
+    if (!make_path(file.path, elemsof(file.path), dir, filename, ext)) {
         file.error = ENAMETOOLONG;
         return false;
     }

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -173,7 +173,7 @@ public fn i32 SourceMgr.addResource(SourceMgr* sm, const char* name, const void*
 }
 
 public fn i32 SourceMgr.loadFile(SourceMgr* sm, const char* filename, SrcLoc sloc) {
-    file_utils.File file.init("", filename);
+    file_utils.File file.init(filename);
     if (!file.load()) {
         char[256] tmp;
         *tmp = '\0';

--- a/compiler/compiler_libs.c2
+++ b/compiler/compiler_libs.c2
@@ -182,7 +182,7 @@ fn void Compiler.parseExternalModule(void* arg, ast.Module* m) {
     if (!m.isUsed()) return;
 
     char[file_utils.Max_path] filename;
-    if (!file_utils.make_path_ext(filename, elemsof(filename), c.current.getPath(), m.getName(), ".c2i"))
+    if (!file_utils.make_path(filename, elemsof(filename), c.current.getPath(), m.getName(), ".c2i"))
         return;
 
     i32 file_id = c.sm.loadFile(filename, 0);

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -72,7 +72,7 @@ fn void Options.free(Options *opts) {
 }
 
 fn void write_file_or_die(const char* filename, string_buffer.Buf* buf) {
-    file_utils.File file.init("", filename);
+    file_utils.File file.init(filename);
     if (!file.write(buf.data(), buf.size())) {
         console.error("c2c: cannot write to %s: %s", file.path, file.getError());
         exit(EXIT_FAILURE);

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -736,10 +736,7 @@ fn void Generator.emitGlobalDecl(Generator* gen, Decl* d) {
             gen.cur_function = fd;
             d.setGenerated();  // for recursive inline functions
             out.newline();
-            string_buffer.Buf* saved = gen.out;
-            gen.out = out;
-            gen.emitStmt((ast.Stmt*)fd.getBody(), 0, true);
-            gen.out = saved;
+            gen.emitStmt(out, (Stmt*)fd.getBody(), 0, true);
             out.newline();
             gen.cur_function = nil;
         } else {
@@ -835,8 +832,6 @@ fn void Generator.on_ast_decl(void* arg, AST* a) {
 
 fn void Generator.gen_member_type_func(Generator* gen, FunctionDecl* fd, string_buffer.Buf* out, const char* name) {
     // generate something like: void (*name)(void* arg)
-    Decl* d = (Decl*)fd;
-
     gen.emitTypePre(out, fd.getRType());
     out.print(" (*%s)", name);
     gen.emitFuncParams(fd, out);
@@ -900,17 +895,17 @@ fn void Generator.emitFuncParams(Generator* gen, FunctionDecl* fd, string_buffer
     for (u32 i=0; i<num_params; i++) {
         Decl* argx = (Decl*)params[i];
         if (i != 0) out.add(", ");
+        char[8] temp;
+        const char* name = argx.getName();
+        if (!name) {
+            snprintf(temp, elemsof(temp), "_arg%d", i);
+            name = temp;
+        }
         QualType qt = argx.getType();
         if (qt.isFunction()) {
             FunctionType* ft = qt.getFunctionType();
             FunctionDecl* fd2 = ft.getDecl();
             if (fd2.isParam()) {
-                const char* name = argx.getName();
-                char[8] temp;
-                if (!name) {
-                    snprintf(temp, elemsof(temp), "_arg%d", i);
-                    name = temp;
-                }
                 gen.gen_member_type_func(fd2, out, name);
                 continue;
             }
@@ -918,9 +913,7 @@ fn void Generator.emitFuncParams(Generator* gen, FunctionDecl* fd, string_buffer
 
         gen.emitTypePre(out, qt);
         out.space();
-        const char* name = argx.getName();
-        if (name) out.add(name);
-        else out.print("_arg%d", i);
+        out.add(name);
     }
     if (fd.isVariadic()) {
         if (num_params) out.add(", ");
@@ -938,15 +931,8 @@ fn void Generator.emitFunction(Generator* gen, FunctionDecl* fd) {
     gen.indent = 0;
     gen.gen_func_proto(fd, out);
     out.newline();
-
-    // work-around Stmts using gen.out
-    string_buffer.Buf* saved = gen.out;
-    gen.out = out;
-
-    gen.emitStmt((ast.Stmt*)fd.getBody(), 0, true);
+    gen.emitStmt(out, (Stmt*)fd.getBody(), 0, true);
     out.newline();
-
-    gen.out = saved;    // restore saved gen.out
     gen.addFragment(f, false);
 }
 
@@ -1049,12 +1035,11 @@ fn void Generator.on_header_decl(void* arg, Decl* d) {
     Generator* gen = arg;
     gen.deps.check(d);  // generate dependencies first
 
-    gen.emitHeaderDecl(d);
+    gen.emitHeaderDecl(gen.header, d);
     d.setGenerated();
 }
 
-fn void Generator.emitHeaderDecl(Generator* gen, Decl* d) {
-    string_buffer.Buf* out = gen.header;
+fn void Generator.emitHeaderDecl(Generator* gen, string_buffer.Buf* out, Decl* d) {
 
     // TODO refactor to common code with normal C generation (currently uses fragments)
     switch (d.getKind()) {
@@ -1064,7 +1049,7 @@ fn void Generator.emitHeaderDecl(Generator* gen, Decl* d) {
         gen.gen_func_proto(fd, out);
         if (fd.isInline()) {
             out.newline();
-            gen.emitStmt((ast.Stmt*)fd.getBody(), 0, true);
+            gen.emitStmt(out, (Stmt*)fd.getBody(), 0, true);
             out.newline();
         } else {
             out.add(";\n");
@@ -1107,7 +1092,7 @@ fn void Generator.generateInterfaceFiles(Generator* gen, Module* m) {
 
     string_buffer.Buf* hdr = gen.header;
     add_gen_warning(hdr);
-    char[32] upper_name;
+    char[64] upper_name;
     string_utils.toUpper(m.getName(), upper_name);
     hdr.print("#ifndef %s_H\n", upper_name);
     hdr.print("#define %s_H\n\n", upper_name);
@@ -1121,20 +1106,14 @@ fn void Generator.generateInterfaceFiles(Generator* gen, Module* m) {
     m.visitASTs(Generator.create_interface_decls, gen);
 
     gen.deps.init(m, gen, Generator.on_header_decl);
-    string_buffer.Buf* saved = gen.out;
-    gen.out = hdr;
     for (u32 i=0; i<gen.decls.size(); i++) {
         Generator.on_header_decl(gen, gen.decls.get(i));
     }
-    gen.out = saved;
 
     hdr.add("#ifdef __cplusplus\n}\n#endif\n\n");
     hdr.add("#endif\n");
 
-    file_utils.File file.init_ext(gen.results_dir, m.getName(), ".h");
-    if (!file.write(hdr.data(), hdr.size())) {
-        console.error("cannot write to %s: %s", file.path, file.getError());
-    }
+    gen.write(hdr, gen.results_dir, m.getName(), ".h");
     gen.cur_external = false;
 }
 
@@ -1142,7 +1121,6 @@ fn void Generator.on_module(void* arg, Module* m) {
     if (!m.isUsed()) return;
 
     Generator* gen = arg;
-    string_buffer.Buf* out = gen.out;
 
     gen.mod_name = m.getName();
     gen.mod = m;
@@ -1151,23 +1129,22 @@ fn void Generator.on_module(void* arg, Module* m) {
     gen.no_trace = !string.strcmp(gen.mod_name, "c2_trace");
 
     if (gen.fast_build) {
-        out.clear();
         gen.header.clear();
         add_gen_warning(gen.header);
-        char[32] upper_name;
+        char[64] upper_name;
         string_utils.toUpper(gen.mod_name, upper_name);
         gen.header.print("#ifndef %s_H\n", upper_name);
         gen.header.print("#define %s_H\n\n", upper_name);
         gen.header.add("#include \"_external.h\"\n\n");
 
-        add_gen_warning(out);
+        gen.out.clear();
+        add_gen_warning(gen.out);
     } else {
-        out.print("\n// --- module %s ---\n", gen.mod_name);
+        gen.out.print("\n// --- module %s ---\n", gen.mod_name);
     }
 
     // Note: special case for stdarg.h va_list
     if (m.getNameIdx() == gen.varargsName) {
-        if (gen.fast_build) out = gen.header;
         const char[] builtin_defs =
         ```c
         // Note: this module is a special case and is custom generated
@@ -1176,7 +1153,9 @@ fn void Generator.on_module(void* arg, Module* m) {
         #define va_end __builtin_va_end
 
         ```;
-        out.add(builtin_defs);
+
+        if (gen.fast_build) gen.header.add(builtin_defs);
+        else gen.out.add(builtin_defs);
 
         // set all decls to generated
         m.visitASTs(Generator.ast_mark_generated, arg);
@@ -1187,7 +1166,7 @@ fn void Generator.on_module(void* arg, Module* m) {
 
     if (gen.fast_build) {
         // generate self include
-        out.print("#include \"%s.h\"\n", gen.mod_name);
+        gen.out.print("#include \"%s.h\"\n", gen.mod_name);
         // For now just iterate twice, possibly generating same include twice
         // if used public and non-public by other ASTs
 
@@ -1220,14 +1199,11 @@ fn void Generator.write_files(Generator* gen) {
     assert(gen.fast_build);
     gen.header.add("\n#endif\n\n");
 
-    char[64] outfile;
     if (!gen.cur_external) {
-        snprintf(outfile, elemsof(outfile), "%s.c", gen.mod_name);
-        gen.write(gen.cgen_dir, outfile, gen.out);
+        gen.write(gen.out, gen.cgen_dir, gen.mod_name, ".c");
     }
 
-    snprintf(outfile, elemsof(outfile), "%s.h", gen.mod_name);
-    gen.write(gen.cgen_dir, outfile, gen.header);
+    gen.write(gen.header, gen.cgen_dir, gen.mod_name, ".h");
 
     gen.out.clear();
     gen.header.clear();
@@ -1280,8 +1256,8 @@ fn void Generator.free(Generator* gen) {
     gen.funcnames.free();
 }
 
-fn void Generator.write(Generator* gen, const char* output_dir, const char* filename, const string_buffer.Buf* buf) {
-    file_utils.File file.init(output_dir, filename);
+fn void Generator.write(Generator* gen, const string_buffer.Buf* buf, const char* output_dir, const char* filename, const char* ext = nil) {
+    file_utils.File file.init(output_dir, filename, ext);
     if (!file.write(buf.data(), buf.size())) {
         console.error("cannot write to %s: %s", file.path, file.getError());
     }
@@ -1310,8 +1286,7 @@ public fn void generate(string_pool.Pool* astPool,
         return;
     }
 
-    Generator gen;
-    gen.init(astPool, target, kind, output_dir, dir, diags, sm, build_info, mainFunc);
+    Generator gen.init(astPool, target, kind, output_dir, dir, diags, sm, build_info, mainFunc);
     gen.auxPool = auxPool;
     gen.enable_asserts = enable_asserts;
     gen.fast_build = fast_build;
@@ -1321,18 +1296,17 @@ public fn void generate(string_pool.Pool* astPool,
     gen.trace_calls = trace_calls;
     gen.targetInfo = targetInfo;
     gen.cgen_dir = dir;
-    string_buffer.Buf* out = gen.out;
 
     if (!fast_build) {
-        add_gen_warning(out);
+        add_gen_warning(gen.out);
     }
 
     // generate C2-internal and external lib stuff in external.h, the main component in build.c
-    gen.emit_external_header(target);
+    gen.emit_external_header(gen.out);
 
     if (fast_build) {
-        gen.write(gen.cgen_dir, "_external.h", gen.out);
-        out.clear();
+        gen.write(gen.out, gen.cgen_dir, "_external.h");
+        gen.out.clear();
 
         gen.cur_external = true;
     }
@@ -1361,13 +1335,13 @@ public fn void generate(string_pool.Pool* astPool,
             gen.out.clear();
             gen.out.add("#include \"c2_trace_tables.h\"\n\n");
             gen.writeCalls(gen.out);
-            gen.write(dir, "c2_trace_tables.c", gen.out);
+            gen.write(gen.out, dir, "c2_trace_tables.c");
         }
     } else {
         if (gen.trace_calls) {
             gen.writeCalls(gen.out);
         }
-        gen.write(dir, "build.c", gen.out);
+        gen.write(gen.out, dir, "build.c");
     }
 
     u32 libc_name = auxPool.addStr("libc", true);
@@ -1389,7 +1363,7 @@ public fn void build(const char* output_dir)
 #endif
 
     char[file_utils.Max_path] dir;
-    if (!file_utils.make_path_ext(dir, elemsof(dir), output_dir, Dir, "/")) {
+    if (!file_utils.make_path(dir, elemsof(dir), output_dir, Dir, "/")) {
         console.error("cannot launch C compilation: %s", string.strerror(errno));
         return;
     }
@@ -1464,9 +1438,7 @@ const char[] C_defines =
     #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
     ```;
 
-fn void Generator.emit_external_header(Generator* gen, const char* target) {
-    string_buffer.Buf* out = gen.out;
-
+fn void Generator.emit_external_header(Generator* gen, string_buffer.Buf* out) {
     out.add(Include_guard1);
     out.add(Warning_control);
     out.add(C_types);

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -19,7 +19,6 @@ import ast;
 import build_file;
 import build_target;
 import component;
-import console;
 import file_utils;
 import module_list;
 import string_buffer;
@@ -145,8 +144,8 @@ fn void Generator.createMakefile(Generator* gen,
         const char* triplet = gen.targetInfo.str();
 
         // interate Components in reverse order
-        for (u32 i=comps.size(); i != 0; i--) {
-            component.Component* c = comps.get(i-1);
+        for (u32 i = comps.size(); i-- > 0;) {
+            component.Component* c = comps.get(i);
             if (!c.isExternal()) continue;
             const char* linkname = c.getLinkName();
 
@@ -225,7 +224,7 @@ fn void Generator.createMakefile(Generator* gen,
     out.add("clean:\n");
     out.print("\t\trm -f *.o *.a ../%s\n\n", target_name);
 
-    gen.write(output_dir, "Makefile", gen.out);
+    gen.write(gen.out, output_dir, "Makefile");
 }
 
 fn void Generator.createExportsFile(Generator* gen, const char* output_dir, component.Component* mainComp) {
@@ -255,7 +254,7 @@ fn void Generator.createExportsFile(Generator* gen, const char* output_dir, comp
     out.add("\tlocal:\n\t\t*;\n");
     out.add("};\n");
 
-    gen.write(output_dir, "exports.version", gen.out);
+    gen.write(gen.out, output_dir, "exports.version");
 }
 
 const char[] C2_types_header =
@@ -306,11 +305,7 @@ fn void Generator.generateC2TypesHeader(Generator* gen) {
     string_buffer.Buf* out = gen.header;
     out.clear();
     out.add(C2_types_header);
-
-    file_utils.File file.init(gen.results_dir, "c2types.h");
-    if (!file.write(out.data(), out.size())) {
-        console.error("cannot write to %s: %s", file.path, file.getError());
-    }
+    gen.write(out, gen.results_dir, "c2types.h");
     out.clear();
 }
 

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -42,8 +42,7 @@ fn void Generator.emitVarDecl(Generator* gen, VarDecl* vd, string_buffer.Buf* ou
     }
 }
 
-fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
-    string_buffer.Buf* out = gen.out;
+fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 indent, bool newline) {
 
     if (out.endsWith('\n')) out.indent(indent);
 
@@ -73,7 +72,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         if (is_decl) {
             out.add("{\n");
             indent++;
-            gen.emitStmt(cond, indent, true);
+            gen.emitStmt(out, cond, indent, true);
             out.indent(indent);
             out.add("if (");
             DeclStmt* ds = (DeclStmt*)cond;
@@ -86,7 +85,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         }
         out.add(") ");
         Stmt* thenStmt = i.getThen();
-        gen.emitStmt(thenStmt, indent, true);
+        gen.emitStmt(out, thenStmt, indent, true);
         Stmt* elseStmt = i.getElse();
         if (elseStmt) {
             if (thenStmt.isCompound()) {
@@ -96,7 +95,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
                 out.indent(indent);
             }
             out.add("else ");
-            gen.emitStmt(elseStmt, indent, true);
+            gen.emitStmt(out, elseStmt, indent, true);
         }
         if (is_decl) {
             indent--;
@@ -131,7 +130,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
             gen.emitExpr(out, (Expr*)cond);
             out.add(") ");
         }
-        gen.emitStmt(w.getBody(), indent, true);
+        gen.emitStmt(out, w.getBody(), indent, true);
         if (is_decl) {
             indent--;
             out.indent(indent);
@@ -143,7 +142,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         out.add("for (");
         Stmt* initStmt = f.getInit();
         if (initStmt) {
-            gen.emitStmt(initStmt, 0, false);
+            gen.emitStmt(out, initStmt, 0, false);
         }
         out.add1(';');
         if (f.getCond()) {
@@ -157,10 +156,10 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
             gen.emitExpr(out, cont);
         }
         out.add(") ");
-        gen.emitStmt(f.getBody(), indent, true);
+        gen.emitStmt(out, f.getBody(), indent, true);
         break;
     case Switch:
-        gen.emitSwitchStmt((SwitchStmt*)s, indent);
+        gen.emitSwitchStmt(out, (SwitchStmt*)s, indent);
         break;
     case Break:
         out.add("break;\n");
@@ -181,7 +180,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
             out.add1(';');
         }
         out.newline();
-        if (stmt) gen.emitStmt(stmt, indent, true);
+        if (stmt) gen.emitStmt(out, stmt, indent, true);
         break;
     case Goto:
         GotoStmt* g = (GotoStmt*)s;
@@ -195,7 +194,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         u32 count = c.getCount();
         Stmt** stmts = c.getStmts();
         for (u32 i=0; i<count; i++) {
-            gen.emitStmt(stmts[i], indent+1, true);
+            gen.emitStmt(out, stmts[i], indent+1, true);
         }
 
         out.indent(indent);
@@ -213,7 +212,7 @@ fn void Generator.emitStmt(Generator* gen, Stmt* s, u32 indent, bool newline) {
         if (newline) out.add(";\n");
         break;
     case Asm:
-        gen.emitAsmStmt((AsmStmt*)s, indent);
+        gen.emitAsmStmt(out, (AsmStmt*)s, indent);
         break;
     case Assert:
         if (!gen.enable_asserts) out.print(";//assert");
@@ -241,8 +240,7 @@ fn void emitAsmPart(string_buffer.Buf* out, bool multi_line, u32 indent) {
     out.add(": ");
 }
 
-fn void Generator.emitAsmOperand(Generator* gen, u32 name, const Expr* c, Expr* e) {
-    string_buffer.Buf* out = gen.out;
+fn void Generator.emitAsmOperand(Generator* gen, string_buffer.Buf* out, u32 name, const Expr* c, Expr* e) {
     if (name) {
         out.print("[%s] ", ast.idx2name(name));
     }
@@ -252,9 +250,7 @@ fn void Generator.emitAsmOperand(Generator* gen, u32 name, const Expr* c, Expr* 
     out.rparen();
 }
 
-fn void Generator.emitAsmStmt(Generator* gen, AsmStmt* a, u32 indent) {
-    string_buffer.Buf* out = gen.out;
-
+fn void Generator.emitAsmStmt(Generator* gen, string_buffer.Buf* out, AsmStmt* a, u32 indent) {
     out.add("__asm__ ");
     if (a.isVolatile()) out.add("volatile ");
 
@@ -275,7 +271,7 @@ fn void Generator.emitAsmStmt(Generator* gen, AsmStmt* a, u32 indent) {
         emitAsmPart(out, multi_line, indent);
         for (u32 i=0; i<num_outputs; i++) {
             if (i!=0) out.add(", ");
-            gen.emitAsmOperand(names[i], constraints[i], exprs[i]);
+            gen.emitAsmOperand(out, names[i], constraints[i], exprs[i]);
         }
         // inputs
         if (num_inputs | num_clobbers) {
@@ -283,7 +279,7 @@ fn void Generator.emitAsmStmt(Generator* gen, AsmStmt* a, u32 indent) {
             for (u32 i=0; i<num_inputs; i++) {
                 if (i!=0) out.add(", ");
                 u32 idx = i + num_outputs;
-                gen.emitAsmOperand(names[idx], constraints[idx], exprs[idx]);
+                gen.emitAsmOperand(out, names[idx], constraints[idx], exprs[idx]);
             }
         }
         // clobbers
@@ -301,14 +297,12 @@ fn void Generator.emitAsmStmt(Generator* gen, AsmStmt* a, u32 indent) {
     out.add(";\n");
 }
 
-fn void Generator.emitSwitchStmt(Generator* gen, SwitchStmt* sw, u32 indent) {
-    string_buffer.Buf* out = gen.out;
-
+fn void Generator.emitSwitchStmt(Generator* gen, string_buffer.Buf* out, SwitchStmt* sw, u32 indent) {
     bool is_decl = sw.hasDecl();
     if (is_decl) {
         out.add("{\n");
         indent++;
-        gen.emitStmt(sw.getDecl(), indent, true);
+        gen.emitStmt(out, sw.getDecl(), indent, true);
         out.indent(indent);
     }
     out.add("switch (");
@@ -322,7 +316,7 @@ fn void Generator.emitSwitchStmt(Generator* gen, SwitchStmt* sw, u32 indent) {
     u32 lab = 2;
     u32* lab_p = sw.isString() ? &lab : nil;
     for (u32 i = 0; i < num_cases; i++) {
-        gen.emitCase(cases[i], indent, lab_p);
+        gen.emitCase(out, cases[i], indent, lab_p);
     }
     out.indent(indent);
     out.add("}\n");
@@ -333,8 +327,7 @@ fn void Generator.emitSwitchStmt(Generator* gen, SwitchStmt* sw, u32 indent) {
     }
 }
 
-fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) {
-    string_buffer.Buf* out = gen.out;
+fn void Generator.emitCase(Generator* gen, string_buffer.Buf* out, SwitchCase* c, u32 indent, u32 *lab) {
     const char* brace = c.hasDecls() ? " {" : "";
 
     out.indent(indent);
@@ -387,7 +380,7 @@ fn void Generator.emitCase(Generator* gen, SwitchCase* c, u32 indent, u32 *lab) 
     if (num_stmts > 0) {
         Stmt** stmts = c.getStmts();
         for (u32 i=0; i<num_stmts; i++) {
-            gen.emitStmt(stmts[i], indent+1, true);
+            gen.emitStmt(out, stmts[i], indent+1, true);
         }
     }
 

--- a/generator/c2i/c2i_generator.c2
+++ b/generator/c2i/c2i_generator.c2
@@ -73,7 +73,7 @@ fn void Generator.on_module(void* arg, Module* m) {
     // public decls
     m.visitDecls(on_decl, gen);
 
-    file_utils.File file.init_ext(gen.output_dir, gen.mod_name, ".c2i");
+    file_utils.File file.init(gen.output_dir, gen.mod_name, ".c2i");
     if (!file.write(gen.out.data(), gen.out.size())) {
         console.error("cannot write to %s: %s", file.path, file.getError());
     }

--- a/plugins/shell_cmd_plugin.c2
+++ b/plugins/shell_cmd_plugin.c2
@@ -74,7 +74,7 @@ fn void init(void* arg, plugin_info.Info* info) {
     ast.setGlobals(info.ast_globals);
 
     console.debug("shell_cmd: loading %s", p.config_file);
-    file_utils.File file.init("", p.config_file);
+    file_utils.File file.init(p.config_file);
     if (!file.load()) {
         console.error("shell_cmd: cannot load file %s: %s", p.config_file, file.getError());
         exit(EXIT_FAILURE);

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -242,7 +242,7 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
 
 public fn i32 c2cat(const char* filename, bool use_color)
 {
-    file_utils.File file.init("", filename);
+    file_utils.File file.init(filename);
     if (!file.load()) {
         fprintf(stderr, "error opening %s: %s\n", filename, file.getError());
         return -1;

--- a/tools/common/replacer.c2
+++ b/tools/common/replacer.c2
@@ -123,7 +123,7 @@ fn void Replacer.flushFragments(Replacer* r, const char* filename) {
     r.dest[dest_idx] = 0;
 
     // write
-    file_utils.File outfile.init("", filename);
+    file_utils.File outfile.init(filename);
     if (!outfile.write(r.dest, new_size)) {
         fprintf(stderr, "cannot write to %s: %s\n", filename, outfile.getError());
     }
@@ -202,7 +202,7 @@ public fn i32 Replacer.replace(Replacer* r, u16 old_len) {
                 prev_offset = 0;
             }
             cur_file = filename;
-            r.file.init("", filename);
+            r.file.init(filename);
             if (!r.file.load()) {
                 fprintf(stderr, "error opening %s: %s\n", filename, r.file.getError());
                 return -1;

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -255,7 +255,7 @@ fn void Tester.run_test(Tester* t, Test* test) {
     string_buffer.Buf* buf = string_buffer.create(4096, color_output, 2);
     buf.print("%s\n", test.filename);
 
-    file_utils.File file.init("", test.filename);
+    file_utils.File file.init(test.filename);
     if (!file.load()) {
         print_error("error opening %s: %s", test.filename, file.getError());
         exit(EXIT_FAILURE);


### PR DESCRIPTION
* pass output string_buffer to all C code emitters
* create `File` object in `Generator.write`
* merge `make_path_ext` into `make_path` using optional arguments
* merge `File.init_ext` into `File.init` using optional arguments
* simplify file name constructors