### PR TITLE
Parser: add `VarDeclList` for function parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ trace: trace_calls
 	cat output/c2c/calls
 
 alloc_trace: $(C2C) output/c2c_trace/c2c_trace
-	C2_TRACE="min=10;min2=1;mode=3;name=stdlib.malloc,stdlib.calloc;fd=2" output/c2c_trace/c2c_trace c2c -o c2c_alloc --test 2> output/c2c/calls
+	C2_TRACE="min=10;min2=1;mode=3;name=stdlib.malloc,stdlib.calloc,stdlib.realloc;fd=2" output/c2c_trace/c2c_trace c2c -o c2c_alloc --test 2> output/c2c/calls
 	cat output/c2c/calls
 
 errors:

--- a/ast/var_decl_list.c2
+++ b/ast/var_decl_list.c2
@@ -1,4 +1,4 @@
-/* Copyright 2022-2026 Bas van den Berg
+/* Copyright 2022-2026 Bas van den Berg, Charlie Gordon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,31 @@ module ast;
 import string local;
 import stdlib local;
 
-public type DeclList struct {
+public type VarDeclList struct {
     u32 count;
     u32 capacity;
-    Decl** data;
-    Decl*[4] stash;
+    VarDecl** data;
+    VarDecl*[4] stash;
 }
 
-public fn void DeclList.init(DeclList* l) {
+public fn void VarDeclList.init(VarDeclList* l) {
     l.count = 0;
     l.capacity = elemsof(l.stash);
     l.data = l.stash;
 }
 
-public fn void DeclList.free(DeclList* l) {
+public fn void VarDeclList.free(VarDeclList* l) {
     if (l.capacity > elemsof(l.stash)) free(l.data);
     l.data = nil;
     l.count = 0;
     l.capacity = 0;
 }
 
-public fn void DeclList.clear(DeclList* l) @(unused) {
+public fn void VarDeclList.clear(VarDeclList* l) @(unused) {
     l.count = 0;
 }
 
-fn void DeclList.resize(DeclList* l) {
+fn void VarDeclList.resize(VarDeclList* l) {
     if (l.capacity < elemsof(l.stash)) {
         l.capacity = elemsof(l.stash);
         l.data = l.stash;
@@ -57,22 +57,22 @@ fn void DeclList.resize(DeclList* l) {
     }
 }
 
-public fn void DeclList.add(DeclList* l, Decl* d) {
+public fn void VarDeclList.add(VarDeclList* l, VarDecl* d) {
     if (l.count >= l.capacity) l.resize();
 
     l.data[l.count] = d;
     l.count++;
 }
 
-public fn u32 DeclList.size(const DeclList* l) {
+public fn u32 VarDeclList.size(const VarDeclList* l) {
     return l.count;
 }
 
-public fn Decl* DeclList.get(const DeclList* l, u32 idx) @(unused) {
+public fn VarDecl* VarDeclList.get(const VarDeclList* l, u32 idx) @(unused) {
     return l.data[idx];
 }
 
-public fn Decl** DeclList.getData(const DeclList* l) {
+public fn VarDecl** VarDeclList.getData(const VarDeclList* l) {
     return l.data;
 }
 

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -546,7 +546,7 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
         p.errorAt(func_loc, "a function name must start with a lower case character");
     }
 
-    DeclList params.init();
+    VarDeclList params.init();
 
     bool is_variadic = p.parseFunctionParams(&params, is_public, true);
 
@@ -566,7 +566,7 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
                                                 rtype,
                                                 template_name,
                                                 template_loc,
-                                                (VarDecl**)params.getDecls(),
+                                                params.getData(),
                                                 params.size(),
                                                 is_variadic);
     } else {
@@ -575,7 +575,7 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
                                         is_public,
                                         rtype,
                                         prefix,
-                                        (VarDecl**)params.getDecls(),
+                                        params.getData(),
                                         params.size(),
                                         is_variadic);
     }
@@ -603,7 +603,7 @@ fn void Parser.parseFunctionDecl2(Parser* p, u32 func_name, SrcLoc func_loc,
     p.builder.actOnFunctionBody(f, body);
 }
 
-fn bool Parser.parseFunctionParams(Parser* p, DeclList* params, bool is_public, bool accept_default) {
+fn bool Parser.parseFunctionParams(Parser* p, VarDeclList* params, bool is_public, bool accept_default) {
     p.expectAndConsume(LParen);
 
     // fast path for ()
@@ -625,7 +625,7 @@ fn bool Parser.parseFunctionParams(Parser* p, DeclList* params, bool is_public, 
     while (p.tok.kind != RParen) {
         VarDecl* decl = p.parseParamDecl(is_public, accept_default);
         decl.setOffset(params.count);  // set argument number
-        params.add(decl.asDecl());
+        params.add(decl);
 
         if (p.tok.kind != Comma) break;
         p.consumeToken();
@@ -658,12 +658,12 @@ fn VarDecl* Parser.parseParamDecl(Parser* p, bool is_public, bool accept_default
         TypeRefHolder rtype.init();
         p.parseSingleTypeSpecifier(&rtype);
 
-        DeclList params.init();
+        VarDeclList params.init();
 
         bool is_variadic = p.parseFunctionParams(&params, is_public, false);
 
         Decl* fd = p.builder.actOnFunctionType(&rtype,
-                                               (VarDecl**)params.getDecls(),
+                                               params.getData(),
                                                params.size(),
                                                is_variadic,
                                                Param);

--- a/parser/c2_parser_type.c2
+++ b/parser/c2_parser_type.c2
@@ -56,14 +56,14 @@ fn void Parser.parseFunctionType(Parser* p, u32 name, SrcLoc loc, bool is_public
     TypeRefHolder rtype.init();
     p.parseSingleTypeSpecifier(&rtype);
 
-    DeclList params.init();
+    VarDeclList params.init();
 
     bool is_variadic = p.parseFunctionParams(&params, is_public, false);
     Decl* ftd = p.builder.actOnFunctionTypeDecl(name,
                                                 loc,
                                                 is_public,
                                                 &rtype,
-                                                (VarDecl**)params.getDecls(),
+                                                params.getData(),
                                                 params.size(),
                                                 is_variadic);
     u32 num_attr = p.parseOptionalAttributes();
@@ -92,7 +92,7 @@ fn void Parser.parseStructType(Parser* p, bool is_struct, u32 name, SrcLoc loc, 
                                                   is_public,
                                                   is_struct,
                                                   true,
-                                                  members.getDecls(),
+                                                  members.getData(),
                                                   members.size());
     members.free();
 
@@ -143,7 +143,7 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
                                                                is_public,
                                                                is_struct,
                                                                false,
-                                                               sub_members.getDecls(),
+                                                               sub_members.getData(),
                                                                sub_members.size());
             sub_members.free();
             members.add(member.asDecl());
@@ -156,12 +156,12 @@ fn void Parser.parseStructBlock(Parser* p, DeclList* members, bool is_public) {
             TypeRefHolder rtype.init();
             p.parseSingleTypeSpecifier(&rtype);
 
-            DeclList params.init();
+            VarDeclList params.init();
 
             bool is_variadic = p.parseFunctionParams(&params, is_public, false);
 
             Decl* fd = p.builder.actOnFunctionType(&rtype,
-                                                   (VarDecl**)params.getDecls(),
+                                                   params.getData(),
                                                    params.size(),
                                                    is_variadic,
                                                    StructMember);
@@ -264,7 +264,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
 
     bool has_assoc_values = false;
     // TODO BB FIX memleak on parse error (assoc_values)
-    DeclList assoc_values.init();
+    VarDeclList assoc_values.init();
     if (p.tok.kind == LParen) {
         has_assoc_values = true;
         p.parseEnumAssocAttributes(&assoc_values);
@@ -331,9 +331,9 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
                                               is_public,
                                               is_incr,
                                               implType,
-                                              (EnumConstantDecl**)constants.getDecls(),
+                                              (EnumConstantDecl**)constants.getData(),
                                               constants.size(),
-                                              (VarDecl**)assoc_values.getDecls(),
+                                              assoc_values.getData(),
                                               (u16)assoc_values.size());
     assoc_values.free();
     constants.free();
@@ -341,7 +341,7 @@ fn void Parser.parseEnumType(Parser* p, u32 name, SrcLoc loc, bool is_public) {
     p.applyAttributes((Decl*)d, num_attr);
 }
 
-fn void Parser.parseEnumAssocAttributes(Parser* p, DeclList* params) {
+fn void Parser.parseEnumAssocAttributes(Parser* p, VarDeclList* params) {
     p.expectAndConsume(LParen);
 
     // TODO error message is obscure: list of associate values cannot be empty
@@ -351,7 +351,7 @@ fn void Parser.parseEnumAssocAttributes(Parser* p, DeclList* params) {
     while (p.tok.kind != RParen) {
         VarDecl* decl = p.parseEnumAttribute();
         decl.setOffset(params.count);  // set argument number
-        params.add(decl.asDecl());
+        params.add(decl);
 
         if (p.tok.kind != Comma) break;
         p.consumeToken();
@@ -378,12 +378,12 @@ fn VarDecl* Parser.parseEnumAttribute(Parser* p) {
         TypeRefHolder rtype.init();
         p.parseSingleTypeSpecifier(&rtype);
 
-        DeclList params.init();
+        VarDeclList params.init();
 
         bool is_variadic = p.parseFunctionParams(&params, is_public, false);
 
         Decl* fd = p.builder.actOnFunctionType(&rtype,
-                                               (VarDecl**)params.getDecls(),
+                                               params.getData(),
                                                params.size(),
                                                is_variadic,
                                                EnumValue);
@@ -495,11 +495,10 @@ fn void Parser.parseTypedef(Parser* p, bool is_public) {
         p.consumeToken();
     }
     if (p.tok.kind == LParen) {
-        DeclList params.init();
+        VarDeclList params.init();
         bool is_variadic = p.parseFunctionParams(&params, is_public, false);
-        d = p.builder.actOnFunctionTypeDecl(type_name, loc, is_public,
-                                            &ref, (VarDecl**)params.getDecls(),
-                                            params.size(), is_variadic);
+        d = p.builder.actOnFunctionTypeDecl(type_name, loc, is_public, &ref,
+                                            params.getData(), params.size(), is_variadic);
         params.free();
     } else {
         if (p.tok.kind == LSquare) {

--- a/recipe.txt
+++ b/recipe.txt
@@ -53,6 +53,7 @@ set ast
     ast/static_assert.c2
     ast/struct_type_decl.c2
     ast/var_decl.c2
+    ast/var_decl_list.c2
 
     # ast statements
     ast/stmt.c2


### PR DESCRIPTION
* add `VarDeclList` with the exact same code as `DeclList`
* use `data` and `getData()` for genericity
* use `stdlib.realloc()` to simplify code
* remove casts