### PR TITLE
Examples: remove redundant casts

### DIFF
--- a/examples/comment_strip/main.c2
+++ b/examples/comment_strip/main.c2
@@ -95,13 +95,13 @@ public fn i32 main(i32 argc, char** argv) {
 
     utils.StringBuffer* buffer = utils.StringBuffer.create(infile.size);
 
-    strip_comments(infile.char_data(), buffer);
+    strip_comments(infile.data(), buffer);
     infile.close();
 
     file_utils.Writer outfile;
     const char* outname = "out.c";
     printf("written %s\n", outname);
-    if (!outfile.write(outname, (const u8*)buffer.data(), buffer.size())) {
+    if (!outfile.write(outname, buffer.data(), buffer.size())) {
         printf("error writing file: %s\n", outfile.getError());
     }
 

--- a/examples/common/file/reader.c2
+++ b/examples/common/file/reader.c2
@@ -81,12 +81,8 @@ public fn bool Reader.isOpen(const Reader* file) {
     return file.region != nil;
 }
 
-public fn const u8* Reader.data(Reader* file) {
-    return (u8*)file.region;
-}
-
-public fn const char* Reader.char_data(Reader* file) {
-    return (char*)file.region;
+public fn const void* Reader.data(Reader* file) {
+    return file.region;
 }
 
 public fn bool Reader.isEmpty(const Reader* file) {

--- a/examples/common/file/writer.c2
+++ b/examples/common/file/writer.c2
@@ -26,7 +26,7 @@ public type Writer struct {
     char[256] msg;
 }
 
-public fn bool Writer.write(Writer* writer, const char* filename, const u8* data, u32 len) {
+public fn bool Writer.write(Writer* writer, const char* filename, const void* data, u32 len) {
     writer.msg[0] = 0;
     i32 fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0660);
     if (fd == -1) {

--- a/examples/event/events.c2
+++ b/examples/event/events.c2
@@ -121,7 +121,7 @@ fn void Base.writeCmd(Base* base, Cmd* cmd) {
 }
 
 fn void handlePipe(i32 fd, void* arg, u16 flags) {
-    Base* base = (Base*)arg;
+    Base* base = arg;
     Cmd cmd;
     i64 numread = read(base.read_pipe, &cmd, sizeof(Cmd));
     // TODO assert numread

--- a/examples/file_ops/main.c2
+++ b/examples/file_ops/main.c2
@@ -26,7 +26,8 @@ public fn i32 main(i32 argc, char** argv) {
     file_utils.Reader file;
     file.open(argv[1]);
 
-    printf("%s", file.char_data());
+    const char *contents = file.data();
+    printf("%s", contents);
 
     file.close();
 

--- a/examples/json_parser/json_data.c2
+++ b/examples/json_parser/json_data.c2
@@ -158,10 +158,10 @@ fn u32 NodeBuffer.getSize(const NodeBuffer* b) {
 
 fn void NodeBuffer.resize(NodeBuffer* b, u32 cap2) {
     b.cap = cap2;
-    char* data2 = malloc(b.cap * sizeof(Node));
+    Node* data2 = malloc(b.cap * sizeof(Node));
     memcpy(data2, b.data, b.cur * sizeof(Node));
     free(b.data);
-    b.data = (Node*)data2;
+    b.data = data2;
 }
 
 fn u32 NodeBuffer.add(NodeBuffer* b, NodeKind kind, u32 name_idx, u32 value_idx) {

--- a/examples/json_parser/json_serialize.c2
+++ b/examples/json_parser/json_serialize.c2
@@ -41,9 +41,8 @@ fn bool Data.write(const Data* d, i32 fd) {
     size += roundup(d.names.cur);
     size += roundup(d.values.cur);
     size += roundup(d.nodes.getSize());
-    u8* buf = malloc(size);
 
-    Header* hdr = (Header*)buf;
+    Header* hdr = malloc(size);
     hdr.names_size = d.names.cur;
     hdr.values_size = d.values.cur;
     hdr.nodes_size = d.nodes.getSize();
@@ -52,17 +51,17 @@ fn bool Data.write(const Data* d, i32 fd) {
     offset += roundup(d.names.cur);
     memcpy(&hdr.data[offset], d.values.data, d.values.cur);
     offset += roundup(d.values.cur);
-    memcpy(&hdr.data[offset], (u8*)d.nodes.data, d.nodes.getSize());
+    memcpy(&hdr.data[offset], d.nodes.data, d.nodes.getSize());
 
-    i64 written = write(fd, buf, size);
-    free(buf);
+    i64 written = write(fd, hdr, size);
+    free(hdr);
     if (written != size) return false;
     return true;
 }
 
-fn Data* Data.read(const u8* data, u32 size) {
+fn Data* Data.read(const void* data, u32 size) {
     if (size < sizeof(Header)) return nil;
-    const Header* hdr = (Header*)data;
+    const Header* hdr = data;
     u32 exp_size = sizeof(Header);
     exp_size += roundup(hdr.names_size);
     exp_size += roundup(hdr.values_size);

--- a/examples/json_parser/main.c2
+++ b/examples/json_parser/main.c2
@@ -64,7 +64,7 @@ public fn i32 main(i32 argc, char** argv) {
             return 0;
         }
 
-        if (!parser.parse((const char*)file.data())) {
+        if (!parser.parse(file.data())) {
             fprintf(stderr, "error parsing %s: %s\n", filename, parser.getDiag());
             return -1;
         }

--- a/examples/multicast/multicast_sender.c2
+++ b/examples/multicast/multicast_sender.c2
@@ -84,7 +84,7 @@ fn void Sender.open_socket(Sender* s) {
     //printf("sending to %s, port %d\n", s.ipnr, s.port);
 }
 
-public fn void Sender.broadcast(Sender* s, const u8* data, u32 size) {
+public fn void Sender.broadcast(Sender* s, const void* data, u32 size) {
     if (send(s.fd, data, size, 0) < 0) {
         fprintf(stderr, "send: %s\n", strerror(*errno2()));
         exit(EXIT_FAILURE);

--- a/examples/multicast/sender.c2
+++ b/examples/multicast/sender.c2
@@ -36,7 +36,7 @@ public fn i32 main() {
         sprintf(tmp, "%s %d", message, nr);
         nr++;
 
-        sender.broadcast((u8*)tmp, (u32)strlen(tmp));
+        sender.broadcast(tmp, (u32)strlen(tmp));
         unistd.sleep(1);
     }
 

--- a/examples/sudoku/sudoku.c2
+++ b/examples/sudoku/sudoku.c2
@@ -151,7 +151,7 @@ fn void Board.printOptions(const Board* board) {
         for (u8 x=0; x<9; x++) {
             const Field* f = &board.fields[y*9 + x];
             u32 offset = (1 + 4 * y) * width + (1 + 8 * x);
-            u8* square = (u8*)&buffer[offset];
+            char* square = &buffer[offset];
             for (u8 o=1; o<10; o++) {
                 if (f.options & (1<<o)) {
                     u32 h = (o-1) % 3;

--- a/examples/toml_parser/toml_parser.c2
+++ b/examples/toml_parser/toml_parser.c2
@@ -120,8 +120,8 @@ fn bool Parser.parse(Parser* p, const char* input, char* diagMsg, Blocks* blocks
     p.errorMsg[0] = 0;
 
     p.blocks = blocks;
-    memset((void*)p.parents, 0, sizeof(Node*)*MaxDepth);
-    memset((void*)p.lastChild, 0, sizeof(Node*)*MaxDepth);
+    memset(p.parents, 0, sizeof(Node*) * MaxDepth);
+    memset(p.lastChild, 0, sizeof(Node*) * MaxDepth);
     p.numParents = 0;
     p.topParent = nil;
 
@@ -419,7 +419,7 @@ public fn bool Reader.parse(Reader* r, const char* filename) {
         return false;
     }
     Parser parser;
-    bool status = parser.parse((const char*)file.data(), r.message, r.blocks);
+    bool status = parser.parse(file.data(), r.message, r.blocks);
     file.close();
 
 #if DEBUG_NODES

--- a/examples/toml_parser/toml_tokenizer.c2
+++ b/examples/toml_parser/toml_tokenizer.c2
@@ -338,7 +338,7 @@ fn bool isKeyChar(u8 c) {
 
 fn void Tokenizer.parseKey(Tokenizer* t, Token* result) {
     const char* start = t.current;
-    while (t.current[0] && isKeyChar((u8)t.current[0])) t.current++;
+    while (t.current[0] && isKeyChar(t.current[0])) t.current++;
 
     u32 len = (u32)(t.current - start);
     // assert(len < MaxText);

--- a/examples/xml_parser/main.c2
+++ b/examples/xml_parser/main.c2
@@ -37,7 +37,7 @@ public fn i32 main(i32 argc, char** argv) {
     }
 
     xml.Parser parser;
-    if (!parser.parse(file.char_data(), verbose)) {
+    if (!parser.parse(file.data(), verbose)) {
         printf("error parsing %s: %s\n", filename, parser.getDiag());
     }
 

--- a/examples/yaml_parser/main.c2
+++ b/examples/yaml_parser/main.c2
@@ -46,7 +46,7 @@ public fn i32 main(i32 argc, char** argv) {
 
     yaml.Parser* parser = yaml.Parser.create();
 
-    bool ok = parser.parse((char*)file.region);
+    bool ok = parser.parse(file.data());
     if (ok) {
         parser.dump(true);
         get_info(parser);

--- a/examples/yaml_parser/yaml_iterator.c2
+++ b/examples/yaml_parser/yaml_iterator.c2
@@ -84,7 +84,7 @@ public fn Iter Parser.getNodeChildIter(const Parser* p, const Node* n) {
 }
 
 public fn void Iter.next(Iter* iter) {
-    const Data* d = (Data*)iter.data;
+    const Data* d = iter.data;
     if (iter.node) {
         if (iter.node.next_idx) iter.node = d.idx2node(iter.node.next_idx);
         else iter.node = nil;
@@ -96,13 +96,13 @@ public fn bool Iter.done(const Iter* iter) {
 }
 
 public fn const char* Iter.getName(const Iter* iter) {
-    const Data* d = (Data*)iter.data;
+    const Data* d = iter.data;
     if (iter.node) return &d.text[iter.node.name_idx];
     return nil;
 }
 
 public fn const char* Iter.getValue(const Iter* iter) {
-    const Data* d = (Data*)iter.data;
+    const Data* d = iter.data;
     if (iter.node && iter.node.kind == NodeKind.Scalar) return &d.text[iter.node.text_idx];
     return nil;
 }
@@ -113,7 +113,7 @@ public fn Iter Iter.getChildIter(Iter* parent) {
 
     const Node* n = parent.node;
     if (n.kind != NodeKind.Scalar && n.child_idx) {
-        const Data* d = (Data*)iter.data;
+        const Data* d = iter.data;
         iter.node = d.idx2node(n.child_idx);
     }
     return iter;
@@ -123,7 +123,7 @@ public fn const char* Iter.getChildScalarValue(Iter* iter, const char* path) {
     if (!iter.node) return nil;
 
     if (iter.node.kind == NodeKind.Sequence) return nil;
-    const Data* d = (Data*)iter.data;
+    const Data* d = iter.data;
     const Node* n = d.findChildNode(path, iter.node.child_idx);
     if (n && n.isScalar()) return &d.text[n.text_idx];
     return nil;


### PR DESCRIPTION
* use `void*` for `file.data()` and remove `file.char_data()`
* remove many redundant casts