### PR TITLE
AST: simplify uses of ast_idx

### DIFF
--- a/ast/ast.c2
+++ b/ast/ast.c2
@@ -52,7 +52,7 @@ fn AST* AST.create(string_pool.Pool* auxPool, u32 name, Module* mod, bool is_int
     a.mod = mod;
     a.auxPool = auxPool;
     a.name = name;
-    a.idx = addAST(a);
+    a.idx = globals.addAST(a);
     a.is_interface = is_interface;
     a.is_generated = is_generated;
     a.imports.init();

--- a/ast/decl.c2
+++ b/ast/decl.c2
@@ -198,9 +198,7 @@ public fn SrcLoc Decl.getLoc(const Decl* d) { return d.loc; }
 public fn QualType Decl.getType(const Decl* d) { return d.qt; }
 public fn void Decl.setType(Decl* d, QualType qt) { d.qt = qt; }
 
-public fn AST* Decl.getAST(const Decl* d) { return idx2ast(d.ast_idx); }
-
-fn u32 Decl.getASTIdx(const Decl* d) { return d.ast_idx; }
+public fn AST* Decl.getAST(const Decl* d) { return globals.idx2ast(d.ast_idx); }
 
 fn u32 Decl.getOffset(const Decl* d) @(unused) { return d.offset; }
 

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -335,7 +335,7 @@ public fn void FunctionDecl.setInstanceName(FunctionDecl* d, u32 name_idx) {
 }
 
 public fn Module* FunctionDecl.getInstanceModule(FunctionDecl* d) {
-    if (d.flags.instance_ast_idx) return idx2ast(d.flags.instance_ast_idx).getMod();
+    if (d.flags.instance_ast_idx) return globals.idx2ast(d.flags.instance_ast_idx).getMod();
     return nil;
 }
 

--- a/ast/function_type_decl.c2
+++ b/ast/function_type_decl.c2
@@ -23,10 +23,10 @@ public type FunctionTypeDecl struct @(opaque) {
     FunctionDecl* func;
 }
 
-public fn FunctionTypeDecl* FunctionTypeDecl.create(ast_context.Context* c, FunctionDecl* func) {
+public fn FunctionTypeDecl* FunctionTypeDecl.create(ast_context.Context* c, FunctionDecl* func, u32 ast_idx) {
     FunctionTypeDecl* ftd = c.alloc(sizeof(FunctionTypeDecl));
     Decl* d = func.asDecl();
-    ftd.base.init(FunctionType, d.getNameIdx(), d.getLoc(), d.isPublic(), d.getType(), d.getASTIdx());
+    ftd.base.init(FunctionType, d.getNameIdx(), d.getLoc(), d.isPublic(), d.getType(), ast_idx);
     ftd.func = func;
 #if AstStatistics
     Stats.addDecl(FunctionType, sizeof(FunctionTypeDecl));

--- a/ast/module.c2
+++ b/ast/module.c2
@@ -33,7 +33,7 @@ public type Module struct @(opaque) {
     u32 is_private : 1;    // for source-libs
     ModuleType* mt;
 
-    ast.AST** files;
+    AST** files;
     u32 num_files;
     u32 max_files;
 
@@ -179,17 +179,17 @@ public fn u32 Module.getNameIdx(const Module* m) { return m.name_idx; }
 
 fn void Module.resizeFiles(Module* m, u32 cap) {
     m.max_files = cap;
-    void* buf = stdlib.malloc(m.max_files * sizeof(ast.AST*));
+    void* buf = stdlib.malloc(m.max_files * sizeof(AST*));
     if (m.files) {
         void* old = m.files;
-        string.memcpy(buf, old, m.num_files * sizeof(ast.AST*));
+        string.memcpy(buf, old, m.num_files * sizeof(AST*));
         stdlib.free(old);
     }
     m.files = buf;
 }
 
-public fn ast.AST* Module.add(Module* m, string_pool.Pool* auxPool, u32 filename, bool is_interface, bool is_generated) {
-    ast.AST* a = ast.AST.create(auxPool, filename, m, is_interface, is_generated);
+public fn AST* Module.add(Module* m, string_pool.Pool* auxPool, u32 filename, bool is_interface, bool is_generated) {
+    AST* a = AST.create(auxPool, filename, m, is_interface, is_generated);
 
     if (m.num_files == m.max_files) m.resizeFiles(m.max_files * 2);
 
@@ -198,31 +198,31 @@ public fn ast.AST* Module.add(Module* m, string_pool.Pool* auxPool, u32 filename
     return a;
 }
 
-public fn void Module.addSymbol(Module* m, u32 name_idx, ast.Decl* d) {
+public fn void Module.addSymbol(Module* m, u32 name_idx, Decl* d) {
     m.symbols.add(name_idx, d);
 }
 
-public fn ast.Decl* Module.findSymbol(const Module* m, u32 name_idx) {
+public fn Decl* Module.findSymbol(const Module* m, u32 name_idx) {
     return m.symbols.find(name_idx);
 }
 
-public fn ast.Decl* Module.findPublicSymbol(const Module* m, u32 name_idx) {
+public fn Decl* Module.findPublicSymbol(const Module* m, u32 name_idx) {
     return m.symbols.findPublic(name_idx);
 }
 
-public fn ast.Decl* Module.findPrivateSymbol(const Module* m, u32 name_idx) {
+public fn Decl* Module.findPrivateSymbol(const Module* m, u32 name_idx) {
     return m.symbols.findPrivate(name_idx);
 }
 
-public fn ast.FunctionDecl* Module.findInstance(const Module* m, ast.FunctionDecl* fd, QualType qt) {
+public fn FunctionDecl* Module.findInstance(const Module* m, FunctionDecl* fd, QualType qt) {
     return m.instances.find(fd, qt);
 }
 
-public fn u16 Module.addInstance(Module* m, ast.FunctionDecl* fd, QualType qt, ast.FunctionDecl* instance) {
+public fn u16 Module.addInstance(Module* m, FunctionDecl* fd, QualType qt, FunctionDecl* instance) {
     return m.instances.add(fd, qt, instance);
 }
 
-public fn ast.FunctionDecl* Module.getInstance(const Module* m, ast.FunctionDecl* fd, u32 idx) {
+public fn FunctionDecl* Module.getInstance(const Module* m, FunctionDecl* fd, u32 idx) {
     return m.instances.get(fd, idx);
 }
 

--- a/ast/static_assert.c2
+++ b/ast/static_assert.c2
@@ -44,7 +44,7 @@ public fn StaticAssert* StaticAssert.create(ast_context.Context* c,
 }
 
 public fn AST* StaticAssert.getAST(const StaticAssert* d) {
-    return idx2ast(d.ast_idx);
+    return globals.idx2ast(d.ast_idx);
 }
 
 public fn Expr* StaticAssert.getLHS(const StaticAssert* d) {

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -134,7 +134,7 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
     g.wordsize = wordsize;
     g.use_color = use_color;
     g.names_pool = astPool;
-    g.ast_count = 1;
+    g.ast_count = 0;
     g.ast_capacity = 0;
     g.ast_list = nil;
     g.dump_buf = string_buffer.create(4096, use_color, 2);
@@ -142,6 +142,8 @@ public fn void initialize(Context* c, string_pool.Pool* astPool, u32 wordsize, b
     g.stats.reset();
 #endif
     globals = g;  // must be set here because BuiltinType.create calls Stats.addType
+
+    g.addAST(nil);  // ensure idx2ast(0) is nil
 
     // create all Qualtypes for builtin-types
     for (BuiltinKind kind = BuiltinKind.min; kind <= BuiltinKind.max; kind++) {
@@ -206,37 +208,28 @@ public fn QualType getBuiltinQT(BuiltinKind kind) {
     return globals.builtins[kind];
 }
 
-fn u32 addAST(AST* ast_) {
-    Globals* g = globals;
+fn u32 Globals.addAST(Globals* g, AST* a) {
     if (g.ast_count >= g.ast_capacity) {
         if (g.ast_capacity == 0) g.ast_capacity = 16;
         else g.ast_capacity *= 2;
 
-        void* buf = stdlib.malloc(g.ast_capacity * sizeof(ast.AST*));
+        void* buf = stdlib.malloc(g.ast_capacity * sizeof(AST*));
         if (g.ast_list) {
             void* old = g.ast_list;
-            string.memcpy(buf, old, g.ast_count * sizeof(ast.AST*));
+            string.memcpy(buf, old, g.ast_count * sizeof(AST*));
             stdlib.free(old);
         }
         g.ast_list = buf;
     }
 
     u32 idx = g.ast_count;
-    g.ast_list[idx] = ast_;
+    g.ast_list[idx] = a;
     g.ast_count++;
     return idx;
 }
 
-/*
-public fn u32 ast2idx(const AST* ast_) {
-    if (ast_) return ast_.idx;
-    return 0;
-}
-*/
-
-fn AST* idx2ast(u32 idx) {
-    if (idx == 0) return nil;
-    return globals.ast_list[idx];
+fn AST* Globals.idx2ast(Globals* g, u32 idx) {
+    return g.ast_list[idx];
 }
 
 fn string_buffer.Buf* getDumpBuf() {

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -204,7 +204,7 @@ public fn Decl* Builder.actOnFunctionTypeDecl(Builder* b,
                                            is_variadic,
                                            Type);
 
-    FunctionTypeDecl* d = FunctionTypeDecl.create(b.context, fd);
+    FunctionTypeDecl* d = FunctionTypeDecl.create(b.context, fd, b.ast_idx);
     b.ast.addTypeDecl(d.asDecl());
     Decl* dd = (Decl*)d;
     if (b.is_interface) {


### PR DESCRIPTION
* make `idx2ast` and `addAst` type methods of `globals`
* ensure `globals.ast_list[0]` is `nil` and simplify `idx2ast()`
* remove redundant `ast` prefix in ast/module.c2 and
* remove `Decl.getASTIdx`