### PR TITLE
Compiler: remove `enum_min` and `enum_max` builtin operators

### DIFF
--- a/analyser/module_analyser_builtin.c2
+++ b/analyser/module_analyser_builtin.c2
@@ -28,9 +28,6 @@ fn QualType Analyser.analyseBuiltin(Analyser* ma, Expr** e_ptr) {
         return ma.analyseSizeof(b);
     case Elemsof:
         return ma.analyseElemsof(b);
-    case EnumMin:
-    case EnumMax:
-        return ma.analyseEnumMinMax(b);
     case OffsetOf:
         return ma.analyseOffsetOf(b);
     case ToContainer:
@@ -86,7 +83,7 @@ fn QualType Analyser.analyseSizeof(Analyser* ma, BuiltinExpr* e) {
     if (qt.isInvalid()) return QualType_Invalid;
 
     size_analyser.TypeSize info = size_analyser.sizeOfType(qt);
-    e.setUValue(info.size);
+    e.setValue(info.size);
     return getBuiltinQT(UInt32);
 }
 
@@ -106,41 +103,17 @@ fn QualType Analyser.analyseElemsof(Analyser* ma, BuiltinExpr* b) {
             ma.error(inner.getLoc(), "elemsof cannot be used on arrays of unknown length");
             return QualType_Invalid;
         }
-        b.setUValue(at.getSize());
+        b.setValue(at.getSize());
         return getBuiltinQT(UInt32);
     }
     const EnumType* et = qt.getEnumTypeOrNil();
     if (et) {
         const EnumTypeDecl* etd = et.getDecl();
-        b.setUValue(etd.getNumConstants());
+        b.setValue(etd.getNumConstants());
         return getBuiltinQT(UInt32);
     }
     ma.error(inner.getLoc(), "elemsof can only be used on arrays/enums");
     return QualType_Invalid;
