### PR TITLE
IR-Generator: use `QualType.getElemSize()` in `Generator.emitArraySub…

### DIFF
--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -214,9 +214,14 @@ public fn u32 QualType.getAlignment(const QualType qt) {
     return t.getAlignment();
 }
 
-public fn u32 QualType.getSize(const QualType qt, bool deref_ptr) {
+public fn u32 QualType.getSize(const QualType qt) {
     const Type* t = qt.getType();
-    return t.getSize(deref_ptr);
+    return t.getSize();
+}
+
+public fn u32 QualType.getElemSize(const QualType qt) {
+    const Type* t = qt.getType();
+    return t.getElemSize();
 }
 
 public fn bool QualType.isBool(const QualType qt) {

--- a/ast/type.c2
+++ b/ast/type.c2
@@ -135,22 +135,35 @@ fn u32 Type.getAlignment(const Type* t) {
     return getWordSize();
 }
 
-fn u32 Type.getSize(const Type* t, bool deref_ptr) {
+fn u32 Type.getElemSize(const Type* t) {
+    switch (t.getKind()) {
+    case Pointer:
+        const PointerType* pt = (PointerType*)t;
+        QualType inner = pt.getInner();
+        return inner.getSize();
+    case Array:
+        const ArrayType* at =  (ArrayType*)t;
+        QualType elem = at.getElemType();
+        return elem.getSize();
+    case Alias:
+        QualType canon = t.getCanonicalType();
+        return canon.getElemSize();
+    default:
+        return 1;
+    }
+}
+
+fn u32 Type.getSize(const Type* t) {
     switch (t.getKind()) {
     case Builtin:
         const BuiltinType* bi =  (BuiltinType*)t;
         return bi.getAlignment();   // note: alignment is size
     case Pointer:
-        if (deref_ptr) {
-            const PointerType* pt = (PointerType*)t;
-            QualType inner = pt.getInner();
-            return inner.getSize(deref_ptr);
-        }
         break;
     case Array:
         const ArrayType* at =  (ArrayType*)t;
         QualType elem = at.getElemType();
-        return at.getSize() * elem.getSize(false);
+        return at.getSize() * elem.getSize();
     case Struct:
         const StructType* s = (StructType*)t;
         const StructTypeDecl* std = s.getDecl();
@@ -159,14 +172,14 @@ fn u32 Type.getSize(const Type* t, bool deref_ptr) {
         const EnumType * e = (EnumType*)t;
         const EnumTypeDecl* etd = e.getDecl();
         QualType it = etd.getImplType();
-        return it.getTypeOrNil().getSize(false);
+        return it.getSize();
     case Function:
         break;
     case Void:
         return 0;
     case Alias:
         QualType canon = t.getCanonicalType();
-        return canon.getAlignment();
+        return canon.getSize();
     case Module:
         // should not happen
         return 0;

--- a/generator/ir/field_struct_layouter.c2
+++ b/generator/ir/field_struct_layouter.c2
@@ -99,7 +99,7 @@ fn void FieldStructLayouter.finalize(FieldStructLayouter* l) {
         const FieldInit* fi = &l.inits[i];
         const ast.Expr* e = fi.expr;
         ast.QualType qt = e.getType();
-        u32 size = qt.getSize(false);
+        u32 size = qt.getSize();
         // TODO dont get from type, already set is Layout
 
         // TODO merge bit-fields and/or other CTV fields

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -415,7 +415,7 @@ fn void Generator.emitArrayInit(Generator* gen, const Expr* e) {
     ArrayType* at = qt.getArrayType();
     u32 array_size = at.getSize();  // TODO use for un-initialized stuff
     QualType et = at.getElemType();
-    u32 elem_size = et.getSize(false);
+    u32 elem_size = et.getSize();
 
     if (ile.hasDesignators()) {
         // TODO handle sparse arrays
@@ -554,7 +554,7 @@ fn void on_var_decl(void* arg, VarDecl* vd) {
 
     c.startGlobal(gen_idx);
     const Expr* ie = vd.getInit();
-    u32 size = qt.getSize(false);
+    u32 size = qt.getSize();
     if (ie) {
         gen.emitInit(ie, size);
     } else {
@@ -630,7 +630,7 @@ fn void Generator.addLocalVar(Generator* gen, VarDecl* vd) {
     }
 
     // emit alloc (LocalSlot)
-    u32 size = qt.getSize(false);
+    u32 size = qt.getSize();
     // TODO filter duplicates (0-100?) Q: filter here or in Context?
     ir.Ref size_ref = gen.ctx.addIntegerConstant(size);
     ir.Ref slot = gen.ctx.addStackSlot(align, size_ref);
@@ -712,7 +712,7 @@ fn void Generator.collectLocalVars(Generator* gen, Stmt* s) {
                 ir.Ref ref;
                 gen.emitVarDecl(&ref, d);
                 QualType qt = d.getType();
-                u32 size = qt.getSize(false);
+                u32 size = qt.getSize();
 
                 const Expr* ie = vd.getInit();
                 gen.ctx.startGlobal((u32)ref.value);

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -510,15 +510,15 @@ fn void Generator.emitArraySubscript(Generator* gen, ir.Ref* result, const Expr*
     Expr* base = a.getBase();
     Expr* index = a.getIndex();
     QualType qt = base.getType();
-    u32 base_size = qt.getSize(true);
+    u32 elem_size = qt.getElemSize();
 
     if (index.isCtv()) {
         ir.Ref base_ref;
         gen.emitExpr(&base_ref, base);
 
-        // offset = value * base_size;
+        // offset = value * elem_size;
         Value v = ast.evalExpr(index);
-        u32 offset = v.as_u32() * base_size;
+        u32 offset = v.as_u32() * elem_size;
         if (offset == 0) {
             *result = base_ref;
         } else {
@@ -533,11 +533,11 @@ fn void Generator.emitArraySubscript(Generator* gen, ir.Ref* result, const Expr*
         ir.Ref idx_ref;
         gen.emitExpr(&idx_ref, index);
 
-        // offset = value * base_size;
-        if (base_size == 1) {
+        // offset = value * elem_size;
+        if (elem_size == 1) {
             *result = gen.ctx.addBinaryInstr(InstrKind.Add, base_ref, idx_ref);
         } else {
-            ir.Ref size_ref = gen.ctx.addIntegerConstant(base_size);
+            ir.Ref size_ref = gen.ctx.addIntegerConstant(elem_size);
             ir.Ref offset_ref = gen.ctx.addBinaryInstr(InstrKind.Mul, idx_ref, size_ref);
             // add base and offset
             *result = gen.ctx.addBinaryInstr(InstrKind.Add, base_ref, offset_ref);


### PR DESCRIPTION
…script`

* remove `deref_ptr` argument from `QualType.getSize()`: should only have been dereferenced once for pointers and was incorrect for arrays
* add more explicit `getElemSize()` type function
* fix case of `Alias` type (returned alignment instead of size)
* simplify code