### PR TITLE
Compiler: try and avoid using `ast.idx2name()`

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -141,6 +141,10 @@ public fn void Analyser.free(Analyser* ma) {
     stdlib.free(ma);
 }
 
+fn const char* Analyser.idx2name(const Analyser* ma, u32 name_idx) {
+    return ma.astPool.idx2str(name_idx);
+}
+
 public fn void Analyser.check(Analyser* ma, Module* mod) {
     ma.mod = mod;
     ma.prefix_cache_name = 0;
@@ -256,7 +260,7 @@ fn void Analyser.handleIncrEntry(Analyser* ma, ia_list.Info* entry) {
     // find array Decl
     Decl* d = ma.mod.findSymbol(name);
     if (!d) {
-        ma.error(entry.loc, "module '%s' has no symbol '%s'", ma.mod.getName(), ast.idx2name(name));
+        ma.error(entry.loc, "module '%s' has no symbol '%s'", ma.mod.getName(), ma.idx2name(name));
         return;
     }
     // check if incremental array/enum
@@ -265,8 +269,8 @@ fn void Analyser.handleIncrEntry(Analyser* ma, ia_list.Info* entry) {
         VarDecl* vd = (VarDecl*)d;
         TypeRef* ref = vd.getTypeRef();
         if (!ref.isIncrArray()) {
-            ma.error(entry.loc, "'%s' is not an incremental array", ast.idx2name(name));
-            ma.note(d.getLoc(), "'%s' is defined here", ast.idx2name(name));
+            ma.error(entry.loc, "'%s' is not an incremental array", ma.idx2name(name));
+            ma.note(d.getLoc(), "'%s' is defined here", ma.idx2name(name));
             return;
         }
 
@@ -279,8 +283,8 @@ fn void Analyser.handleIncrEntry(Analyser* ma, ia_list.Info* entry) {
         // dont analyse yet, just check if Identifier and convert to EnumConstantDecl
         EnumTypeDecl* etd = (EnumTypeDecl*)d;
         if (!etd.isIncremental()) {
-            ma.error(entry.loc, "'%s' is not an incremental enum", ast.idx2name(name));
-            ma.note(d.getLoc(), "'%s' is defined here", ast.idx2name(name));
+            ma.error(entry.loc, "'%s' is not an incremental enum", ma.idx2name(name));
+            ma.note(d.getLoc(), "'%s' is defined here", ma.idx2name(name));
             return;
         }
 
@@ -295,8 +299,8 @@ fn void Analyser.handleIncrEntry(Analyser* ma, ia_list.Info* entry) {
         }
         etd.setIncrConstants(ma.context, (IdentifierExpr**)values, num_values);
     } else {
-        ma.error(entry.loc, "'%s' is not an incremental array/enum", ast.idx2name(name));
-        ma.note(d.getLoc(), "'%s' is defined here", ast.idx2name(name));
+        ma.error(entry.loc, "'%s' is not an incremental array/enum", ma.idx2name(name));
+        ma.note(d.getLoc(), "'%s' is defined here", ma.idx2name(name));
     }
 }
 
@@ -361,6 +365,7 @@ fn void Analyser.createGlobalScope(void* arg, AST* a) {
     Analyser* ma = arg;
     scope.Scope* s = scope.create(ma.allmodules,
                                   ma.diags,
+                                  ma.astPool,
                                   a.getImports(),
                                   ma.mod,
                                   ma.mod.getSymbols(),

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -651,8 +651,8 @@ fn bool Analyser.checkFormatArgs(Analyser* ma, Expr* format, Expr** args, u32 nu
     return true;
 }
 
-fn void create_template_name(char* name, u32 size, const char* orig, u16 idx) {
-    stdio.snprintf(name, size, "%s_%d_", orig, idx);
+fn void Analyser.create_template_name(Analyser* ma, char* name, u32 size, u32 orig, u16 idx) {
+    stdio.snprintf(name, size, "%s_%d_", ma.idx2name(orig), idx);
 }
 
 fn void Analyser.opaque_callback(void* arg, SrcLoc loc, Decl* d) {
@@ -697,6 +697,7 @@ fn FunctionDecl* Analyser.instantiateTemplateFunction(Analyser* ma, CallExpr* ca
         analyser.setMod(template_mod);
         scope.Scope* tmpScope = scope.create(ma.allmodules,
                                              ma.diags,
+                                             ma.astPool,
                                              d.getAST().getImports(),
                                              template_mod,
                                              template_mod.getSymbols(),
@@ -710,7 +711,7 @@ fn FunctionDecl* Analyser.instantiateTemplateFunction(Analyser* ma, CallExpr* ca
         u16 instance_idx = ma.mod.addInstance(fd, templateType, instance);
         instance.setTemplateInstanceIdx(instance_idx);
         char[64] name;
-        create_template_name(name, elemsof(name), d.getName(), instance_idx);
+        ma.create_template_name(name, elemsof(name), d.getNameIdx(), instance_idx);
         instance.setInstanceName(ma.astPool.addStr(name, true));
     }
     call.setTemplateIdx(instance.getTemplateInstanceIdx());

--- a/analyser/module_analyser_enum_assoc.c2
+++ b/analyser/module_analyser_enum_assoc.c2
@@ -80,12 +80,12 @@ fn void Analyser.analyseEnumAssocValues(Analyser* ma, EnumTypeDecl* etd) {
             u32 name_idx2 = prev.getNameIdx();
             if (name_idx == name_idx2) {
                 has_error = true;
-                ma.error(vd.asDecl().getLoc(), "redefinition of '%s'", prev.getName());
+                ma.error(vd.asDecl().getLoc(), "redefinition of '%s'", ma.idx2name(name_idx2));
             }
         }
         if (name_idx == ma.min_idx || name_idx == ma.max_idx) {
             has_error = true;
-            ma.error(vd.asDecl().getLoc(), "enum-associated name '%s' is reserved", vd.getName());
+            ma.error(vd.asDecl().getLoc(), "enum-associated name '%s' is reserved", ma.idx2name(name_idx));
         }
         Decl* fn_decl = etd.findFunction(name_idx);
         if (fn_decl) {
@@ -176,7 +176,7 @@ fn bool Analyser.analyseEnumConstantAssocValues(Analyser* ma,
     }
     if (num_values < num_assocs) {
         Decl* col_decl = (Decl*)columns[num_values];
-        ma.error(ile.getEndLoc(), "missing initializer for enum-associated value '%s'", col_decl.getName());
+        ma.error(ile.getEndLoc(), "missing initializer for enum-associated value '%s'", ma.idx2name(col_decl.getNameIdx()));
         return false;
     }
     return is_ok;

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -645,15 +645,17 @@ fn bool Analyser.analyseBitOffsetIndex(Analyser* ma, Expr** e_ptr, QualType base
     return true;
 }
 
-fn void get_best_match(const char* name1, usize len1, StructTypeDecl* s, usize* best_dist, const char** result) {
+fn void Analyser.get_best_match(Analyser* ma, const char* name1, usize len1, StructTypeDecl* s, usize* best_dist, const char** result) {
     Decl** members = s.getMembers();
     u32 num_members = s.getNumMembers();
     for (u32 i = 0; i < num_members; i++) {
         Decl* m = members[i];
-        const char* name2 = m.getName();
-        if (name2 == nil) {
-            get_best_match(name1, len1, (StructTypeDecl*)m, best_dist, result);
+        u32 name_idx = m.getNameIdx();
+        if (!name_idx) {
+            // anonymous sub structure
+            ma.get_best_match(name1, len1, (StructTypeDecl*)m, best_dist, result);
         } else {
+            const char* name2 = ma.idx2name(name_idx);
             usize len2 = string.strlen(name2);
             usize dist = levenshtein.dist(name1, len1, name2, len2);
             if (dist < *best_dist) {
@@ -666,28 +668,23 @@ fn void get_best_match(const char* name1, usize len1, StructTypeDecl* s, usize* 
 }
 
 fn void Analyser.memberError(Analyser* ma, u32 name_idx, SrcLoc loc, StructTypeDecl* s) {
-    const char* name1 = idx2name(name_idx);
+    const char* name1 = ma.idx2name(name_idx);
     usize len1 = string.strlen(name1);
 
     const char* result = nil;
     usize dist = usize.max;
-    get_best_match(name1, len1, s, &dist, &result);
+    ma.get_best_match(name1, len1, s, &dist, &result);
 
     u32 max_dist = (u32)len1 / 2;
     if (max_dist > 2) max_dist = 2;
 
     if (dist <= max_dist) {
         ma.error(loc, "no member named '%s' in %s '%s'; did you mean '%s'?",
-            idx2name(name_idx),
-            s.isStruct() ? "struct" : "union",
-            s.asDecl().getFullName(),
-            result);
+                 name1, s.isStruct() ? "struct" : "union", s.asDecl().getFullName(), result);
 
     } else {
         ma.error(loc, "no member named '%s' in %s '%s'",
-            idx2name(name_idx),
-            s.isStruct() ? "struct" : "union",
-            s.asDecl().getFullName());
+                 name1, s.isStruct() ? "struct" : "union", s.asDecl().getFullName());
     }
 }
 

--- a/analyser/module_analyser_function.c2
+++ b/analyser/module_analyser_function.c2
@@ -224,6 +224,7 @@ fn bool Analyser.analyseFunctionBody2(Analyser* ma, FunctionDecl* fd, Module* mo
     analyser.setMod(mod);
     scope.Scope* tmpScope = scope.create(ma.allmodules,
                                          ma.diags,
+                                         ma.astPool,
                                          fd.asDecl().getAST().getImports(),
                                          mod,
                                          mod.getSymbols(),
@@ -286,7 +287,7 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
             Decl* p = (Decl*)params[i];
             if (!p.isUsed() && p.getNameIdx()) {
                 // TODO check attribute?
-                ma.warn(p.getLoc(), "unused parameter '%s'", p.getName());
+                ma.warn(p.getLoc(), "unused parameter '%s'", ma.idx2name(p.getNameIdx()));
             }
         }
     }
@@ -297,10 +298,10 @@ fn void Analyser.analyseFunctionBody(Analyser* ma, FunctionDecl* fd, scope.Scope
         const Label* l = &labels[i];
         if (l.is_label) {
             if (!l.used && !ma.warnings.no_unused_label) {
-                ma.warn(l.loc, "unused label '%s'", ast.idx2name(l.name_idx));
+                ma.warn(l.loc, "unused label '%s'", ma.idx2name(l.name_idx));
             }
         } else {
-            ma.error(l.loc, "use of undeclared label '%s'", ast.idx2name(l.name_idx));
+            ma.error(l.loc, "use of undeclared label '%s'", ma.idx2name(l.name_idx));
         }
     }
 done:

--- a/analyser/module_analyser_struct.c2
+++ b/analyser/module_analyser_struct.c2
@@ -193,7 +193,7 @@ fn void Analyser.analyseStructNames(Analyser* ma, StructTypeDecl* d, NameMap* na
         } else {
             u32 old_index;
             if (names.find(name_idx, &old_index)) {
-                ma.error(member.getLoc(), "duplicate struct/union member '%s'", member.getName());
+                ma.error(member.getLoc(), "duplicate struct/union member '%s'", ma.idx2name(name_idx));
                 ma.note(names.getLoc(old_index), "previous declaration is here");
                 return;
             }

--- a/analyser/module_analyser_switch.c2
+++ b/analyser/module_analyser_switch.c2
@@ -313,7 +313,7 @@ fn bool Analyser.analyseCaseCondition(Analyser* ma,
                 if (etd) {
                     if (lhs_index > rhs_index) {
                         ma.error(loc, "enum constant '%s' does not come after '%s'",
-                                 idx2name(rhs_name_idx), idx2name(lhs_name_idx));
+                                 ma.idx2name(rhs_name_idx), ma.idx2name(lhs_name_idx));
                         res = false;
                         continue;
                     }

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -66,7 +66,7 @@ fn void Analyser.analyseEnumType(Analyser* ma, EnumTypeDecl* d) {
         for (u32 j=0; j<i; j++) {
             const Decl* other = constants[j].asDecl();
             if (other.getNameIdx() == name_idx) {
-                ma.error(cd.getLoc(), "duplicate enum constant '%s'", ast.idx2name(name_idx));
+                ma.error(cd.getLoc(), "duplicate enum constant '%s'", ma.idx2name(name_idx));
                 ma.note(other.getLoc(), "previous definition is here");
                 return;
             }

--- a/analyser/scope.c2
+++ b/analyser/scope.c2
@@ -21,6 +21,7 @@ import levenshtein;
 import module_list;
 import constants;
 import src_loc local;
+import string_pool;
 
 import stdio;
 import stdlib;
@@ -43,8 +44,9 @@ type Level struct {
 
 public type Scope struct @(opaque) {
     // global scope
-    const module_list.List* allmodules;
     diagnostics.Diags* diags;
+    string_pool.Pool* astPool;
+    const module_list.List* allmodules;
     const ast.ImportDeclList* imports;
     const ast.Module* mod;
     const ast.SymbolTable* symbols; // all symbols of the module
@@ -71,14 +73,16 @@ public type Scope struct @(opaque) {
 
 public fn Scope* create(module_list.List* allmodules,
                           diagnostics.Diags* diags,
+                          string_pool.Pool* astPool,
                           const ast.ImportDeclList* imports,
                           ast.Module* mod,
                           const ast.SymbolTable* symbols,
                           bool warn_on_unused)
 {
     Scope* s = stdlib.calloc(1, sizeof(Scope));
-    s.allmodules = allmodules;
     s.diags = diags;
+    s.astPool = astPool;
+    s.allmodules = allmodules;
     s.imports = imports;
     s.mod = mod;
     s.symbols = symbols;
@@ -106,6 +110,10 @@ public fn void Scope.reset(Scope* s) {
     s.stack_max = s.stack_base = s.stack_count = first_index;
 }
 
+fn const char* Scope.idx2name(const Scope* s, u32 name_idx) {
+    return s.astPool.idx2str(name_idx);
+}
+
 fn void Scope.addImports(Scope* s) {
     // Note: this also adds the module itself (import[0])
 
@@ -117,7 +125,7 @@ fn void Scope.addImports(Scope* s) {
         // check for clash with other imports
         ast.Decl* decl = s.stack_find(name_idx);
         if (decl) {
-            s.diags.error(id.getLoc(), "duplicate import name '%s'", ast.idx2name(name_idx));
+            s.diags.error(id.getLoc(), "duplicate import name '%s'", s.idx2name(name_idx));
             assert(decl.isImport());
             ast.ImportDecl* other = (ast.ImportDecl*)decl;
             s.diags.note(other.getLoc(), "previous definition is here");
@@ -127,7 +135,7 @@ fn void Scope.addImports(Scope* s) {
         // check for clash with other symbol in this module
         decl = s.symbols.find(name_idx);
         if (decl) {
-            s.diags.error(id.getLoc(), "import redefinition of '%s'", ast.idx2name(name_idx));
+            s.diags.error(id.getLoc(), "import redefinition of '%s'", s.idx2name(name_idx));
             s.diags.note(decl.getLoc(), "previous definition is here");
             continue;
         }
@@ -262,7 +270,7 @@ public fn bool Scope.add(Scope* s, ast.Decl* d, bool set_offset = false) {
 
     ast.Decl* decl = s.stack_find(name_idx);
     if (decl) {
-        s.diags.error(d.getLoc(), "redefinition of '%s'", decl.getName());
+        s.diags.error(d.getLoc(), "redefinition of '%s'", s.idx2name(name_idx));
         s.diags.note(decl.getLoc(), "previous definition is here");
         return true;
     }
@@ -270,7 +278,7 @@ public fn bool Scope.add(Scope* s, ast.Decl* d, bool set_offset = false) {
     bool other_error = false;
     decl = s.findGlobalSymbol(name_idx, d.getLoc(), &other_error, false, false);
     if (decl) {
-        s.diags.error(d.getLoc(), "redefinition of '%s'", decl.getName());
+        s.diags.error(d.getLoc(), "redefinition of '%s'", s.idx2name(name_idx));
         s.diags.note(decl.getLoc(), "previous definition is here");
         return true;
     }
@@ -291,7 +299,7 @@ fn const char* Scope.findBestMatch(const Scope* s, u32 name_idx, const char* nam
     const char* hint = nil;
             // TODO make suggestion based on symbols in all modules
     for (u32 i=0; i<s.stack_count; i++) {
-        const char* name2 = ast.idx2name(s.stack_symbols[i]);
+        const char* name2 = s.idx2name(s.stack_symbols[i]);
         usize len2 = string.strlen(name2);
         usize dist = levenshtein.dist(name1, len1, name2, len2);
         if (dist < best_dist) {
@@ -320,7 +328,7 @@ fn const char* Scope.findBestMatch(const Scope* s, u32 name_idx, const char* nam
         const ast.SymbolTable* st = m.getSymbols();
         u32 num_syms = st.num_public + st.num_private;
         for (u32 j=0; j<num_syms; j++) {
-            const char* name2 = ast.idx2name(st.symbols[j]);
+            const char* name2 = s.idx2name(st.symbols[j]);
             usize len2 = string.strlen(name2);
             usize dist = levenshtein.dist(name1, len1, name2, len2);
             if (dist < best_dist) {
@@ -351,12 +359,11 @@ public fn ast.Decl* Scope.find(Scope* s, u32 name_idx, SrcLoc loc, bool usedPubl
     decl = s.findGlobalSymbol(name_idx, loc, &other_error, usedPublic, true);
 
     if (!decl && !other_error) {
-
+        const char* name = s.idx2name(name_idx);
         ast.ImportDecl* id  = s.imports.findAny(name_idx);
         if (id) {
-            s.diags.error(loc, "module '%s' is imported with alias '%s'", id.asDecl().getName(), id.getAliasName());
+            s.diags.error(loc, "module '%s' is imported with alias '%s'", name, id.getAliasName());
         } else {
-            const char* name = ast.idx2name(name_idx);
             const char* hint = s.findBestMatch(name_idx, name, string.strlen(name));
             if (hint) {
                 s.diags.error(loc, "use of undeclared identifier '%s'; did you mean '%s'?", name, hint);
@@ -390,7 +397,7 @@ public fn bool Scope.checkGlobalSymbol(Scope* s, u32 name_idx, SrcLoc loc) {
         }
     }
     if (decl) {
-        s.diags.error(loc, "redefinition of '%s'", ast.idx2name(name_idx));
+        s.diags.error(loc, "redefinition of '%s'", s.idx2name(name_idx));
         s.diags.note(decl.getLoc(), "previous definition is here");
         return false;
     }
@@ -407,15 +414,15 @@ public fn ast.ImportDecl* Scope.findModule(Scope* s, u32 name_idx, SrcLoc loc) {
 
     d = s.imports.findAny(name_idx);
     if (d) {
-        s.diags.error(loc, "module '%s' is imported with alias '%s'", d.asDecl().getName(), d.getAliasName());
+        s.diags.error(loc, "module '%s' is imported with alias '%s'", s.idx2name(name_idx), d.getAliasName());
         return nil;
     }
 
     ast.Module* mod = s.allmodules.find(name_idx);
     if (mod) {
-        s.diags.error(loc, "module %s not imported", ast.idx2name(name_idx));
+        s.diags.error(loc, "module '%s' not imported", s.idx2name(name_idx));
     } else {
-        s.diags.error(loc, "unknown module: '%s'", ast.idx2name(name_idx));
+        s.diags.error(loc, "unknown module: '%s'", s.idx2name(name_idx));
     }
     return nil;
 }
@@ -424,7 +431,7 @@ public fn ast.Decl* Scope.findSymbolInModule(Scope* s, ast.Module* mod, u32 name
     assert(s);
     ast.Decl* d = mod.findSymbol(name_idx);
     if (!d) {
-        s.diags.error(loc, "module '%s' has no symbol '%s'", mod.getName(), ast.idx2name(name_idx));
+        s.diags.error(loc, "module '%s' has no symbol '%s'", mod.getName(), s.idx2name(name_idx));
         return nil;
     }
 
@@ -449,7 +456,7 @@ public fn ast.Decl* Scope.findType(Scope* s, u32 name_idx, SrcLoc loc, bool used
     bool other_error = false;
     decl = s.findGlobalSymbol(name_idx, loc, &other_error, usedPublic, true);
     if (!decl && !other_error) {
-        s.diags.error(loc, "unknown type '%s'", ast.idx2name(name_idx));
+        s.diags.error(loc, "unknown type '%s'", s.idx2name(name_idx));
         // TODO make suggestion based on symbols in all modules
     }
     return decl;
@@ -494,7 +501,7 @@ fn ast.Decl* Scope.findGlobalSymbol(Scope* s, u32 name_idx, SrcLoc loc, bool* ot
         if (!d) continue;
 
         if (decl) { // already have result
-            const char* name = ast.idx2name(name_idx);
+            const char* name = s.idx2name(name_idx);
             if (!ambiguous) {
                 s.diags.error(loc, "symbol '%s' is ambiguous", name);
                 s.diags.note(decl.getLoc(), "did you mean '%s'?", decl.getFullName());

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -209,7 +209,8 @@ fn QualType getStringType(u32 len) {
     return globals.string_types.get(len);
 }
 
-public fn const char* idx2name(u32 idx) {
+// only used by ref_generator and ast module
+public fn const char* idx2name(u32 idx) @(unused) {
     if (idx) return globals.names_pool.idx2str(idx);
     return nil;
 }

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -130,7 +130,7 @@ public fn Decl* Builder.actOnImport(Builder* b,
     if (b.ast.getNameIdx() == mod_name) {
         if (mod_loc) {
             // reject self imports, no error for implicit imports (eg: varargs)
-            b.diags.error(mod_loc, "cannot import own module '%s'", idx2name(mod_name));
+            b.diags.error(mod_loc, "cannot import own module '%s'", b.astPool.idx2str(mod_name));
         }
         return nil;
     }
@@ -139,7 +139,7 @@ public fn Decl* Builder.actOnImport(Builder* b,
     if (old) {
         if (mod_loc) {
             // reject duplicate imports, no error for implicit imports
-            b.diags.error(mod_loc, "duplicate import of module '%s'", idx2name(mod_name));
+            b.diags.error(mod_loc, "duplicate import of module '%s'", b.astPool.idx2str(mod_name));
             b.diags.note(old.asDecl().getLoc(), "previous import is here");
         }
         return (Decl*)old;
@@ -359,9 +359,9 @@ public fn VarDecl* Builder.createEnumAssocDecl(Builder* b,
 
     // name is Enum__<name> for now. The first letter is always capital-cased, even if not const
     string_buffer.Buf* out = string_buffer.create(128, false, 0);
-    out.add(d.getName());
+    out.add(b.astPool.idx2str(d.getNameIdx()));
     out.add("__");
-    out.add(ast.idx2name(esv.getNameIdx()));
+    out.add(b.astPool.idx2str(esv.getNameIdx()));
     u32 name_idx = b.astPool.add(out.str(), out.size(), true);
     out.free();
 
@@ -693,7 +693,7 @@ fn bool Builder.actOnParamAttr(Builder* b, VarDecl* d, const Attr* a) {
         return true;
     default:
         b.diags.error(a.loc, "attribute '%s' cannot be applied to function parameters",
-                      ast.idx2name(a.name));
+                      b.astPool.idx2str(a.name));
         return false;
     }
     b.diags.error(a.loc, "invalid combination of attributes");
@@ -1232,7 +1232,7 @@ public fn void Builder.insertImplicitCast(Builder* b,
 fn void Builder.addSymbol(Builder* b, u32 name_idx, Decl* d) {
     Decl* old = b.mod.findSymbol(name_idx);
     if (old) {
-        b.diags.error(d.getLoc(), "redefinition of '%s'", idx2name(name_idx));
+        b.diags.error(d.getLoc(), "redefinition of '%s'", b.astPool.idx2str(name_idx));
         b.diags.note(old.getLoc(), "previous definition is here");
     } else {
         b.mod.addSymbol(name_idx, d);

--- a/common/attr_handler.c2
+++ b/common/attr_handler.c2
@@ -18,6 +18,7 @@ module attr_handler;
 import ast;
 import attr local;
 import diagnostics;
+import string_pool;
 import warning_flags;
 
 import stdlib;
@@ -31,6 +32,7 @@ type Entry struct {
 
 public type Handler struct @(opaque) {
     diagnostics.Diags* diags;   // no ownership
+    string_pool.Pool* astPool;
     const warning_flags.Flags* warnings;
 
     Entry* entries;
@@ -39,9 +41,11 @@ public type Handler struct @(opaque) {
 }
 
 public fn Handler* create(diagnostics.Diags* diags,
+                          string_pool.Pool* astPool,
                           const warning_flags.Flags* warnings) {
     Handler* h = stdlib.calloc(1, sizeof(Handler));
     h.diags = diags;
+    h.astPool = astPool;
     h.warnings = warnings;
     return h;
 }
@@ -78,7 +82,7 @@ public fn bool Handler.handle(Handler* h, ast.Decl* d, const Attr* a) {
         if (e.name == a.name) return e.func(e.arg, d, a);
     }
     if (!h.warnings.no_unknown_attribute) {
-        h.diags.warn(a.loc, "unknown attribute '%s'", ast.idx2name(a.name));
+        h.diags.warn(a.loc, "unknown attribute '%s'", h.astPool.idx2str(a.name));
     }
     return false;
 }

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -215,7 +215,7 @@ fn void Compiler.build(Compiler* c,
 
     c.parse_queue.init(false, 64);
 
-    c.attr_handler = attr_handler.create(diags, target.getWarnings());
+    c.attr_handler = attr_handler.create(diags, c.astPool, target.getWarnings());
     c.builder = ast_builder.create(c.context,
                                    diags,
                                    c.astPool,

--- a/compiler/compiler_analyse.c2
+++ b/compiler/compiler_analyse.c2
@@ -152,15 +152,17 @@ fn void Compiler.handleImport(void* arg, ast.ImportDecl* id) {
     ast.Module* m = c.allmodules.find(name_idx);
     if (!m) {
         component.Component* comp = c.findModuleComponent(name_idx);
+        const char* mod_name = c.astPool.idx2str(name_idx);
         if (comp) {
             // check if comp is a direct dependency, otherwise module is a private module
             if (c.current.hasDep(comp.getNameIdx())) {
-                c.diags.error(d.getLoc(), "module '%s' is private to component %s", ast.idx2name(name_idx), comp.getName());
+                c.diags.error(d.getLoc(), "module '%s' is private to component %s", mod_name, comp.getName());
             } else {
-                c.diags.error(d.getLoc(), "module '%s' is defined in component %s that is not a dependency of component %s", ast.idx2name(name_idx), comp.getName(), c.current.getName());
+                c.diags.error(d.getLoc(), "module '%s' is defined in component %s that is not a dependency of component %s",
+                              mod_name, comp.getName(), c.current.getName());
             }
         } else {
-            c.diags.error(d.getLoc(), "unknown module: '%s'", ast.idx2name(name_idx));
+            c.diags.error(d.getLoc(), "unknown module: '%s'", mod_name);
         }
         return;
     }

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -111,6 +111,9 @@ type Generator struct {
     StringList funcnames;
 }
 
+fn const char* Generator.idx2name(const Generator* gen, u32 name_idx) {
+    return gen.astPool.idx2str(name_idx);
+}
 
 const char[] Dir = "cgen";
 const char[] LogFile = "build.log";
@@ -155,7 +158,7 @@ fn void Generator.emitCName(Generator* gen, string_buffer.Buf* out, const Decl* 
     gen.emitCNameMod(out, d, gen.mod);
 }
 
-fn void Generator.emitCNameMod(Generator* /*gen*/, string_buffer.Buf* out, const Decl* d, Module* mod) {
+fn void Generator.emitCNameMod(Generator* gen, string_buffer.Buf* out, const Decl* d, Module* mod) {
     if (!d.getName()) return;
     if (d.isExternal() && d.getModule().isForeign()) {
         const char* cname = d.getCName();
@@ -180,7 +183,7 @@ c2_style:
         FunctionDecl* fd = (FunctionDecl*)d;
         Ref* prefix = fd.getPrefix();
         if (prefix) {
-            out.add(ast.idx2name(prefix.name_idx));
+            out.add(gen.idx2name(prefix.name_idx));
             out.add1('_');
         }
     }

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -168,7 +168,7 @@ fn void Generator.emitExpr2(Generator* gen, string_buffer.Buf* out, Expr* e, C_P
 }
 
 fn void Generator.emitStringLiteral(Generator* gen, string_buffer.Buf* out, const StringLiteral* s, bool raw = false) {
-    const char* p = idx2name(s.getTextIndex());
+    const char* p = gen.idx2name(s.getTextIndex());
     u32 len = s.getSize() - 1;
     if (!raw && len > 10) {
         // break long string with embedded newlines on multiple lines

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -242,7 +242,7 @@ fn void emitAsmPart(string_buffer.Buf* out, bool multi_line, u32 indent) {
 
 fn void Generator.emitAsmOperand(Generator* gen, string_buffer.Buf* out, u32 name, const Expr* c, Expr* e) {
     if (name) {
-        out.print("[%s] ", ast.idx2name(name));
+        out.print("[%s] ", gen.idx2name(name));
     }
     gen.emitStringLiteral(out, (const StringLiteral*)c);
     out.add(" (");

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -101,6 +101,10 @@ fn void Generator.free(Generator* gen) {
     gen.locals.free();
 }
 
+fn const char* Generator.idx2name(const Generator* gen, u32 name_idx) {
+    return gen.names.idx2str(name_idx);
+}
+
 fn void Generator.enterScope(Generator* gen, u32 break_block, u32 continue_block) {
     assert(gen.num_scopes < elemsof(gen.scopes));
     JumpScope* s = &gen.scopes[gen.num_scopes];
@@ -152,7 +156,7 @@ fn const char* Generator.createSymbolName(Generator* gen, const Decl* d) {
                 FunctionDecl* fd = (FunctionDecl*)d;
                 ast.Ref* prefix = fd.getPrefix();
                 if (prefix) {
-                    out.add(ast.idx2name(prefix.name_idx));
+                    out.add(gen.idx2name(prefix.name_idx));
                     out.add1('_');
                 }
             } else if (d.isEnumConstant()) {


### PR DESCRIPTION
* `ast.idx2name()` uses global variable `globals`, should be removed
* add handlers in `Analyser`, `Scope`... to convert `astPool` name indexes to string pointers directly
* some simplifications