### PR TITLE
Analyser: simplify conversion checker

### DIFF
--- a/analyser/conversion_checker.c2
+++ b/analyser/conversion_checker.c2
@@ -39,7 +39,7 @@ import src_loc local;
 // 15 = Builtin -> Func
 // 16 = Func -> Builtin
 // 17 = Anything -> Void
-const u8[elemsof(TypeKind)][elemsof(TypeKind)] Conversions = {
+const u8[TypeKind][TypeKind] Conversions = {
     //  Builtin Pointer Array   Struct  Enum    Func   Void     Alias    Module
     //  Builtin ->
     {   2,      3,      1,      1,     13,     15,     17,     0,      0   },
@@ -70,37 +70,36 @@ const u8[elemsof(TypeKind)][elemsof(TypeKind)] Conversions = {
 //  6 = loss of FP-precision
 //  7 = ok, no conversion needed (eg. char -> u8, isize -> i64, i32 -> bool)
 // No need to adjust for 32-bit as ISize and USize are converted before the lookup
-const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] BuiltinConversions = {
-    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32  Flt64  ISize  USize  Bool
-    //  1      2      3      4      5      6      7      8      9      10     11     12     13     14
-    // Char ->
-    {   0,     3,     1,     1,     1,     7,     1,     1,     1,     1,     1,     1,     1,     7  },
-    // Int8 ->
-    {   3,     0,     1,     1,     1,     3,     3,     3,     3,     1,     1,     1,     3,     7  },
-    // Int16 ->
-    {   4,     4,     0,     1,     1,     4,     3,     3,     3,     1,     1,     1,     3,     7  },
-    // Int32 ->
-    {   4,     4,     4,     7,     1,     4,     4,     3,     3,     1,     1,     1,     3,     7  },
-    // Int64 ->
-    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     7,     3,     7  },
-    // UInt8 ->
-    {   1,     3,     1,     1,     1,     0,     1,     1,     1,     1,     1,     3,     1,     7  },
-    // UInt16 ->
-    {   4,     4,     3,     1,     1,     4,     0,     1,     1,     1,     1,     3,     1,     7  },
-    // UInt32 ->
-    {   4,     4,     4,     3,     1,     4,     4,     7,     1,     1,     1,     3,     1,     7  },
-    // UInt64 ->
-    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     7,     7  },
-    // Flt32 ->
-    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     0,     1,     5,     5,     2  },
-    // Flt64 ->
-    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     6,     0,     5,     5,     2  },
-    // ISize ->
-    {   4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     0,     3,     7  },
-    // USize ->
-    {   4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     0,     7  },
+const u8[BuiltinKind][BuiltinKind] BuiltinConversions = {
+    //  Bool   Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32  Flt64  ISize  USize
     // Bool ->
-    {   1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     0  },
+    {   0,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1,     1  },
+    // Char ->
+    {   7,     0,     3,     1,     1,     1,     7,     1,     1,     1,     1,     1,     1,     1  },
+    // Int8 ->
+    {   7,     3,     0,     1,     1,     1,     3,     3,     3,     3,     1,     1,     1,     3  },
+    // Int16 ->
+    {   7,     4,     4,     0,     1,     1,     4,     3,     3,     3,     1,     1,     1,     3  },
+    // Int32 ->
+    {   7,     4,     4,     4,     7,     1,     4,     4,     3,     3,     1,     1,     1,     3  },
+    // Int64 ->
+    {   7,     4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     7,     3  },
+    // UInt8 ->
+    {   7,     1,     3,     1,     1,     1,     0,     1,     1,     1,     1,     1,     3,     1  },
+    // UInt16 ->
+    {   7,     4,     4,     3,     1,     1,     4,     0,     1,     1,     1,     1,     3,     1  },
+    // UInt32 ->
+    {   7,     4,     4,     4,     3,     1,     4,     4,     7,     1,     1,     1,     3,     1  },
+    // UInt64 ->
+    {   7,     4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     7  },
+    // Flt32 ->
+    {   2,     5,     5,     5,     5,     5,     5,     5,     5,     5,     0,     1,     5,     5  },
+    // Flt64 ->
+    {   2,     5,     5,     5,     5,     5,     5,     5,     5,     5,     6,     0,     5,     5  },
+    // ISize ->
+    {   7,     4,     4,     4,     4,     7,     4,     4,     4,     3,     1,     1,     0,     3  },
+    // USize ->
+    {   7,     4,     4,     4,     4,     3,     4,     4,     4,     7,     1,     1,     3,     0  },
 }
 
 public type Checker struct {
@@ -127,7 +126,18 @@ fn bool Checker.conversionError(Checker* c, const char* msg) {
     return false;
 }
 
-public fn bool Checker.check(Checker* c, QualType lhs, QualType rhs, Expr** e_ptr, SrcLoc loc) {
+fn bool Checker.shouldNotHappen(Checker* c, const char* from @(auto_func),
+                                const Type* lcanon, const Type* rcanon, u8 res)
+{
+    c.diags.error(c.loc, "%s: SHOULD NOT HAPPEN (%s -> %s, res=%d)\n",
+                  from, rcanon.getKind().name, lcanon.getKind().name, res);
+    c.lhs.dump_full();
+    c.rhs.dump_full();
+    assert(0);
+    return false;
+}
+
+public fn bool Checker.checkAssign(Checker* c, QualType lhs, QualType rhs, Expr** e_ptr, SrcLoc loc) {
     assert(lhs.ptr);
     assert(rhs.ptr);
     assert(!(*e_ptr).isNValue());
@@ -146,19 +156,7 @@ public fn bool Checker.check(Checker* c, QualType lhs, QualType rhs, Expr** e_pt
     const Type* lcanon = t1.getTypeOrNil();
     const Type* rcanon = t2.getTypeOrNil();
 
-    if (lcanon == rcanon) {
-#if 0   // This is bogus!
-        //u32 lquals = lhs.getQuals();
-        //u32 rquals = rhs.getQuals();
-        // TODO: check constness of pointed thing instead of that of pointer
-        if (lcanon.getKind() == Pointer && rhs.isConst() && !lhs.isConst()) {
-            // TODO volatile discard?
-            c.diags.error(loc, "conversion discards const qualifier");
-            return false;
-        }
-#endif
-        return true;
-    }
+    if (lcanon == rcanon) return true;
 
     c.lhs = lhs;
     c.rhs = rhs;
@@ -171,15 +169,14 @@ public fn bool Checker.check(Checker* c, QualType lhs, QualType rhs, Expr** e_pt
 fn bool Checker.checkTypes(Checker* c, const Type* lcanon, const Type* rcanon) {
 
     u8 res = Conversions[rcanon.getKind()][lcanon.getKind()];
-
     switch (res) {
     case 0: // cannot happen
-        c.diags.error(c.loc, "SHOULD NOT HAPPEN (%d - %d)\n", lcanon.getKind(), rcanon.getKind());
-        c.lhs.dump_full();
-        c.rhs.dump_full();
-        assert(0);
-        return false;
+        break;
     case 1: // not allowed
+    case 8: //  8 = Array -> Array
+    case 13: // Builtin -> Enum
+    case 14: // Enum -> Enum (not allowed, since the ptr check already filters out the allowed ones)
+    case 15: // Builtin -> Func
         return c.conversionError("invalid type conversion from");
     case 2: //  2 = Builtin -> Builtin
         return c.checkBuiltins(lcanon, rcanon);
@@ -192,13 +189,7 @@ fn bool Checker.checkTypes(Checker* c, const Type* lcanon, const Type* rcanon) {
     case 6: //  6 = Pointer -> Func (void* or Func*)
         return c.checkPointer2Func(lcanon, rcanon);
     case 7: //  7 = Array -> Pointer
-        c.diags.note(c.loc, "SHOULD NOT HAPPEN (Array -> Ptr)");
-        c.lhs.dump_full();
-        c.rhs.dump_full();
-        assert(0);
-        return false;
-    case 8: //  8 = Array -> Array
-        return c.conversionError("invalid type conversion from");
+        break;  // should not happen
     case 9: //  9 = Struct -> Struct
         return c.conversionError("conversion between struct of different types:");
     case 10: // 10 = Enum -> Builtin (check range)
@@ -207,18 +198,14 @@ fn bool Checker.checkTypes(Checker* c, const Type* lcanon, const Type* rcanon) {
         return c.checkFunc2Pointer(lcanon, rcanon);
     case 12: // Func -> Func
         return c.checkFunc2Func(lcanon, rcanon);
-    case 13: // Builtin -> Enum
-    case 14: // Enum -> Enum (not allowed, since the ptr check already filters out the allowed ones)
-    case 15: // Builtin -> Func
-        return c.conversionError("invalid type conversion from");
     case 16: // Function -> Builtin
         return c.checkFunc2Builtin(lcanon, rcanon, false);
     case 17: // Anything -> Void
         return true;
     default:
-        c.diags.note(c.loc, "TODO CONVERSION  %d)", res);
-        return false;
+        break;
     }
+    return c.shouldNotHappen(lcanon, rcanon, res);
 }
 
 fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon) {
@@ -234,13 +221,11 @@ fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon
     u8 res = BuiltinConversions[rbuiltin.getBaseKind()][lbuiltin.getBaseKind()];
     switch (res) {
     case 0:     // should not happen
-        c.diags.error(c.loc, "BUILTIN SHOULD NOT HAPPEN (%d - %d)\n", lcanon.getKind(), rcanon.getKind());
-        assert(0);
-        return false;
+        break;
     case 1:     // ok, needs conversion
         //c.diags.note(c.loc, "WIDEN %s -> %s", c.rhs.diagName(), c.lhs.diagName());
         c.builder.insertImplicitCast(IntegralCast, c.expr_ptr, c.lhs);
-        break;
+        return true;
     case 2:     // incompatible
         return c.conversionError("invalid type conversion from");
     case 3:     // sign-conversion
@@ -250,7 +235,7 @@ fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon
             // TODO: is this just a warning?
             c.conversionError("implicit conversion changes signedness:");
         }
-        break;
+        return true;
     case 4:     // loss of integer-precision
         if (c.checkIntConversion(lbuiltin)) {
             c.builder.insertImplicitCast(IntegralCast, c.expr_ptr, c.lhs);
@@ -258,11 +243,11 @@ fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon
             // TODO: is this just a warning?
             c.conversionError("implicit conversion loses integer precision:");
         }
-        break;
+        return true;
     case 5:     // float -> integer
         // TODO: is this just a warning?
         c.conversionError("implicit conversion turns floating-point number into integer:");
-        break;
+        return true;
     case 6:     // loss of FP-precision
         if ((*c.expr_ptr).isCtv()) {
             c.builder.insertImplicitCast(IntegralCast, c.expr_ptr, c.lhs);
@@ -270,15 +255,13 @@ fn bool Checker.checkBuiltins(Checker* c, const Type* lcanon, const Type* rcanon
             // TODO: is this just a warning?
             c.conversionError("implicit conversion loses floating-point precision:");
         }
-        break;
+        return true;
     case 7:     // ok, no conversion needed
-        break;
+        return true;
     default:
-        assert(0);
-        return false;
+        break;
     }
-
-    return true;
+    return c.shouldNotHappen(lcanon, rcanon, res);
 }
 
 fn bool Checker.checkBuiltin2Pointer(Checker* c, const Type* lcanon, const Type* rcanon) {
@@ -458,7 +441,7 @@ fn bool Checker.checkEnum2Int(Checker* c, const Type* lcanon, const Type* rcanon
         const EnumTypeDecl* etd = et.getDecl();
         QualType impl = etd.getImplType();
 
-        return c.check(c.lhs, impl, c.expr_ptr, c.loc);
+        return c.checkAssign(c.lhs, impl, c.expr_ptr, c.loc);
     }
 }
 
@@ -489,29 +472,24 @@ fn bool checkFunc2Func(const FunctionDecl* fdl, const FunctionDecl* fdr) {
     u32 num1 = fdl.getNumParams();
     u32 num2 = fdr.getNumParams();
     if (num1 != num2) return false;
+    if (fdl.isVariadic() != fdr.isVariadic()) return false;
 
     Decl** args1 = (Decl**)fdl.getParams();
     Decl** args2 = (Decl**)fdr.getParams();
     for (u32 i=0; i<num1; i++) {
         Decl* a1 = args1[i];
         Decl* a2 = args2[i];
-
-        ql = a1.getType();
-        qr = a2.getType();
-        if (ql.ptr != qr.ptr) {
-            if (ql.isFunction() && qr.isFunction()) {
-                FunctionType* ft = ql.getFunctionType();
-                FunctionDecl* fd1 = ft.getDecl();
-                ft = qr.getFunctionType();
-                FunctionDecl* fd2 = ft.getDecl();
+        QualType qt1 = a1.getType();
+        QualType qt2 = a2.getType();
+        if (qt1.ptr != qt2.ptr) {
+            if (qt1.isFunction() && qt2.isFunction()) {
+                FunctionDecl* fd1 = qt1.getFunctionType().getDecl();
+                FunctionDecl* fd2 = qt2.getFunctionType().getDecl();
                 if (checkFunc2Func(fd1, fd2)) continue;
             }
             return false;
         }
     }
-
-    if (fdl.isVariadic() != fdr.isVariadic()) return false;
-
     return true;
 }
 
@@ -558,54 +536,34 @@ public fn bool Checker.checkCast(Checker* c, QualType lhs, QualType rhs, SrcLoc 
     u8 res = Conversions[rcanon.getKind()][lcanon.getKind()];
     switch (res) {
     case 0: // cannot happen
-        c.diags.error(lhsLoc, "SHOULD NOT HAPPEN (%d - %d)\n", lcanon.getKind(), rcanon.getKind());
-        c.lhs.dump_full();
-        c.rhs.dump_full();
-        assert(0);
-        return false;
+        break;
     case 1: // not allowed
         return c.conversionError("invalid cast from");
     case 2: //  2 = Builtin -> Builtin
-        // Allow all, except to/from void
-        return true;
+    case 5: //  5 = Pointer -> Pointer
+    case 6: //  6 = Pointer -> Func (void* or Func*)
+    case 10: // 10 = Enum -> Builtin
+    case 11: // 11 = Func -> Pointer (void* or Func*)
+    case 12: // Func -> Func
+    case 13: // Builtin -> Enum
+    case 14: // Enum -> Enum
+        return true;    // always allow
     case 3: //  3 = Builtin -> Pointer (only if usize/u64/u32)
         return c.checkBuiltin2PointerCast(lcanon, rcanon);
     case 4: //  4 = Pointer -> Builtin (only if usize/u64/u32)
         return c.checkPointer2BuiltinCast(lcanon, rcanon);
-    case 5: //  5 = Pointer -> Pointer
-        return true;    // always allow
-    case 6: //  6 = Pointer -> Func (void* or Func*)
-        return true;    // always allow
     case 7: //  7 = Array -> Pointer
-        c.diags.note(c.loc, "SHOULD NOT HAPPEN (Array -> Ptr)");
-        assert(0);
-        return false;
     case 8: //  8 = Array -> Array
-        c.diags.error(lhsLoc, "SHOULD NOT HAPPEN (%d - %d)\n", lcanon.getKind(), rcanon.getKind());
-        assert(0);
-        return false;
     case 9: //  9 = Struct -> Struct
-        c.diags.error(lhsLoc, "SHOULD NOT HAPPEN (%d - %d)\n", lcanon.getKind(), rcanon.getKind());
-        assert(0);
-        return false;
-    case 10: // 10 = Enum -> Builtin
-        return true;    // always allow
-    case 11: // 11 = Func -> Pointer (void* or Func*)
-        return true;    // always allow
-    case 12: // Func -> Func
-        return true;    // always allow
-    case 13: // Builtin -> Enum
-        return true;    // always allow
-    case 14: // Enum -> Enum
-        return true;    // always allow
+        break;  // should not happen
     case 15: // Builtin -> Func
         return c.checkBuiltin2PointerCast(lcanon, rcanon);
     case 16: // Func -> Builtin
         return c.checkFunc2Builtin(lcanon, rcanon, true);
     default:
-        c.diags.note(c.loc, "TODO CONVERSION  %d)", res);
-        return false;
+        break;
     }
+    return c.shouldNotHappen(lcanon, rcanon, res);
 }
 
 fn bool Checker.checkBuiltin2PointerCast(Checker* c, const Type* lcanon, const Type* rcanon) {
@@ -638,108 +596,78 @@ fn bool Checker.checkPointer2BuiltinCast(Checker* c, const Type* lcanon, const T
 
 // Just takes smallest type, dont promote both sides to i32
 // No need to adjust for 32-bit as ISize and USize are converted before the lookup
-const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] ConditionalOperatorResult = {
-    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool
-    //  0      1      2      3      4      5      6      7      8      9     10     11     12     13
-    // Char ->
-    {   0,     2,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     0  },
-    // Int8 ->
-    {   2,     1,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     1  },
-    // Int16 ->
-    {   2,     2,     2,     3,     4,     2,     6,     7,     8,     9,    10,    11,    12,     2  },
-    // Int32 ->
-    {   3,     3,     3,     3,     4,     3,     3,     7,     8,     9,    10,    11,    12,     3  },
-    // Int64 ->
-    {   4,     4,     4,     4,     4,     4,     4,     4,     8,     9,    10,    11,    12,     4  },
-    // UInt8 ->
-    {   5,     5,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,     5  },
-    // UInt16 ->
-    {   6,     6,     6,     3,     4,     6,     6,     7,     8,     9,    10,    11,    12,     6  },
-    // UInt32 ->
-    {   7,     7,     7,     7,     7,     7,     7,     7,     8,     9,    10,    11,    12,     7  },
-    // UInt64 ->
-    {   8,     8,     8,     8,     8,     8,     8,     8,     8,     9,    10,    11,    12,     8  },
-    // Flt32 ->
-    {   9,     9,     9,     9,     9,     9,     9,     9,     9,     9,    10,     9,     9,     9  },
-    // Flt64 ->
-    {  10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10,    10  },
-    // ISize ->
-    {  11,    11,    11,    11,    11,    11,    11,    11,     8,     9,    10,    11,    12,    11  },
-    // USize ->
-    {  12,    12,    12,    12,    12,    12,    12,    12,     8,     9,    10,    12,    12,    12  },
+const BuiltinKind X = Bool;  // used as a placeholder for ISize/Usize entries
+const BuiltinKind[BuiltinKind][BuiltinKind] ConditionalOperatorResult = {
+    //  Bool    Char    Int8     Int16    Int32    Int64    UInt8    UInt16   UInt32   UInt64   Float32  Float64 ISize USize
     // Bool ->
-    {   0,     1,     2,     3,     4,     5,     6,     7,     8,     9,    10,    11,    12,    13  },
-}
-public fn QualType get_common_arithmetic_type(BuiltinType* bi1, BuiltinType* bi2) {
-    BuiltinKind kind = (BuiltinKind)ConditionalOperatorResult[bi2.getBaseKind()][bi1.getBaseKind()];
-    return getBuiltinQT(kind);
+    {  Bool,    Char,    Int8,    Int16,   Int32,   Int64,   UInt8,   UInt16,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // Char ->
+    {  Char,    Char,    Int16,   Int16,   Int32,   Int64,   UInt8,   UInt16,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int8 ->
+    {  Int8,    Int16,   Int8,    Int16,   Int32,   Int64,   UInt8,   UInt16,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int16 ->
+    {  Int16,   Int16,   Int16,   Int16,   Int32,   Int64,   Int16,   UInt16,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int32 ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int64 ->
+    {  Int64,   Int64,   Int64,   Int64,   Int64,   Int64,   Int64,   Int64,   Int64,   UInt64,  Float32, Float64, X, X },
+    // UInt8 ->
+    {  UInt8,   UInt8,   UInt8,   Int16,   Int32,   Int64,   UInt8,   UInt16,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // UInt16 ->
+    {  UInt16,  UInt16,  UInt16,  UInt16,  Int32,   Int64,   UInt16,  UInt16,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // UInt32 ->
+    {  UInt32,  UInt32,  UInt32,  UInt32,  UInt32,  UInt32,  UInt32,  UInt32,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // UInt64 ->
+    {  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  Float32, Float64, X, X },
+    // Flt32 ->
+    {  Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float64, X, X },
+    // Flt64 ->
+    {  Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, X, X },
+    // ISize ->
+    {  X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X, X },
+    // USize ->
+    {  X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X, X },
 }
 
-/*
-    Results:
-     0 Int32
-     1 UInt32,
-     2 Int64,
-     3 UInt64,
-     4 Float32,
-     5 Float64,
-     6 error,
-*/
+public fn QualType get_common_arithmetic_type(BuiltinType* bi1, BuiltinType* bi2) {
+    return getBuiltinQT(ConditionalOperatorResult[bi2.getBaseKind()][bi1.getBaseKind()]);
+}
+
 // See ISO/IEC 9899:201x 6.3.1
 // No need to adjust for 32-bit as ISize and USize are converted before the lookup
-const u8[elemsof(BuiltinKind)][elemsof(BuiltinKind)] UsualArithmeticConversions = {
-    //  Char   Int8   Int16  Int32  Int64  UInt8  UInt16 UInt32 UInt64 Flt32 Flt64  ISize  USize  Bool
-    //  0      1      2      3      4      5      6      7      8      9     10     11     12     13
-    // Char ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
-    // Int8 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
-    // Int16 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
-    // Int32 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
-    // Int64 ->
-    {   2,     2,     2,     3,     2,     2,     2,     2,     3,     4,     5,     6,     6,     2  },
-    // UInt8 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
-    // UInt16 ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
-    // UInt32 ->
-    {   1,     1,     1,     1,     3,     1,     1,     1,     3,     4,     5,     6,     6,     1  },
-    // UInt64 ->
-    {   3,     3,     3,     3,     3,     3,     3,     3,     3,     4,     5,     6,     6,     3  },
-    // Flt32 ->
-    {   4,     4,     4,     4,     4,     4,     4,     4,     4,     4,     5,     4,     4,     4  },
-    // Flt64 ->
-    {   5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5,     5  },
-    // ISize ->
-    {   6,     6,     6,     6,     6,     6,     6,     6,     3,     4,     5,     6,     6,     6  },
-    // USize ->
-    {   6,     6,     6,     6,     6,     6,     6,     6,     6,     4,     5,     6,     6,     6  },
+const BuiltinKind[BuiltinKind][BuiltinKind] UsualArithmeticConversions = {
+    // Bool     Char     Int8     Int16    Int32    Int64    UInt8    UInt16   UInt32   UInt64   Float32  Float64  ISize USize
     // Bool ->
-    {   0,     0,     0,     0,     2,     0,     0,     1,     3,     4,     5,     6,     6,     0  },
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // Char ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int8 ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int16 ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int32 ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // Int64 ->
+    {  Int64,   Int64,   Int64,   Int64,   UInt64,  Int64,   Int64,   Int64,   Int64,   UInt64,  Float32, Float64, X, X },
+    // UInt8 ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // UInt16 ->
+    {  Int32,   Int32,   Int32,   Int32,   Int32,   Int64,   Int32,   Int32,   UInt32,  UInt64,  Float32, Float64, X, X },
+    // UInt32 ->
+    {  UInt32,  UInt32,  UInt32,  UInt32,  UInt32,  UInt64,  UInt32,  UInt32,  UInt32,  UInt64,  Float32, Float64, X, X },
+    // UInt64 ->
+    {  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  UInt64,  Float32, Float64, X, X },
+    // Flt32 ->
+    {  Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float32, Float64, X, X },
+    // Flt64 ->
+    {  Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, X, X },
+    // ISize ->
+    {  X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X, X },
+    // USize ->
+    {  X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X,       X, X },
 }
 
-public fn QualType usual_arithmetic_conversion(const BuiltinType* b1, const BuiltinType* b2) {
-    BuiltinKind k1 = b1.getBaseKind();
-    BuiltinKind k2 = b2.getBaseKind();
-
-    switch(UsualArithmeticConversions[k2][k1]) {
-    case 0:
-        return getBuiltinQT(Int32);
-    case 1:
-        return getBuiltinQT(UInt32);
-    case 2:
-        return getBuiltinQT(Int64);
-    case 3:
-        return getBuiltinQT(UInt64);
-    case 4:
-        return getBuiltinQT(Float32);
-    case 5:
-        return getBuiltinQT(Float64);
-    case 6:
-        break;
-    }
-    return QualType_Invalid;
+public fn QualType usual_arithmetic_conversion(const BuiltinType* bi1, const BuiltinType* bi2) {
+    return getBuiltinQT(UsualArithmeticConversions[bi1.getBaseKind()][bi2.getBaseKind()]);
 }
 

--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -44,7 +44,7 @@ const u32 MaxDepth = 8;
 
 public type Analyser struct @(opaque) {
     diagnostics.Diags* diags;
-    conv.Checker checker;
+    conv.Checker conv_checker;
     ast_context.Context* context;
     string_pool.Pool* astPool;
     ast_builder.Builder* builder;
@@ -98,7 +98,7 @@ public fn Analyser* create(diagnostics.Diags* diags,
 {
     Analyser* ma = stdlib.calloc(1, sizeof(Analyser));
     ma.diags = diags;
-    ma.checker.init(diags, builder);
+    ma.conv_checker.init(diags, builder);
     ma.context = context;
     ma.astPool = astPool;
     ma.builder = builder;
@@ -117,7 +117,7 @@ public fn Analyser* create(diagnostics.Diags* diags,
 fn Analyser* Analyser.clone(Analyser* org) {
     Analyser* ma = stdlib.calloc(1, sizeof(Analyser));
     ma.diags = org.diags;
-    ma.checker.init(org.diags, org.builder);
+    ma.conv_checker.init(org.diags, org.builder);
     ma.context = org.context;
     ma.astPool = org.astPool;
     ma.builder = org.builder;
@@ -154,7 +154,7 @@ fn const char* Analyser.getFullName(const Analyser* ma, const Decl* d) {
     return d.getFullName();
 }
 
-public fn void Analyser.check(Analyser* ma, Module* mod) {
+public fn void Analyser.checkModule(Analyser* ma, Module* mod) {
     ma.mod = mod;
     ma.prefix_cache_name = 0;
     ma.prefix_cache_idx = 0;

--- a/analyser/module_analyser_builtin.c2
+++ b/analyser/module_analyser_builtin.c2
@@ -173,7 +173,7 @@ fn QualType Analyser.analyseToContainer(Analyser* ma, BuiltinExpr* b) {
     qmem.copyQuals(pt.getInner());
     QualType expectedType = ma.builder.actOnPointerType(qmem);
 
-    if (!ma.checker.check(expectedType, qptr, pptr, (*pptr).getLoc())) {
+    if (!ma.conv_checker.checkAssign(expectedType, qptr, pptr, (*pptr).getLoc())) {
         return QualType_Invalid;
     }
 

--- a/analyser/module_analyser_call.c2
+++ b/analyser/module_analyser_call.c2
@@ -195,7 +195,7 @@ fn QualType Analyser.analyseCallExpr(Analyser* ma, Expr** e_ptr) {
         }
 
         // TODO FIX loc, will always be memberExpr, so loc should be last one in member
-        bool ok = ma.checker.check(expectedType, baseType, e_ptr, loc);
+        bool ok = ma.conv_checker.checkAssign(expectedType, baseType, e_ptr, loc);
         if (!ok) return QualType_Invalid;
 
         func_arg_index++;

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -477,7 +477,7 @@ fn QualType Analyser.analyseExplicitCast(Analyser* ma, Expr** e_ptr) {
         return QualType_Invalid;
     }
 
-    if (!ma.checker.checkCast(destType, srcType, ref.getLoc(), inner.getLoc())) return QualType_Invalid;
+    if (!ma.conv_checker.checkCast(destType, srcType, ref.getLoc(), inner.getLoc())) return QualType_Invalid;
 
     return destType;
 }

--- a/analyser/module_analyser_init.c2
+++ b/analyser/module_analyser_init.c2
@@ -66,7 +66,7 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
                 QualType qt = ma.analyseExpr(e_ptr, true, RHS);
                 // TODO check qt?
                 e = *e_ptr;
-                if (!ma.checker.check(expectedType, e.getType(), e_ptr, assignLoc)) return false;
+                if (!ma.conv_checker.checkAssign(expectedType, e.getType(), e_ptr, assignLoc)) return false;
             }
             return true;
         }
@@ -99,7 +99,7 @@ fn bool Analyser.analyseInitExpr(Analyser* ma, Expr** e_ptr, QualType expectedTy
         }
     }
 
-    if (!ma.checker.check(expectedType, res, e_ptr, assignLoc)) return false;
+    if (!ma.conv_checker.checkAssign(expectedType, res, e_ptr, assignLoc)) return false;
 
     if (!ma.curFunction && !e.isCtv()) {
         if (!e.isCtc()) {

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -279,7 +279,7 @@ fn QualType Analyser.analyseCondition(Analyser* ma, Stmt** s_ptr, const char* co
     QualType qt = ma.analyseExpr((Expr**)s_ptr, true, RHS);
     Expr* e = (Expr*)*s_ptr;
     if (check_bool) {
-        if (qt.isValid()) ma.checker.check(getBuiltinQT(Bool), qt, (Expr**)s_ptr, e.getLoc());
+        if (qt.isValid()) ma.conv_checker.checkAssign(getBuiltinQT(Bool), qt, (Expr**)s_ptr, e.getLoc());
         e = (Expr*)*s_ptr;    // re-read in case of ImplicitCast insertions
     }
     if (check_assign && e.isAssignment()) {
@@ -316,7 +316,7 @@ fn FlowBits Analyser.analyseIfStmt(Analyser* ma, Stmt* s) {
     if (vd) vd.asDecl().clearUsed();
 
     Expr* e = *condp;
-    bool ok = ma.checker.check(getBuiltinQT(Bool), qt, condp, e.getLoc());
+    bool ok = ma.conv_checker.checkAssign(getBuiltinQT(Bool), qt, condp, e.getLoc());
     e = *condp;    // re-read in case of ImplicitCast insertions
     if (e.isAssignment()) {
         ma.warn(e.getLoc(), "using the result of an assignment as a condition without parentheses");
@@ -356,7 +356,7 @@ fn FlowBits Analyser.analyseForStmt(Analyser* ma, Stmt* s) {
     if (cond) {
         QualType qt = ma.analyseExpr(cond, true, RHS);
         if (qt.isInvalid()) goto done;
-        ma.checker.check(getBuiltinQT(Bool), qt, cond, (*cond).getLoc());
+        ma.conv_checker.checkAssign(getBuiltinQT(Bool), qt, cond, (*cond).getLoc());
         if ((*cond).isCtv()) {
             Value v = ast.evalExpr((*cond));
             if (v.isZero()) {
@@ -524,7 +524,7 @@ fn void Analyser.analyseAssertStmt(Analyser* ma, Stmt* s) {
     if (qt.isInvalid()) return;
 
     Expr* inner = a.getInner();
-    ma.checker.check(getBuiltinQT(Bool), qt, a.getInner2(), inner.getLoc());
+    ma.conv_checker.checkAssign(getBuiltinQT(Bool), qt, a.getInner2(), inner.getLoc());
 
     if (ma.has_asserts) {
         SrcLoc loc = s.getLoc();

--- a/ast/builtin_type.c2
+++ b/ast/builtin_type.c2
@@ -28,6 +28,7 @@ public type BuiltinKind enum u8 (public const char* const name,
                                  const u8 width)
 {
     // Note: align/width is adjusted for 32-bit in globals
+    Bool        : { "bool",  true,  false, false, false, 1,  1 },
     Char        : { "char",  true,  false, true,  true,  1,  8 },
     Int8        : { "i8",    true,  true,  false, true,  1,  8 },
     Int16       : { "i16",   true,  true,  false, true,  2, 16 },
@@ -41,7 +42,6 @@ public type BuiltinKind enum u8 (public const char* const name,
     Float64     : { "f64",   false, true,  false, false, 8,  0 },
     ISize       : { "isize", false, true,  false, true,  0,  0 },
     USize       : { "usize", false, false, true,  true,  0,  0 },
-    Bool        : { "bool",  true,  false, false, false, 1,  1 },
 }
 
 type BuiltinTypeBits struct {

--- a/ast/type.c2
+++ b/ast/type.c2
@@ -17,7 +17,7 @@ module ast;
 
 import string_buffer;
 
-public type TypeKind enum u8 (const char* const name) {
+public type TypeKind enum u8 (public const char* const name) {
     Builtin   : { "Builtin" },
     Pointer   : { "Pointer" },
     Array     : { "Array" },

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -372,6 +372,7 @@ fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
     }
     out.color(col_Attr);
     VarDeclKind k = d.getKind();
+    out.space();
     out.add(k.name);
     if (d.base.varDeclBits.is_bitfield) {
         BitFieldLayout* layout = d.getBitfieldLayout();

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -479,13 +479,13 @@ fn bool Compiler.register_attr(void* arg, u32 name, ast.AttrHandlerFn handler, v
 fn void Compiler.analyseModule(void* arg, ast.Module* m) {
     Compiler* c = arg;
     console.debug("analysing module %s", m.getName());
-    c.analyser.check(m);
+    c.analyser.checkModule(m);
 }
 
 fn void Compiler.analyseUsedModule(void* arg, ast.Module* m) {
     Compiler* c = arg;
     if (m.isUsed()) {
-        c.analyser.check(m);
+        c.analyser.checkModule(m);
     }
 }
 

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -249,6 +249,7 @@ fn void Generator.emitEnumType(Generator* gen, string_buffer.Buf* out, Decl* d) 
 }
 
 const char*[BuiltinKind] builtinType_cnames = {
+    [Bool]    = "bool",
     [Char]    = "char",
     [Int8]    = "i8",
     [Int16]   = "i16",
@@ -262,7 +263,6 @@ const char*[BuiltinKind] builtinType_cnames = {
     [Float64] = "double",
     [ISize]   = "ssize_t",
     [USize]   = "size_t",
-    [Bool]    = "bool",
 }
 
 fn void Generator.emitTypePre(Generator* gen, string_buffer.Buf* out, QualType qt, bool bitfield = false) {

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -195,6 +195,7 @@ fn const char* Generator.createStringVar(Generator* gen) {
 }
 
 const ir.Type[BuiltinKind] Ast_type2ir_type = {
+    [Bool]    = I8,   // TODO ir.Type.I1?
     [Char]    = U8,
     [Int8]    = I8,
     [Int16]   = I16,
@@ -208,7 +209,6 @@ const ir.Type[BuiltinKind] Ast_type2ir_type = {
     [Float64] = F64,
     [ISize]   = I64,  // TODO 32-bit
     [USize]   = U64,  // TODO 32-bit
-    [Bool]    = I8,    // TODO ir.Type.I1?
 }
 
 fn ir.Type builtin2irtype(BuiltinKind k) {


### PR DESCRIPTION
* rename ambiguous objects and type functions:
 - `Analyser.check` -> `Analyser.checkModule`
 - `conversion_checker.Check.check` -> `conversion_checker.Check.checkAssign`
 - `ma.checker` -> `ma.conv_checker`
* remove bogus absolete code in `Checker.checkAssign`
* simplify conversion switches: factorize identical cases