### PR TITLE
String-buffer: simplify `string_buffer.Buf.encodeBytes` API

### DIFF
--- a/ast/char_literal.c2
+++ b/ast/char_literal.c2
@@ -73,10 +73,8 @@ public fn void CharLiteral.printLiteral(const CharLiteral* e, string_buffer.Buf*
         out.print("'\\x%02x'", c);
         return;
     default:
-        out.add1('\'');
         char cc = c;
         out.encodeBytes(&cc, 1, '\'');
-        out.add1('\'');
         return;
     }
 }

--- a/ast/string_literal.c2
+++ b/ast/string_literal.c2
@@ -62,9 +62,7 @@ fn SrcLoc StringLiteral.getEndLoc(const StringLiteral* e) {
 }
 
 public fn void StringLiteral.printLiteral(const StringLiteral* e, string_buffer.Buf* out) {
-    out.add1('"');
     out.encodeBytes(idx2name(e.value), e.len, '"');
-    out.add1('"');
 }
 
 fn void StringLiteral.print(const StringLiteral* e, string_buffer.Buf* out, u32 indent) {

--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -216,6 +216,7 @@ public fn u32 Buf.getColumn(const Buf* buf) {
 
 public fn u32 Buf.encodeBytes(Buf* buf, const char* p, u32 len, char sep) {
     u32 size = buf.size_;
+    if (sep) buf.add1(sep);
     u32 copy = 0;
     const char* end = p + len;
     while (p < end) {
@@ -230,7 +231,7 @@ public fn u32 Buf.encodeBytes(Buf* buf, const char* p, u32 len, char sep) {
         case '\v':  c = 'v'; goto add_char;
         case '"':
         case '\'':
-            if (sep && sep != c) goto normal;
+            if (sep && c != sep) goto normal;
             fallthrough;
         case '\\':
         add_char:
@@ -261,6 +262,7 @@ public fn u32 Buf.encodeBytes(Buf* buf, const char* p, u32 len, char sep) {
         }
     }
     if (copy) buf.add2(p - copy, copy);
+    if (sep) buf.add1(sep);
     return buf.size_ - size;
 }
 

--- a/generator/c/c_generator_expr.c2
+++ b/generator/c/c_generator_expr.c2
@@ -177,18 +177,14 @@ fn void Generator.emitStringLiteral(Generator* gen, string_buffer.Buf* out, cons
             while (i < len && p[i] == '\n') i++;
             if (i == len) break;
             u32 col = out.getColumn();
-            out.add1('"');
             out.encodeBytes(p, i, '"');
-            out.add1('"');
             out.newline();
             while (col-- > 0) out.add1(' ');
             p += i;
             len -= i;
         }
     }
-    out.add1('"');
     out.encodeBytes(p, len, '"');
-    out.add1('"');
 }
 
 fn void Generator.emitBitOffset(Generator* gen, string_buffer.Buf* out, Expr* base, Expr* index, C_Prec prec) {

--- a/ir/print.c2
+++ b/ir/print.c2
@@ -327,9 +327,7 @@ fn void PrintHelper.printInitValue(PrintHelper* ph, const InitValue* v, string_b
         out.color(col_Data);
         // TODO: handle potential embelled null bytes
         const char* text = ph.c.pool.idx2str(v.value);
-        out.add1('"');
         out.encodeBytes(text, (u32)string.strlen(text) + 1, '"');
-        out.add1('"');
         break;
     case Zero:
         out.color(col_Data);

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -1006,16 +1006,12 @@ fn void Parser.dump_token(Parser* p, const Token* tok) @(unused) {
             break;
         default:
             char cc = tok.char_value;
-            out.add1('\'');
             out.encodeBytes(&cc, 1, '\'');
-            out.add1('\'');
             break;
         }
         break;
     case StringLiteral:
-        out.add1('"');
         out.encodeBytes(p.pool.idx2str(tok.text_idx), tok.text_len, '"');
-        out.add1('"');
         out.color(color.Normal);
         out.print(" (len %d)", tok.text_len);
         break;

--- a/plugins/shell_cmd_plugin.c2
+++ b/plugins/shell_cmd_plugin.c2
@@ -169,8 +169,8 @@ fn bool run_cmd(Cmd* cmd, string_buffer.Buf* out) {
         return false;
     }
 
-    out.print("public const char[] %s = \"", cmd.variable);
+    out.print("public const char[] %s = ", cmd.variable);
     out.encodeBytes(output, (u32)strlen(output), '"');
-    out.add("\";\n\n");
+    out.add(";\n\n");
     return true;
 }

--- a/tools/c2cat.c2
+++ b/tools/c2cat.c2
@@ -202,10 +202,8 @@ fn void C2cat.print_token(C2cat* ctx, const Token* tok) {
         break;
     case StringLiteral:
         out.color(col_string);
-        out.add1('"');
         u32 len = out.encodeBytes(ctx.pool.idx2str(tok.text_idx), tok.text_len, '"');
-        out.add1('"');
-        ctx.offset = tok.loc + len + 2;
+        ctx.offset = tok.loc + len;
         break;
     case LineComment:
         out.color(col_comment);


### PR DESCRIPTION
* `encodeBytes` always outputs the surrounding separtors if passed a `sep` character and escapes both `"` and `'` if `sep == 0`.