-}
-
-fn QualType Analyser.analyseEnumMinMax(Analyser* ma, BuiltinExpr* b) {
-    Expr* inner = b.getInner();
-    QualType qt = ma.analyseExpr(&inner, false, RHS);
-    if (qt.isInvalid()) return QualType_Invalid;
-
-    EnumType* et = qt.getEnumTypeOrNil();
-    if (!et) {
-        const char* kind = (b.getKind() == EnumMin) ? "enum_min" : "enum_max";
-        ma.error(inner.getLoc(), "%s can only be used on enum types", kind);
-        return QualType_Invalid;
-    }
-
-    EnumTypeDecl* etd = et.getDecl();
-    u32 num = etd.getNumConstants();
-    EnumConstantDecl** constants = etd.getConstants();
-
-    u32 index = 0;
-    if (b.getKind() == EnumMax) index = num-1;
-    // Since enum constants must be in-order return value of first/last
-    b.setValue(constants[index].getValue());
-
-    return etd.getImplType();
 }
 
 fn QualType Analyser.analyseOffsetOf(Analyser* ma, BuiltinExpr* b) {
@@ -253,7 +226,7 @@ fn Decl* Analyser.findMemberOffsetAux(Analyser* ma, FindMemberOffsetContext* ctx
 fn Decl* Analyser.findMemberOffset(Analyser* ma, BuiltinExpr* b, StructTypeDecl* std, Expr* member) {
     FindMemberOffsetContext ctx = { std, 0 }
     Decl* d = ma.findMemberOffsetAux(&ctx, member);
-    if (d) b.setUValue(ctx.base_offset);
+    if (d) b.setValue(ctx.base_offset);
     return d;
 }
 

--- a/ast/ast_evaluator.c2
+++ b/ast/ast_evaluator.c2
@@ -78,7 +78,7 @@ fn Value Evaluator.get_value(Evaluator* eval, const Expr* e) {
         return eval.get_value(!v.isZero() ? c.getLHS() : c.getRHS());
     case Builtin:
         const BuiltinExpr* bi = (BuiltinExpr*)e;
-        return bi.getValue();
+        return Value.createUnsigned(bi.getValue());
     case ArraySubscript:  // a[high:low], both included
         // note: can be CTV if BitOffsetExpr
         ArraySubscriptExpr* a = (ArraySubscriptExpr*)e;

--- a/ast/builtin_expr.c2
+++ b/ast/builtin_expr.c2
@@ -18,21 +18,21 @@ module ast;
 import ast_context;
 import string_buffer;
 import src_loc local;
-import value_type local;
 
 public type BuiltinExprKind enum u8 (const char* const name) {
     Sizeof      : { "sizeof" },
     Elemsof     : { "elemsof" },
-    EnumMin     : { "enum_min" },
-    EnumMax     : { "enum_max" },
     OffsetOf    : { "offsetof" },
     ToContainer : { "to_container" },
 }
 
 type BuiltinExprBits struct {
     u32 : NumExprBits;
-    u8 : 2; // make sure kind does not span an 8-bit boundary
-    BuiltinExprKind kind : 3;
+    BuiltinExprKind kind : 2;
+    // TODO: builtin expressions should be output literally in the
+    //   C generator except elemsof(enum) that cannot be expressed in C.
+    //   use_literal is tested in the C generator but not set yet.
+    bool use_literal : 1;
     u32 src_len : 32 - NumExprBits - 5; // length of () expression
 }
 
@@ -49,7 +49,7 @@ public type BuiltinExpr struct @(opaque) {
     Expr base;
     // TODO use TypeRef (can contain Type or VarDecl ref)
     Expr* inner;
-    Value value;
+    u64 value;
 
     OffsetOfData[0] offset;     // tail-allocated, only for offsetof
     ToContainerData[0] container;   // tail-allocated, only for to_container
@@ -62,7 +62,7 @@ public fn BuiltinExpr* BuiltinExpr.create(ast_context.Context* c, SrcLoc loc, u3
     e.base.base.builtinExprBits.kind = kind;
     e.base.base.builtinExprBits.src_len = src_len;
     e.inner = inner;
-    e.value.setUnsigned(0);
+    e.value = 0;
 #if AstStatistics
     Stats.addExpr(Builtin, size);
 #endif
@@ -76,7 +76,7 @@ public fn BuiltinExpr* BuiltinExpr.createOffsetOf(ast_context.Context* c, SrcLoc
     e.base.base.builtinExprBits.kind = OffsetOf;
     e.base.base.builtinExprBits.src_len = src_len;
     e.inner = typeExpr;
-    e.value.setUnsigned(0);
+    e.value = 0;
     e.offset[0].member = member;
 #if AstStatistics
     Stats.addExpr(Builtin, size);
@@ -91,7 +91,7 @@ public fn BuiltinExpr* BuiltinExpr.createToContainer(ast_context.Context* c, Src
     e.base.base.builtinExprBits.kind = ToContainer;
     e.base.base.builtinExprBits.src_len = src_len;
     e.inner = typeExpr;
-    e.value.setUnsigned(0);
+    e.value = 0;
     e.container[0].member = member;
     e.container[0].pointer = pointer;
 #if AstStatistics
@@ -104,8 +104,6 @@ fn Expr* BuiltinExpr.instantiate(BuiltinExpr* e, Instantiator* inst) {
     switch (e.getKind()) {
     case Sizeof:
     case Elemsof:
-    case EnumMin:
-    case EnumMax:
         return (Expr*)BuiltinExpr.create(inst.c, e.base.base.loc, e.base.base.builtinExprBits.src_len,
                                          e.inner.instantiate(inst), e.getKind());
     case OffsetOf:
@@ -125,14 +123,14 @@ public fn BuiltinExprKind BuiltinExpr.getKind(const BuiltinExpr* e) {
     return e.base.base.builtinExprBits.kind;
 }
 
-public fn Value BuiltinExpr.getValue(const BuiltinExpr* e) { return e.value; }
-
-public fn void BuiltinExpr.setValue(BuiltinExpr* e, Value value) {
-    e.value = value;
+public fn u64 BuiltinExpr.useLiteral(const BuiltinExpr* e) {
+    return e.base.base.builtinExprBits.use_literal;
 }
 
-public fn void BuiltinExpr.setUValue(BuiltinExpr* e, u64 val) {
-    e.value.setUnsigned(val);
+public fn u64 BuiltinExpr.getValue(const BuiltinExpr* e) { return e.value; }
+
+public fn void BuiltinExpr.setValue(BuiltinExpr* e, u64 val) {
+    e.value = val;
 }
 
 public fn Expr* BuiltinExpr.getInner(const BuiltinExpr* e) { return e.inner; }
@@ -167,19 +165,14 @@ fn void BuiltinExpr.print(const BuiltinExpr* e, string_buffer.Buf* out, u32 inde
     out.color(col_Value);
     out.print(" %s", e.getKind().name);
     out.color(col_Calc);
-    out.print(" %s", e.value.str());
+    out.print(" %d", e.value);
     out.newline();
 
     e.inner.print(out, indent + 1);
 
     switch (e.getKind()) {
     case Sizeof:
-        break;
     case Elemsof:
-        break;
-    case EnumMin:
-        break;
-    case EnumMax:
         break;
     case OffsetOf:
         e.offset[0].member.print(out, indent + 1);
@@ -198,8 +191,6 @@ fn void BuiltinExpr.printLiteral(const BuiltinExpr* e, string_buffer.Buf* out) {
     switch (e.getKind()) {
     case Sizeof:
     case Elemsof:
-    case EnumMin:
-    case EnumMax:
         break;
     case OffsetOf:
         out.add(", ");

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -73,7 +73,7 @@ static_assert(32, sizeof(BinaryOperator));
 static_assert(32, sizeof(BitOffsetExpr));
 static_assert(32, sizeof(CallExpr));
 static_assert(40, sizeof(ExplicitCastExpr));
-static_assert(40, sizeof(BuiltinExpr));
+static_assert(32, sizeof(BuiltinExpr));
 static_assert(40, sizeof(FieldDesignatedInitExpr));
 static_assert(48, sizeof(ConditionalOperator));
 static_assert(32, sizeof(NamedArgument));

--- a/docs/docs/introduction/code_fragments.md
+++ b/docs/docs/introduction/code_fragments.md
@@ -82,7 +82,7 @@ enum type, only the constant is allowed (for readability and consistency). When 
 type, the prefix must be used.
 
 To prevent having to add artificial enum constants to determine the range of an enum (for int to enum
-conversion etc.), C2 adds two keywords - _enum_min_ and _enum_max_.
+conversion etc.), C2 provides a generic way to get the minimum and maximum values of an enum.
 
 ```c
 type State enum u32 {
@@ -90,9 +90,8 @@ type State enum u32 {
     Stop,
 }
 
-// enum_min/max() are compile time constant, just like sizeof() and elemsof()
-const u32 lowest = enum_min(State);
-const u32 highest = enum_max(State);
+const State lowest = State.min;
+const State highest = State.max;
 ```
 
 ### struct types

--- a/docs/docs/language/keywords.md
+++ b/docs/docs/language/keywords.md
@@ -16,8 +16,6 @@ C2 has the following keywords:
 * `char`
 * `const`
 * `elemsof`
-* `enum_min`
-* `enum_max`
 * `enum`
 * `false`
 * `f32`

--- a/docs/docs/specification/keywords.md
+++ b/docs/docs/specification/keywords.md
@@ -18,8 +18,6 @@ C2 has the following builtin types and keywords
 * `const`
 * `elemsof`
 * `enum`
-* `enum_max`
-* `enum_min`
 * `f32`
 * `f64`
 * `false`

--- a/generator/ast_visitor_expr.c2
+++ b/generator/ast_visitor_expr.c2
@@ -149,12 +149,7 @@ fn void Visitor.handleBuiltinExpr(Visitor* v, BuiltinExpr* b) {
     v.handleExpr(b.getInner());
     switch (b.getKind()) {
     case Sizeof:
-        break;
     case Elemsof:
-        break;
-    case EnumMin:
-        break;
-    case EnumMax:
         break;
     case OffsetOf:
         v.handleExpr(b.getOffsetOfMember());

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -18,7 +18,6 @@ module c_generator;
 import ast local;
 import c_prec local;
 import string_buffer;
-import value_type local;
 
 fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, Expr* e) {
     gen.emitExpr2(out, e, Assignment);
@@ -354,42 +353,34 @@ fn void Generator.emitBuiltinExpr(Generator* gen, string_buffer.Buf* out, Expr* 
     BuiltinExpr* b = (BuiltinExpr*)e;
     switch (b.getKind()) {
     case Sizeof:
-        Value v = b.getValue();
-        out.print("%s", v.str());
-/*
-        out.add("sizeof(");
-        gen.emitExpr(out, b.getInner());
-        out.rparen();
-*/
+        if (b.useLiteral()) {
+            out.add("sizeof(");
+            gen.emitExpr(out, b.getInner());
+            out.rparen();
+        } else {
+            out.print("%d", b.getValue());
+        }
         break;
     case Elemsof:
-        Value v = b.getValue();
-        out.print("%s", v.str());
-/*
-        // Note: ARRAY_SIZE looks nicer, but doesn't work for elemsof(Enum)
-        out.add("ARRAY_SIZE(");
-        gen.emitExpr(out, b.getInner());
-        out.rparen();
-*/
-        break;
-    case EnumMin:
-        Value v = b.getValue();
-        out.print("%s", v.str());
-        break;
-    case EnumMax:
-        Value v = b.getValue();
-        out.print("%s", v.str());
+        if (b.useLiteral()) {
+            // Note: ARRAY_SIZE looks nicer, but doesn't work for elemsof(Enum)
+            out.add("ARRAY_SIZE(");
+            gen.emitExpr(out, b.getInner());
+            out.rparen();
+        } else {
+            out.print("%d", b.getValue());
+        }
         break;
     case OffsetOf:
-        Value v = b.getValue();
-        out.print("%s", v.str());
-/*
-        out.add("offsetof("); // type, member
-        gen.emitExpr(out, b.getInner());
-        out.add(", ");
-        gen.emitExpr(out, b.getOffsetOfMember());
-        out.rparen();
-*/
+        if (b.useLiteral()) {
+            out.add("offsetof("); // type, member
+            gen.emitExpr(out, b.getInner());
+            out.add(", ");
+            gen.emitExpr(out, b.getOffsetOfMember());
+            out.rparen();
+        } else {
+            out.print("%d", b.getValue());
+        }
         break;
     case ToContainer:
         out.add("to_container("); // type, member, ptr

--- a/generator/c2i/c2i_generator_expr.c2
+++ b/generator/c2i/c2i_generator_expr.c2
@@ -17,7 +17,6 @@ module c2i_generator;
 
 import ast local;
 import string_buffer;
-import value_type local;
 
 fn void Generator.emitExpr(Generator* gen, string_buffer.Buf* out, const Expr* e) {
     switch (e.getKind()) {
@@ -224,12 +223,10 @@ fn void Generator.emitBuiltinExpr(Generator* gen, string_buffer.Buf* out, const 
         out.rparen();
         break;
     case Elemsof:
-    case EnumMin:
-    case EnumMax:
     case OffsetOf:
         // TODO: generate c2 source?
-        Value v = b.getValue();
-        out.print("%s", v.str());
+        // TODO: should be typed explicitly?
+        out.print("%d", b.getValue());
         return;
     case ToContainer:
         out.add("to_container("); // type, member, ptr

--- a/generator/ir/ir_generator_expr.c2
+++ b/generator/ir/ir_generator_expr.c2
@@ -483,8 +483,6 @@ fn void Generator.emitBuiltin(Generator* gen, ir.Ref* result, const Expr* e) {
     switch (bi.getKind()) {
     case Sizeof:
     case Elemsof:
-    case EnumMin:
-    case EnumMax:
     case OffsetOf:
         e.dump();
         assert(0);
@@ -492,8 +490,7 @@ fn void Generator.emitBuiltin(Generator* gen, ir.Ref* result, const Expr* e) {
     case ToContainer: {
             ir.Ref ptr_ref;
             gen.emitExpr(&ptr_ref, bi.getToContainerPointer());
-            Value v = bi.getValue();
-            u32 offset = v.as_u32();
+            u32 offset = (u32)bi.getValue();
             if (offset == 0) {
                 *result = ptr_ref;
             } else {

--- a/parser/c2_parser_expr.c2
+++ b/parser/c2_parser_expr.c2
@@ -188,8 +188,6 @@ const u8[Kind] CastExprTokenLookup = {
     [MinusMinus] = 7,
     [KW_cast] = 8,
     [KW_elemsof] = 9,
-    [KW_enum_min] = 10,
-    [KW_enum_max] = 10,
     [KW_false] = 11,
     [KW_true] = 11,
     [KW_nil] = 12,
@@ -293,8 +291,6 @@ fn Expr* Parser.parseCastExpr(Parser* p, bool /*isUnaryExpr*/, bool /*isAddrOfOp
     case 9: // KW_elemsof
         res = p.parseElemsof();
         break;
-    case 10: // KW_enum_min, KW_enum_max
-        return p.parseEnumMinMax(savedKind == KW_enum_min);
     case 11: // KW_false, KW_true
         res = p.builder.actOnBooleanConstant(p.tok.loc, savedKind == KW_true);
         p.consumeToken();
@@ -690,23 +686,6 @@ fn Expr* Parser.parseExplicitCastExpr(Parser* p) {
     return p.builder.actOnExplicitCast(loc, src_len, &ref, expr, false);
 }
 
-// Syntax:
-//   'enum_min' '(' type-name ')'
-//   'enum_max' '(' type-name ')'
-fn Expr* Parser.parseEnumMinMax(Parser* p, bool is_min) {
-    SrcLoc loc = p.tok.loc;
-    p.consumeToken();
-    p.expectAndConsume(LParen);
-
-    p.expectIdentifier();
-    // TODO parse as TypeRefHolder
-    Expr* expr = p.parseExpr();
-    u32 src_len = p.tok.loc + 1 - loc;
-    p.expectAndConsume(RParen);
-
-    return p.builder.actOnBuiltinExpr(loc, src_len, expr, is_min ? EnumMin : EnumMax);
-}
-
 fn Expr* Parser.parseOffsetOfExpr(Parser* p) {
     SrcLoc loc = p.tok.loc;
     p.consumeToken();
@@ -890,8 +869,6 @@ fn u32 Parser.parseAsCastType(Parser* p, u32 ahead, Kind close_tok) {
             case Exclaim:
             case KW_cast:
             case KW_elemsof:
-            case KW_enum_min:
-            case KW_enum_max:
             case KW_false:
             case KW_true:
             case KW_nil:

--- a/parser/token.c2
+++ b/parser/token.c2
@@ -118,8 +118,6 @@ public type Kind enum u8 (public const char* const name) {
     KW_default           : { "default" },
     KW_elemsof           : { "elemsof" },
     KW_else              : { "else" },
-    KW_enum_max          : { "enum_max" },
-    KW_enum_min          : { "enum_min" },
     KW_enum              : { "enum" },
     KW_extern            : { "extern" },
     KW_fallthrough       : { "fallthrough" },

--- a/test/builtins/enum_invalids.c2
+++ b/test/builtins/enum_invalids.c2
@@ -9,8 +9,6 @@ type Enum enum i8 {
 }
 
 Enum ee;
-i32 ok1 = enum_min(ee);
-i32 ok2 = enum_min(Enum);
 i32 ok3 = Enum.min;
 i32 ok4 = Enum.max;
 

--- a/test/builtins/enum_invalids_builtin.c2
+++ b/test/builtins/enum_invalids_builtin.c2
@@ -1,6 +1,0 @@
-// @warnings{no-unused}
-module test;
-
-i32 a = 10;
-i32 d = enum_min(a);      // @error{enum_min can only be used on enum types}
-

--- a/test/builtins/enum_invalids_func.c2
+++ b/test/builtins/enum_invalids_func.c2
@@ -1,8 +1,0 @@
-// @warnings{no-unused}
-module test;
-
-fn void test2() {}
-
-i32 c = enum_min(test2);  // @error{enum_min can only be used on enum types}
-
-

--- a/test/builtins/enum_invalids_mod.c2
+++ b/test/builtins/enum_invalids_mod.c2
@@ -1,4 +1,0 @@
-// @warnings{no-unused}
-module test;
-
-i32 a = enum_min(test);   // @error{enum_min can only be used on enum types}

--- a/test/builtins/enum_invalids_struct.c2
+++ b/test/builtins/enum_invalids_struct.c2
@@ -1,9 +1,0 @@
-// @warnings{no-unused}
-module test;
-
-type Struct struct {
-    i32 x;
-}
-
-i32 e = enum_min(Struct); // @error{enum_min can only be used on enum types}
-

--- a/test/builtins/enum_pointer.c2
+++ b/test/builtins/enum_pointer.c2
@@ -6,7 +6,7 @@ type Enum enum i8 {
 }
 
 fn void test2() {
-    i32* a = &enum_min(Enum); // @error{cannot take the address of an rvalue of type 'i8'}
+    i32* a = &Enum.max; // @error{cannot take the address of an enum constant}
 }
 
 fn void test3() {

--- a/test/builtins/enum_type_conversion1.c2
+++ b/test/builtins/enum_type_conversion1.c2
@@ -6,14 +6,6 @@ type Enum1 enum i8 {
     DD = 10,
 }
 
-const i8 A = enum_min(Enum1);
-const i8 B = enum_max(Enum1);
-const u32 F = enum_max(Enum1);
-
-static_assert(A, -2);
-static_assert(B, 10);
-static_assert(F, 10);
-
 const i8 A1 = Enum1.min;
 const i8 B1 = Enum1.max;
 const u32 F1 = Enum1.max;

--- a/test/builtins/enum_type_conversion2.c2
+++ b/test/builtins/enum_type_conversion2.c2
@@ -5,6 +5,6 @@ type Enum2 enum u32 {
     EE = 300,
 }
 
-const i8 C = enum_min(Enum2);    // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
 const i8 D = Enum2.min;          // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
+const i8 E = Enum2.max;          // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
 

--- a/test/builtins/enum_type_conversion3.c2
+++ b/test/builtins/enum_type_conversion3.c2
@@ -5,6 +5,6 @@ type Enum2 enum u32 {
     EE = 300,
 }
 
-const i8 D = enum_max(Enum2);    // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
-const i8 E = Enum2.max;          // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
+const i8 D = Enum2.min;  // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
+const i8 E = Enum2.max;  // @error{constant value 300 out-of-bounds for type 'i8', range [-128, 127]}
 

--- a/test/builtins/enum_type_conversion4.c2
+++ b/test/builtins/enum_type_conversion4.c2
@@ -3,9 +3,9 @@ module test;
 
 type Enum1 enum i8 {
     AA = -2,
-    DD = 10,
+    DD = -1,
 }
 
-const u32 E = enum_min(Enum1);  // @error{constant value -2 out-of-bounds for type 'u32', range [0, 4294967295]}
-const u32 F = Enum1.min;        // @error{constant value -2 out-of-bounds for type 'u32', range [0, 4294967295]}
+const u32 E = Enum1.max;  // @error{constant value -1 out-of-bounds for type 'u32', range [0, 4294967295]}
+const u32 F = Enum1.min;  // @error{constant value -2 out-of-bounds for type 'u32', range [0, 4294967295]}
 

--- a/test/builtins/enum_type_conversion5.c2
+++ b/test/builtins/enum_type_conversion5.c2
@@ -10,6 +10,5 @@ type Enum2 enum u32 {
     EE = 300,
 }
 
-const i8 G = enum_max(Enum2) - enum_min(Enum1); // @error{constant value 302 out-of-bounds for type 'i8', range [-128, 127]}
 const i8 H = Enum2.max - Enum1.min;             // @error{constant value 302 out-of-bounds for type 'i8', range [-128, 127]}
 

--- a/test/builtins/enum_type_not_unused.c2
+++ b/test/builtins/enum_type_not_unused.c2
@@ -1,10 +1,11 @@
 module test;
 
 type Enum enum i8 {
+    X,
     A,  // @warning{unused enum constant 'A'}
     B,
 }
 
-const i8 Max = Enum.max;         // @warning{unused variable 'test.Max'}
-const i8 Min = enum_min(Enum);    // @warning{unused variable 'test.Min'}
+const i8 Max = Enum.max;  // @warning{unused variable 'test.Max'}
+const i8 Min = Enum.min;  // @warning{unused variable 'test.Min'}
 

--- a/test/builtins/enum_var_not_unused.c2
+++ b/test/builtins/enum_var_not_unused.c2
@@ -3,10 +3,9 @@ module test;
 type Enum enum i8 {
     B,
     A,  // @warning{unused enum constant 'A'}
+    C,
 }
 
-Enum e;
-
-const i8 Min = Enum.min;       // @warning{unused variable 'test.Min'}
-const i8 Max = enum_max(e);    // @warning{unused variable 'test.Max'}
+const i8 Min = Enum.min;  // @warning{unused variable 'test.Min'}
+const i8 Max = Enum.max;  // @warning{unused variable 'test.Max'}
 


### PR DESCRIPTION
* remove `enum_min` and `enum_max` keywords and expressions
* use u64 instead of Value type for computed value of builtin expressions
* add `use_literal` option for C generator (WIP)
* simplify code
* update tests