### PR TITLE
Compiler: make `setTypeUsedPublic()` a type function

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -740,7 +740,7 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
     if (!d.getAST().isInterface())
         ma.checkName(d, res.isConstant());
 
-    if (d.isPublic()) setTypePublicUsed(res);
+    if (d.isPublic()) res.setTypeUsedPublic();
 
     if (init_expr) {
         if (!res.isConstant()) {

--- a/analyser/module_analyser_enum_assoc.c2
+++ b/analyser/module_analyser_enum_assoc.c2
@@ -49,7 +49,7 @@ fn void Analyser.analyseEnumAssocValues(Analyser* ma, EnumTypeDecl* etd) {
             continue;
         }
         if (d.isPublic()) {
-            setTypePublicUsed(res);
+            res.setTypeUsedPublic();
 
             if (!enum_public) {
                 ma.error(ref.getLoc(), "public enum-associated value' with non-public enum type");

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -59,7 +59,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
     }
 
     bool is_public = fd.asDecl().isPublic();
-    if (is_public) setTypePublicUsed(qt);
+    if (is_public) qt.setTypeUsedPublic();
 
     fd.setRType(qt);
 
@@ -86,7 +86,7 @@ fn void Analyser.analyseFunction(Analyser* ma, FunctionDecl* fd) {
             continue;
         }
 
-        if (is_public) setTypePublicUsed(res);
+        if (is_public) res.setTypeUsedPublic();
 
         if (vd.hasInit()) {
             if (vd.hasAutoAttr()) {

--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -165,7 +165,7 @@ fn void Analyser.analyseStructMember(Analyser* ma, VarDecl* v) {
 
     v.asDecl().setType(res);
 
-    if (ma.usedPublic) setTypePublicUsed(res);
+    if (ma.usedPublic) res.setTypeUsedPublic();
 
     // TODO check attributes
 

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -444,6 +444,44 @@ public fn bool QualType.needsCtvInit(const QualType qt) {
     return false;
 }
 
+// Note: qt must be valid
+public fn void QualType.setTypeUsedPublic(QualType qt) {
+    const Type* t = qt.getType();
+    Decl* d = nil;
+    switch (t.getKind()) {
+    case Builtin:
+    case Void:
+        return;
+    case Pointer:
+        PointerType* pt = (PointerType*)t;
+        pt.inner.setTypeUsedPublic();
+        return;
+    case Array:
+        ArrayType* at = (ArrayType*)t;
+        at.elem.setTypeUsedPublic();
+        return;
+    case Struct:
+        StructType* st = (StructType*)t;
+        d = (Decl*)st.decl;
+        break;
+    case Enum:
+        EnumType* et = (EnumType*)t;
+        d = (Decl*)et.decl;
+        break;
+    case Function:
+        //FunctionType* ft = (FunctionType*)t);
+        // TODO how to get from FunctionType to FunctionTypeDecl?
+        return;
+    case Alias:
+        AliasType* at = (AliasType*)t;
+        d = (Decl*)at.decl;
+        break;
+    case Module:
+        return;
+    }
+    if (d) d.setUsedPublic();
+}
+
 public fn const char* QualType.diagName(const QualType qt) {
     static char[4][128] msgs;
     static u32 msg_id = 0;

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -273,44 +273,6 @@ fn void flushDumpBuf(string_buffer.Buf* out) {
     out.clear();
 }
 
-// Note: qt must be valid
-public fn void setTypePublicUsed(QualType qt) {
-    const Type* t = qt.getType();
-    Decl* d = nil;
-    switch (t.getKind()) {
-    case Builtin:
-    case Void:
-        return;
-    case Pointer:
-        PointerType* pt = (PointerType*)t;
-        setTypePublicUsed(pt.inner);
-        return;
-    case Array:
-        ArrayType* at = (ArrayType*)t;
-        setTypePublicUsed(at.elem);
-        return;
-    case Struct:
-        StructType* st = (StructType*)t;
-        d = (Decl*)st.decl;
-        break;
-    case Enum:
-        EnumType* et = (EnumType*)t;
-        d = (Decl*)et.decl;
-        break;
-    case Function:
-        //FunctionType* ft = (FunctionType*)t);
-        // TODO how to get from FunctionType to FunctionTypeDecl?
-        return;
-    case Alias:
-        AliasType* at = (AliasType*)t;
-        d = (Decl*)at.decl;
-        break;
-    case Module:
-        return;
-    }
-    if (d) d.setUsedPublic();
-}
-
 public fn BuiltinKind getNativeKind() {
     return globals.wordsize == 8 ? UInt64 : UInt32;
 }


### PR DESCRIPTION
* move function `setTypeUsedPublic()` from ast/utils.c2 to ast/qual_type.c2 as type function `QualType.setUsedPublic()`
* this function is really a type function and does not depend on `globals`