### PR TITLE
libc: improve libs/libc/sys_utsname.c2i consistency

### DIFF
--- a/libs/libc/sys_utsname.c2i
+++ b/libs/libc/sys_utsname.c2i
@@ -1,19 +1,22 @@
 module sys_utsname extern "C";
 
 #if SYSTEM_LINUX
-const u32 NAME_LEN = 65;
+const u32 NAME_LEN @(cname="_UTSNAME_LENGTH") = 65;
 #else
 // Same for Darwin, FreeBSD and OpenBSD
-const u32 NAME_LEN = 256;
+const u32 NAME_LEN @(cname="_SYS_NAMELEN") = 256;
 #endif
 
 struct Name @(cname="utsname") {
-    char[NAME_LEN] sysname;
-    char[NAME_LEN] nodename;
-    char[NAME_LEN] release;
-    char[NAME_LEN] version;
-    char[NAME_LEN] machine;
+    char[NAME_LEN] sysname;  /* [XSI] Name of OS */
+    char[NAME_LEN] nodename; /* [XSI] Name of this network node */
+    char[NAME_LEN] release;  /* [XSI] Release level */
+    char[NAME_LEN] version;  /* [XSI] Version level */
+    char[NAME_LEN] machine;  /* [XSI] Hardware type */
+#if SYSTEM_LINUX
+    /* Name of the domain of this node on the network */
     char[NAME_LEN] domainname;
+#endif
 }
 
 #if SYSTEM_FREEBSD


### PR DESCRIPTION
* use actual cname for darwin targets
* only define domainname for linux targets