### PR TITLE
Source: use c2 style for consistency

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -535,7 +535,7 @@ fn void Analyser.handleEnumAssocValue(void* arg, Decl* d) {
     ma.popCheck();
 }
 
-fn void Analyser.printLiteral(Analyser* ma, string_buffer.Buf *buf,
+fn void Analyser.printLiteral(Analyser* ma, string_buffer.Buf* buf,
                               const char* s, const Expr* e, Value val,
                               bool as_is = false)
 {

--- a/ast/function_decl.c2
+++ b/ast/function_decl.c2
@@ -67,7 +67,7 @@ public type FunctionDecl struct @(opaque) {
     Decl base;
     union {
         CompoundStmt* body;
-        void *address;
+        void* address;
     }
     QualType rt;          // return type after analysis
     u8 num_params;

--- a/ast/label_stmt.c2
+++ b/ast/label_stmt.c2
@@ -31,10 +31,10 @@ public type LabelStmt struct @(opaque) {
     Stmt base;
     u32 name;
     // 4 bytes padding
-    Stmt *stmt;
+    Stmt* stmt;
 }
 
-public fn LabelStmt* LabelStmt.create(ast_context.Context* c, u32 name, SrcLoc loc, Stmt *stmt) {
+public fn LabelStmt* LabelStmt.create(ast_context.Context* c, u32 name, SrcLoc loc, Stmt* stmt) {
     LabelStmt* s = c.alloc(sizeof(LabelStmt));
     s.base.init(Label, loc);
     s.name = name;

--- a/ast/qualtype.c2
+++ b/ast/qualtype.c2
@@ -56,7 +56,7 @@ public fn u32 QualType.getQuals(const QualType qt) {
     return qt.ptr & QualType_Mask;
 }
 
-public fn void QualType.setQuals(QualType *qt, u32 qualifiers) {
+public fn void QualType.setQuals(QualType* qt, u32 qualifiers) {
     qt.ptr |= qualifiers;
 }
 
@@ -530,7 +530,7 @@ public fn void QualType.print(const QualType qt, string_buffer.Buf* out) {
 }
 
 fn void QualType.printInner(const QualType qt, string_buffer.Buf* out,  bool printCanon, bool printModifiers, bool print_error) {
-    // output examples: const char*,  const char const *,
+    // output examples: const char*,  const char const*,
     const Type* t = qt.getTypeOrNil();
     if (t) {
         u32 quals = qt.getQuals();

--- a/ast_utils/value_type.c2
+++ b/ast_utils/value_type.c2
@@ -737,7 +737,7 @@ public fn void Value.mask(Value* v, u32 width) {
     }
 }
 
-public fn void Value.truncate(Value *v, u32 width, bool is_signed) {
+public fn void Value.truncate(Value* v, u32 width, bool is_signed) {
     if (v.kind == Error) return;
     u64 uvalue = v.as_u64();
     if (is_signed) {
@@ -823,7 +823,7 @@ fn f64 fabs(f64 d) {
 // Convert a floating point number to its closest minimal representation as a
 // string and trying to avoid using exponential notation
 // TODO: should be in the C2 library as a type function f64.str()
-public fn char *ftoa(char *dest, usize size, f64 d) {
+public fn char* ftoa(char* dest, usize size, f64 d) {
     char[32] buf;
     usize pos = 0;
 
@@ -860,20 +860,20 @@ public fn char *ftoa(char *dest, usize size, f64 d) {
         }
     }
     // remove trailing zeroes, keep at least one decimal
-    char *dot = buf + 1;
+    char* dot = buf + 1;
     while (*dot && *dot != '.')
         dot++;
-    char *exp = dot;
+    char* exp = dot;
     while (*exp && *exp != 'e')
         exp++;
     char* decimals = exp;
     while (decimals > dot + 2 && decimals[-1] == '0')
         decimals--;
     usize len = size - 1;
-    for (char *p = buf; p < decimals && pos < len; p++) {
+    for (char* p = buf; p < decimals && pos < len; p++) {
         dest[pos++] = *p;
     }
-    for (char *p = exp; *p && pos < len; p++) {
+    for (char* p = exp; *p && pos < len; p++) {
         dest[pos++] = *p;
     }
     dest[pos] = '\0';

--- a/common/console.c2
+++ b/common/console.c2
@@ -32,7 +32,7 @@ Config config;
 
 const u32 BUF_SIZE = 4096;
 
-public fn void init(const Config *c = nil) {
+public fn void init(const Config* c = nil) {
     if (c) {
         setConfig(c);
     } else {

--- a/common/file/file_utils.c2
+++ b/common/file/file_utils.c2
@@ -43,7 +43,7 @@ public fn const char* get_extension(const char* s) {
 // return the length of the string if shorter than size
 // otherwise truncate the string and return size
 // compare the return value with size to detect truncation
-fn usize pstrcpy(char *dest, usize size, const char* src) {
+fn usize pstrcpy(char* dest, usize size, const char* src) {
     usize i;
     for (i = 0; i < size; i++) {
         if ((dest[i] = src[i]) == '\0') return i;
@@ -53,7 +53,7 @@ fn usize pstrcpy(char *dest, usize size, const char* src) {
 }
 
 // Copy a directory name with truncation and append a / if not empty
-fn usize copy_dirname(char *buf, usize size, const char* dir) {
+fn usize copy_dirname(char* buf, usize size, const char* dir) {
     usize pos = pstrcpy(buf, size, dir);
     if (pos && pos < size && dir[pos - 1] != '/') {
         if (pos + 1 < size) {
@@ -69,7 +69,7 @@ fn usize copy_dirname(char *buf, usize size, const char* dir) {
 // if the path fits in the destination array, a pointer to it is returned.
 // otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
 // both the filename and the extension can be nil or omitted
-public fn const char* make_path(char *buf, usize size, const char* path, const char* filename = nil, const char* ext = nil) {
+public fn const char* make_path(char* buf, usize size, const char* path, const char* filename = nil, const char* ext = nil) {
     usize pos = 0;
     if (filename) {
         if (*filename != '/') pos = copy_dirname(buf, size, path);
@@ -86,7 +86,7 @@ public fn const char* make_path(char *buf, usize size, const char* path, const c
 // construct a path in a buffer from a directory name, a subdirectory name and a filename
 // if the path fits in the destination array, a pointer to it is returned.
 // otherwise the path is truncated, errno is set to ENAMETOOLONG and nil is returned
-public fn const char* make_path3(char *buf, usize size, const char* dir, const char* subdir, const char* filename) {
+public fn const char* make_path3(char* buf, usize size, const char* dir, const char* subdir, const char* filename) {
     usize pos = 0;
     if (*filename != '/') {
         if (*subdir != '/') pos = copy_dirname(buf, size, dir);
@@ -102,7 +102,7 @@ public fn const char* make_path3(char *buf, usize size, const char* dir, const c
 // create a directory path, OK if exists already
 public fn i32 create_path(const char* path) {
     char[file_utils.Max_path] tmp;
-    char *p = tmp;
+    char* p = tmp;
     if (!*path) return 0;
     *p++ = *path++;
     for (;;) {
@@ -166,7 +166,7 @@ public fn void File.close(File* file) @(unused) {
     }
 }
 
-public fn bool File.exists(File *file) @(unused) {
+public fn bool File.exists(File* file) @(unused) {
     return path_exists(file.path);
 }
 

--- a/common/process_utils.c2
+++ b/common/process_utils.c2
@@ -114,7 +114,7 @@ public fn i32 run_args(const char* path, const char* cmd, const char* args, cons
 
         // change to working dir
         if (path && *path) {
-            char *cwd = getcwd(nil, 0);
+            char* cwd = getcwd(nil, 0);
             printf("current dir: %s\n", cwd);
             free(cwd);
 
@@ -190,7 +190,7 @@ public fn i32 run_args(const char* path, const char* cmd, const char* args, cons
     return 0;
 }
 
-fn u32 parseArgs(const char* args, char** argv, u32 maxargs, char *tmp, usize tmp_size) {
+fn u32 parseArgs(const char* args, char** argv, u32 maxargs, char* tmp, usize tmp_size) {
     // TODO accept quoted arguments
     u32 argc = 0;
     usize len = strlen(args);
@@ -209,7 +209,7 @@ fn u32 parseArgs(const char* args, char** argv, u32 maxargs, char *tmp, usize tm
 }
 
 /* Find file in one of the PATH directories */
-fn const char* find_bin(char *dest, usize size, const char* name) {
+fn const char* find_bin(char* dest, usize size, const char* name) {
     Stat statbuf;
     const char* s = getenv("PATH");
     if (!s) s = "";

--- a/common/source_mgr.c2
+++ b/common/source_mgr.c2
@@ -47,7 +47,7 @@ type File struct {
     bool is_generated;
     bool is_const;
     char* data;
-    CheckPoint *checkpoints;
+    CheckPoint* checkpoints;
 }
 
 fn void File.clear(File* f) {
@@ -91,7 +91,7 @@ fn void File.addCheckPoints(File* f) {
     *cp = pos;
 }
 
-fn CheckPoint File.findCheckPoint(File *f, u32 offset) {
+fn CheckPoint File.findCheckPoint(File* f, u32 offset) {
     if (!f.checkpoints) f.addCheckPoints();
     CheckPoint pos = f.checkpoints[offset / CheckPointSize];
     u32 chunk = offset % CheckPointSize;
@@ -169,7 +169,7 @@ public fn i32 SourceMgr.addResource(SourceMgr* sm, const char* name, const void*
 #if PrintGenerated
     stdio.printf("------ RESOURCE (%s) ------\n%s\n", name, data);
 #endif
-    return sm.addFile(name, (void *)data, size, true, true);
+    return sm.addFile(name, (void*)data, size, true, true);
 }
 
 public fn i32 SourceMgr.loadFile(SourceMgr* sm, const char* filename, SrcLoc sloc) {
@@ -193,7 +193,7 @@ public fn i32 SourceMgr.loadFile(SourceMgr* sm, const char* filename, SrcLoc slo
         return -1;
     }
     u32 size;
-    void *data = file.detach(&size);
+    void* data = file.detach(&size);
     return sm.addFile(filename, data, size, false, false);
 }
 

--- a/common/utf8.c2
+++ b/common/utf8.c2
@@ -17,7 +17,7 @@ module utf8;
 
 //public const u32 MB_CUR_MAX = 6;    // UTF-8 uses just 4
 
-public fn u32 encode(char *dest, u32 max_len, u32 cc) {
+public fn u32 encode(char* dest, u32 max_len, u32 cc) {
     if (cc < 0x80) {
         if (max_len >= 1) {
             dest[0] = (char)cc;

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -466,7 +466,7 @@ fn component.Component* Compiler.findModuleComponent(const Compiler* c, u32 name
 fn void Compiler.add_source(void* arg, const char* name, string_buffer.Buf* content) {
     Compiler* c = arg;
     u32 size;
-    void *data = content.detach(&size);
+    void* data = content.detach(&size);
     i32 file_id = c.sm.addGenerated(name, data, size);
     c.parser.parse(file_id, false, true);
 }

--- a/compiler/main.c2
+++ b/compiler/main.c2
@@ -68,7 +68,7 @@ fn void Options.init(Options* opts, string_pool.Pool* pool) {
     opts.features.init(pool);
 }
 
-fn void Options.free(Options *opts) {
+fn void Options.free(Options* opts) {
     opts.targets.free();
     opts.files.free();
     opts.features.free();
@@ -235,12 +235,12 @@ Options:
 type ArgumentParser struct {
     i32 cur;
     i32 argc;
-    char **argv;
+    char** argv;
     const char* prog;
     const char* help;
 }
 
-fn void ArgumentParser.init(ArgumentParser *ap, i32 argc, char **argv,
+fn void ArgumentParser.init(ArgumentParser* ap, i32 argc, char** argv,
                             const char* prog = nil, const char* help = nil)
 {
     ap.cur = 1;
@@ -250,30 +250,30 @@ fn void ArgumentParser.init(ArgumentParser *ap, i32 argc, char **argv,
     ap.help = help;
 }
 
-fn void ArgumentParser.showHelp(ArgumentParser *ap) {
+fn void ArgumentParser.showHelp(ArgumentParser* ap) {
     if (ap.help) console.log("%s", ap.help);
 }
 
-fn const char* ArgumentParser.getArgument(ArgumentParser *ap) {
+fn const char* ArgumentParser.getArgument(ArgumentParser* ap) {
     return ap.cur < ap.argc ? ap.argv[ap.cur++] : nil;
 }
 
-fn const char* ArgumentParser.getOptionArgument(ArgumentParser *ap, const char* option) {
+fn const char* ArgumentParser.getOptionArgument(ArgumentParser* ap, const char* option) {
     if (ap.cur < ap.argc) return ap.argv[ap.cur++];
     ap.missingArgument(option);
 }
 
-fn void ArgumentParser.missingArgument(ArgumentParser *ap, const char* option) @(noreturn) {
+fn void ArgumentParser.missingArgument(ArgumentParser* ap, const char* option) @(noreturn) {
     console.error("%s: missing argument for option '%s'", ap.prog, option);
     exit(EXIT_FAILURE);
 }
 
-fn void ArgumentParser.unknownOption(ArgumentParser *ap, const char* option) @(noreturn) {
+fn void ArgumentParser.unknownOption(ArgumentParser* ap, const char* option) @(noreturn) {
     console.error("%s: unknown option: '%s'", ap.prog, option);
     exit(EXIT_FAILURE);
 }
 
-fn void parse_long_opt(ArgumentParser *ap, const char* arg, compiler.Options* comp_opts, Options* opts) {
+fn void parse_long_opt(ArgumentParser* ap, const char* arg, compiler.Options* comp_opts, Options* opts) {
     switch (arg+2) {
     case "I2":
         opts.use_ir_backend = true;
@@ -341,7 +341,7 @@ fn void parse_long_opt(ArgumentParser *ap, const char* arg, compiler.Options* co
     }
 }
 
-fn void parse_arguments(ArgumentParser *ap, compiler.Options* comp_opts, Options* opts) {
+fn void parse_arguments(ArgumentParser* ap, compiler.Options* comp_opts, Options* opts) {
     while (const char* arg = ap.getArgument()) {
         if (arg[0] == '-') {
             if (arg[1] == '-') {

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -70,7 +70,7 @@ type Generator struct {
     const char* results_dir;
     const char* output_dir;     // output/<target>
     const char* cgen_dir;       // output/<target>/cgen
-    diagnostics.Diags *diags;
+    diagnostics.Diags* diags;
     source_mgr.SourceMgr* sm;
     const build_file.Info* build_info;
     const target_info.Info* targetInfo;
@@ -1222,7 +1222,7 @@ fn void Generator.init(Generator* gen,
                        build_target.Kind kind,
                        const char* results_dir,       // output/<target>/
                        const char* output_dir,        // output/<target>/cgen/
-                       diagnostics.Diags *diags,
+                       diagnostics.Diags* diags,
                        source_mgr.SourceMgr* sm,
                        const build_file.Info* build_info,
                        Decl* mainFunc)
@@ -1275,7 +1275,7 @@ public fn void generate(string_pool.Pool* astPool,
                         const char* target,
                         build_target.Kind kind,
                         const char* output_dir,
-                        diagnostics.Diags *diags,
+                        diagnostics.Diags* diags,
                         source_mgr.SourceMgr* sm,
                         const build_file.Info* build_info,
                         const target_info.Info* targetInfo,

--- a/generator/c/c_generator_special.c2
+++ b/generator/c/c_generator_special.c2
@@ -279,11 +279,11 @@ const char[] C2_types_header =
     ```
 #else
     ```c
-    #define offsetof(type, member) ((unsigned long) &((type *)0)->member)
+    #define offsetof(type, member) ((unsigned long) &((type*)0)->member)
     ```
 #endif
     ```c
-    #define to_container(type, member, ptr) ((type *)((char *)(ptr)-offsetof(type, member)))
+    #define to_container(type, member, ptr) ((type*)((char*)(ptr)-offsetof(type, member)))
 
     // NOTE: 64-bit only for now
     typedef signed char i8;

--- a/generator/c/c_generator_trace.c2
+++ b/generator/c/c_generator_trace.c2
@@ -36,10 +36,10 @@ type TraceCallList struct {
     u32 capacity;
 }
 
-fn u32 TraceCallList.add(TraceCallList *cl, TraceCall call) {
+fn u32 TraceCallList.add(TraceCallList* cl, TraceCall call) {
     if (cl.count >= cl.capacity) {
         cl.capacity += cl.capacity / 2 + 16;
-        TraceCall *array2 = stdlib.malloc(cl.capacity * sizeof(TraceCall));
+        TraceCall* array2 = stdlib.malloc(cl.capacity * sizeof(TraceCall));
         if (cl.array) {
             string.memcpy(array2, cl.array, cl.count * sizeof(TraceCall));
             stdlib.free(cl.array);
@@ -64,7 +64,7 @@ type StringList struct {
     u32* hash_array;
     u32 hash_count;
     u32 hash_capacity;
-    char **strings;
+    char** strings;
     u32 string_count;
     u32 string_capacity;
     const char* last_string;
@@ -140,9 +140,9 @@ fn u32 StringList.add(StringList* sl, const char* s, bool check_last) {
 #endif
     if (sl.string_count >= sl.string_capacity) {
         sl.string_capacity += sl.string_capacity / 2 + 16;
-        char **strings2 = stdlib.malloc(sl.string_capacity * sizeof(char *));
+        char** strings2 = stdlib.malloc(sl.string_capacity * sizeof(char*));
         if (sl.strings) {
-            string.memcpy(strings2, sl.strings, sl.string_count * sizeof(char *));
+            string.memcpy(strings2, sl.strings, sl.string_count * sizeof(char*));
             stdlib.free(sl.strings);
         }
         sl.strings = strings2;

--- a/generator/c2_trace.c2
+++ b/generator/c2_trace.c2
@@ -54,11 +54,11 @@ fn bool match_pattern(const char* name, const char* pattern) {
     return false;
 }
 
-fn i32 cmp_funcs(const void *a, const void *b) {
-    const c2_trace_t *aa = a;
-    const c2_trace_t *bb = b;
-    const c2_func_t *fa = &c2_func_data[aa.callee_idx];
-    const c2_func_t *fb = &c2_func_data[bb.callee_idx];
+fn i32 cmp_funcs(const void* a, const void* b) {
+    const c2_trace_t* aa = a;
+    const c2_trace_t* bb = b;
+    const c2_func_t* fa = &c2_func_data[aa.callee_idx];
+    const c2_func_t* fb = &c2_func_data[bb.callee_idx];
     if (fa.count != fb.count)
         return fa.count < fb.count ? 1 : -1;
     if (fa != fb)
@@ -66,9 +66,9 @@ fn i32 cmp_funcs(const void *a, const void *b) {
     return (aa.count < bb.count) - (aa.count > bb.count);
 }
 
-fn i32 cmp_calls(const void *a, const void *b) {
-    const c2_trace_t *aa = a;
-    const c2_trace_t *bb = b;
+fn i32 cmp_calls(const void* a, const void* b) {
+    const c2_trace_t* aa = a;
+    const c2_trace_t* bb = b;
     return (aa.count < bb.count) - (aa.count > bb.count);
 }
 
@@ -105,11 +105,11 @@ fn void list_calls() @(destructor, unused) {
         while (p[pos] && p[pos++] != ';') continue;
     }
     if (!mode) return;
-    u32 *counts = c2_trace_counts;
+    u32* counts = c2_trace_counts;
     c2_trace_t* data = c2_trace_data;
     u32 n = c2_trace_length;
     for (u32 i = 0; i < n; i++) {
-        c2_trace_t *cp = &data[i];
+        c2_trace_t* cp = &data[i];
         if (match_pattern(c2_func_data[cp.callee_idx].funcname, pattern)
         &&  match_pattern(c2_filenames[cp.filename_idx], filename)
         &&  match_pattern(c2_func_data[cp.caller_idx].funcname, caller)) {
@@ -124,11 +124,11 @@ fn void list_calls() @(destructor, unused) {
     } else {
         qsort(data, n, sizeof(c2_trace_t), cmp_funcs);
     }
-    c2_func_t *last = nil;
+    c2_func_t* last = nil;
     i32 show = 0;
     for (u32 i = 0; i < n; i++) {
-        c2_trace_t *cp = &data[i];
-        c2_func_t *func = &c2_func_data[cp.callee_idx];
+        c2_trace_t* cp = &data[i];
+        c2_func_t* func = &c2_func_data[cp.callee_idx];
         u32 count1 = func.count;
         u32 count2 = cp.count;
         if (count1 < min) continue;

--- a/libs/io_uring/io_uring.c2i
+++ b/libs/io_uring/io_uring.c2i
@@ -71,17 +71,17 @@ static_assert(216, sizeof(Ring));
  * return an allocated io_uring_probe structure, or NULL if probe fails (for
  * example, if it is not available). The caller is responsible for freeing it
  */
-struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring);
+struct io_uring_probe* io_uring_get_probe_ring(struct io_uring* ring);
 /* same as io_uring_get_probe_ring, but takes care of ring init and teardown */
-struct io_uring_probe *io_uring_get_probe(void);
+struct io_uring_probe* io_uring_get_probe(void);
 
 /*
  * frees a probe allocated through io_uring_get_probe() or
  * io_uring_get_probe_ring()
  */
-void io_uring_free_probe(struct io_uring_probe *probe);
+void io_uring_free_probe(struct io_uring_probe* probe);
 
-static inline int io_uring_opcode_supported(const struct io_uring_probe *p, int op)
+static inline int io_uring_opcode_supported(const struct io_uring_probe* p, int op)
 {
 	if (op > p->last_op)
 		return 0;
@@ -93,16 +93,16 @@ fn c_int queue_init_params(u32 entries, Ring* ring, Params* p) @(cname="io_uring
 
 fn c_int queue_init(u32 entries, Ring* ring, u32 flags) @(cname="io_uring_queue_init");
 
-fn c_int queue_mmap(c_int fd, Params *p, Ring* ring) @(cname="io_uring_queue_mmap");
-fn c_int Ring.dontfork(Ring *ring) @(cname="io_uring_ring_dontfork");
+fn c_int queue_mmap(c_int fd, Params* p, Ring* ring) @(cname="io_uring_queue_mmap");
+fn c_int Ring.dontfork(Ring* ring) @(cname="io_uring_ring_dontfork");
 fn void Ring.exit(Ring* ring) @(cname="io_uring_queue_exit");
 
-fn u32 peek_batch_cqe(Ring *ring, Cqe** cqes, u32 count) @(cname="io_uring_peek_batch_cqe");
+fn u32 peek_batch_cqe(Ring* ring, Cqe** cqes, u32 count) @(cname="io_uring_peek_batch_cqe");
 
 #if 0
-int io_uring_wait_cqes(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
-		       unsigned wait_nr, struct __kernel_timespec *ts,
-		       sigset_t *sigmask);
+int io_uring_wait_cqes(struct io_uring* ring, struct io_uring_cqe** cqe_ptr,
+		       unsigned wait_nr, struct __kernel_timespec* ts,
+		       sigset_t* sigmask);
 int io_uring_wait_cqe_timeout(struct io_uring *ring,
 			      struct io_uring_cqe **cqe_ptr,
 			      struct __kernel_timespec *ts);

--- a/libs/libc/ctermios.c2i
+++ b/libs/libc/ctermios.c2i
@@ -429,10 +429,10 @@ const unsigned PENDIN  = 04000000000;
 const unsigned IEXTEN  = 0002000;
 const unsigned EXTPROC = 0004000;
 
-void cfmakesane(Termios *termios_p);
+void cfmakesane(Termios* termios_p);
 int tcsetsid(int fd, pid_t pid);
-int tcgetwinsize(int fd, Winsize *wp);
-int tcsetwinsize(int fd, const Winsize *wp);
+int tcgetwinsize(int fd, Winsize* wp);
+int tcsetwinsize(int fd, const Winsize* wp);
 #endif
 
 #if SYSTEM_OPENBSD
@@ -555,14 +555,14 @@ const int TCSANOW   = 0;
 const int TCSADRAIN = 1;
 const int TCSAFLUSH = 2;
 
-speed_t cfgetispeed(const Termios *termios_p);
-speed_t cfgetospeed(const Termios *termios_p);
-int cfsetispeed(Termios *termios_p, speed_t speed);
-int cfsetospeed(Termios *termios_p, speed_t speed);
-int cfsetspeed(Termios *termios_p, speed_t speed);
-void cfmakeraw(Termios *termios_p);
-int tcgetattr(int fd, Termios *termios_p);
-int tcsetattr(int fd, int optional_actions, const Termios *termios_p);
+speed_t cfgetispeed(const Termios* termios_p);
+speed_t cfgetospeed(const Termios* termios_p);
+int cfsetispeed(Termios* termios_p, speed_t speed);
+int cfsetospeed(Termios* termios_p, speed_t speed);
+int cfsetspeed(Termios* termios_p, speed_t speed);
+void cfmakeraw(Termios* termios_p);
+int tcgetattr(int fd, Termios* termios_p);
+int tcsetattr(int fd, int optional_actions, const Termios* termios_p);
 int tcdrain(int fd);
 int tcflow(int fd, int action);
 int tcflush(int fd, int queue_selector);

--- a/libs/libc/ifaddrs.c2i
+++ b/libs/libc/ifaddrs.c2i
@@ -17,8 +17,8 @@ struct Ifaddrs {
        bit is set in `ifa_flags', then `ifa_broadaddr' is valid.  If the
        IFF_POINTOPOINT bit is set, then `ifa_dstaddr' is valid.
        It is never the case that both these bits are set at once.  */
-    sys_socket.Sockaddr *ifu_broadaddr; /* Broadcast address of this interface. */
-    sys_socket.Sockaddr *ifu_dstaddr; /* Point-to-point destination address.  */
+    sys_socket.Sockaddr* ifu_broadaddr; /* Broadcast address of this interface. */
+    sys_socket.Sockaddr* ifu_dstaddr; /* Point-to-point destination address.  */
   }
   void* ifa_data;       /* Address-specific data (may be unused).  */
 }

--- a/libs/libc/libc_dirent.c2i
+++ b/libs/libc/libc_dirent.c2i
@@ -11,7 +11,7 @@ int closedir(DIR* dirp);
 #if ARCH_X86_64
 Dirent* readdir(DIR* dirp) @(cname="readdir$INODE64");
 #else
-Dirent *readdir(DIR *dirp);
+Dirent* readdir(DIR* dirp);
 #endif
 #else
 Dirent* readdir(DIR* dirp);

--- a/libs/libc/libc_time.c2i
+++ b/libs/libc/libc_time.c2i
@@ -33,7 +33,7 @@ Tm* localtime_r(const Time* timep, Tm* result);
 
 Time mktime(Tm* tm);
 
-size_t strftime(char *s, size_t max, const char* format, const Tm *tm);
+size_t strftime(char* s, size_t max, const char* format, const Tm* tm);
 
 typedef long clock_t;
 clock_t clock(void);

--- a/libs/libc/regex.c2i
+++ b/libs/libc/regex.c2i
@@ -1,7 +1,7 @@
 module regex extern "C";
 
 struct Regex_t @(cname="regex_t") {
-    void *re_pcre;
+    void* re_pcre;
     size_t re_nsub;
     size_t re_erroffset;
 }

--- a/libs/libc/stdio.c2i
+++ b/libs/libc/stdio.c2i
@@ -54,24 +54,24 @@ FILE* stderr @(cname="__stderrp");
 #endif
 #if SYSTEM_OPENBSD
 struct Sbuf__ {
-    unsigned char *_base;
+    unsigned char* _base;
     int _size;
 }
 struct FILE {
-    unsigned char *_p;
+    unsigned char* _p;
     int _r;
     int _w;
     short _flags;
     short _file;
     Sbuf__ _bf;
     int _lbfsize;
-    void *_cookie;
-    void *_close;   //int (*_close)(void *);
-    void *_read;    //int (*_read)(void *, char *, int);
-    void *_seek;    //fpos_t (*_seek)(void *, fpos_t, int);
-    void *_write;   //int (*_write)(void *, const char* , int);
+    void* _cookie;
+    void* _close;   //int (*_close)(void*);
+    void* _read;    //int (*_read)(void*, char*, int);
+    void* _seek;    //fpos_t (*_seek)(void*, fpos_t, int);
+    void* _write;   //int (*_write)(void*, const char*, int);
     Sbuf__ _ext;
-    unsigned char *_up;
+    unsigned char* _up;
     int _ur;
     unsigned char[3] _ubuf;
     unsigned char[1] _nbuf;
@@ -178,9 +178,9 @@ int asprintf(char**, const char* @(printf_format), ...);
 char* ctermid_r(char*);
 char* fgetln(FILE*, size_t*);
 const char* fmtcheck(const char*, const char*);
-int fpurge(FILE *);
+int fpurge(FILE*);
 //int vasprintf(char**, const char*, va_list);
-FILE *zopen(const char*, const char*, int);
+FILE* zopen(const char*, const char*, int);
 
 int vdprintf(int __fd, const char* format, va_list ap);
 int vfprintf(FILE* stream, const char* format, va_list ap);

--- a/libs/libc/stdlib.c2i
+++ b/libs/libc/stdlib.c2i
@@ -23,7 +23,7 @@ void* calloc(size_t count, size_t size);
 #if __ASAN__ || __MSAN__ || __UBSAN__
 void* malloc(size_t size) {
     // fill malloced blocks with junk if debugging
-    void *p = calloc(size, 1);
+    void* p = calloc(size, 1);
     return p ? string.memset(p, 0xAA, size) : p;
 }
 #else

--- a/libs/libc/string.c2i
+++ b/libs/libc/string.c2i
@@ -74,16 +74,16 @@ size_t strlcat(char* dest, const char* src, size_t n);
  * Find the first occurrence of s2 in s1, where the search is limited to the
  * first n c_characters of s.
  */
-char *strnstr(const char* s1, const char* s2, size_t n) {
+char* strnstr(const char* s1, const char* s2, size_t n) {
     /* simplistic algorithm with O(n2) worst case */
     char c = *s2++;
-    if (c == '\0') return (char *)s1;
+    if (c == '\0') return (char*)s1;
     size_t len = strlen(s2);
     for (; n-- >= len && *s1; s1++) {
         if (*s1 == c) {
             for (size_t i = 1;; i++) {
                 if (i == len)
-                    return (char *)s1;
+                    return (char*)s1;
                 if (s1[i] != s2[i])
                     break;
             }
@@ -92,7 +92,7 @@ char *strnstr(const char* s1, const char* s2, size_t n) {
     return nil;
 }
 
-size_t strlcpy(char *dst, const char* src, size_t n) {
+size_t strlcpy(char* dst, const char* src, size_t n) {
     for (size_t i = 0; i < n; i++) {
         if ((dst[i] = *src++) == '\0') return i;
     }
@@ -101,7 +101,7 @@ size_t strlcpy(char *dst, const char* src, size_t n) {
     return n;
 }
 
-size_t strlcat(char *dst, const char* src, size_t n) {
+size_t strlcat(char* dst, const char* src, size_t n) {
     size_t i = 0;
     while (i < n && dst[i]) i++;
     while (i < n) {

--- a/libs/libc/sys_socket.c2i
+++ b/libs/libc/sys_socket.c2i
@@ -174,7 +174,7 @@ int setsockopt(int sockfd, int level, int optname, const void* optval, u32 optle
 int bind(int sockfd, const Sockaddr* addr, u32 addrlen);
 int connect(int sockfd, const Sockaddr* addr, u32 addrlen);
 int listen(int sockfd, int backlog);
-int accept(int sockfd, Sockaddr *addr, u32 *addrlen);
+int accept(int sockfd, Sockaddr* addr, u32* addrlen);
 
 #if SYSTEM_LINUX
 
@@ -183,7 +183,7 @@ int accept4(int sockfd, Sockaddr* addr, u32* addrlen, int flags);
 
 #else
 
-int accept4(int sockfd, Sockaddr *addr, u32 *addrlen, int flags) {
+int accept4(int sockfd, Sockaddr* addr, u32* addrlen, int flags) {
     int new_sockfd = accept(sockfd, addr, addrlen);
     if (new_sockfd < 0) {
         return -1;
@@ -206,7 +206,7 @@ int accept4(int sockfd, Sockaddr *addr, u32 *addrlen, int flags) {
 #endif
 
 // NOTE: some c-prototypes need to be converted
-//int inet_aton(const char* cp, struct in_addr *inp);
+//int inet_aton(const char* cp, struct in_addr* inp);
 InAddr inet_addr(const char* cp);
 char* inet_ntoa(In_addr in);
 //struct in_addr inet_makeaddr(in_addr_t net, in_addr_t host);

--- a/libs/libc/sys_utsname.c2i
+++ b/libs/libc/sys_utsname.c2i
@@ -20,8 +20,8 @@ struct Name @(cname="utsname") {
 }
 
 #if SYSTEM_FREEBSD
-int __xuname(int len, void *);       /* Variable record size. */
-int uname(Name *name) {
+int __xuname(int len, void*);       /* Variable record size. */
+int uname(Name* name) {
     return __xuname(NAME_LEN, name);
 }
 #else

--- a/libs/libc/uio.c2i
+++ b/libs/libc/uio.c2i
@@ -9,7 +9,7 @@ ssize_t writev(int fd, const Iovec* iovec, int count);
 
 /* Structure for scatter/gather I/O.  */
 struct Iovec {
-    void *iov_base; /* Pointer to data.  */
+    void* iov_base; /* Pointer to data.  */
     size_t iov_len; /* Length of data.  */
 }
 

--- a/libs/libc/unistd.c2i
+++ b/libs/libc/unistd.c2i
@@ -31,15 +31,15 @@ int dup2(int oldfd, int newfd);
 int execl(const char* path, const char* arg, ...);
 int execle(const char* path, const char* arg, ...);
 int execlp(const char* file, const char* arg, ...);
-int execv(const char* path, char */*const*/ *argv);
-int execve(const char* path, char */*const*/ *argv, char */*const*/ *envp);
-int execvp(const char* file, char */*const*/ *argv);
-int execvpe(const char* file, char */*const*/ *argv, char */*const*/ *envp);
+int execv(const char* path, char* /*const*/ *argv);
+int execve(const char* path, char* /*const*/ *argv, char* /*const*/ *envp);
+int execvp(const char* file, char* /*const*/ *argv);
+int execvpe(const char* file, char* /*const*/ *argv, char* /*const*/ *envp);
 pid_t fork(void);
 long fpathconf(int fd, int name);
-char *getcwd(char *buf, size_t size);
-int getgroups(int gidsetsize, gid_t *gidset);
-char *getlogin(void);
+char* getcwd(char* buf, size_t size);
+int getgroups(int gidsetsize, gid_t* gidset);
+char* getlogin(void);
 pid_t getpgrp(void);
 pid_t getpid(void);
 pid_t getppid(void);
@@ -49,8 +49,8 @@ int isatty(int fd);
 off_t lseek(int fd, off_t offset, int whence);
 long pathconf(const char* path, int name);
 int pause(void);
-int pipe(int *pipedes);
-ssize_t read(int fd, void *buf, size_t nbytes);
+int pipe(int* pipedes);
+ssize_t read(int fd, void* buf, size_t nbytes);
 int rmdir(const char* path);
 int setgid(gid_t gid);
 int setpgid(pid_t pid, pid_t pgid);
@@ -60,18 +60,18 @@ unsigned sleep(unsigned seconds);
 long sysconf(int name);
 pid_t tcgetpgrp(int fd);
 int tcsetpgrp(int fd, pid_t pgrp_id);
-char *ttyname(int fd);
-int ttyname_r(int fd, char *buf, size_t len);
+char* ttyname(int fd);
+int ttyname_r(int fd, char* buf, size_t len);
 int unlink(const char* name);
-ssize_t write(int fd, const void *buf, size_t nbytes);
+ssize_t write(int fd, const void* buf, size_t nbytes);
 
 /* Additional functionality provided by:
  * POSIX.2-1992 C Language Binding Option
  */
 
-size_t confstr(int name, char *buf, size_t len);
-int getopt(int argc, char */*const*/ *argv, const char* optstring);
-char *optarg;
+size_t confstr(int name, char* buf, size_t len);
+int getopt(int argc, char* /*const*/ *argv, const char* optstring);
+char* optarg;
 int optind;
 int opterr;
 int optopt;
@@ -89,10 +89,10 @@ const int F_TEST  = 3;      /* test a section for locks by other procs */
 
 #if 0
 /* Removed in Issue 6 */
-void *brk(const void *addr) @(deprecated);
+void* brk(const void* addr) @(deprecated);
 int chroot(const char* path) @(deprecated);
-char *crypt(const char* , const char* );
-int encrypt(char *buf /*_LIBC_COUNT(64)*/, int);
+char* crypt(const char*, const char*);
+int encrypt(char* buf /*_LIBC_COUNT(64)*/, int);
 #endif
 
 int fchdir(int fd);
@@ -104,29 +104,29 @@ pid_t getsid(pid_t pid);
 /* Removed in Issue 6 */
 int getdtablesize(void) @(deprecated);
 int getpagesize(void) @(pure, deprecated);
-char *getpass(const char* ) @(deprecated);
+char* getpass(const char*) @(deprecated);
 
 /* Removed in Issue 7 */
-char *getwd(char *buf /*PATH_MAX*/) @(deprecated="obsoleted by getcwd()")
+char* getwd(char* buf /*PATH_MAX*/) @(deprecated="obsoleted by getcwd()")
 #endif
 
 int lchown(const char* file, uid_t owner, gid_t group);
 int lockf(int fd, int cmd, off_t len);
 int nice(int inc);
-ssize_t pread(int fd, void *buf, size_t nbytes, off_t offset);
-ssize_t pwrite(int fd, const void *buf, size_t nbytes, off_t offset);
+ssize_t pread(int fd, void* buf, size_t nbytes, off_t offset);
+ssize_t pwrite(int fd, const void* buf, size_t nbytes, off_t offset);
 
 #if 0
 /* Removed in Issue 6 */
 /* Note that Issue 5 changed the argument as intprt_t,
  * but we keep it as int for binary compatability. */
-void *sbrk(int delta);
+void* sbrk(int delta);
 #endif
 
 int setpgrp(pid_t pid, pid_t pgrp);	/* obsoleted by setpgid() */
 int setregid(gid_t gid, gid_t gid2);
 int setreuid(uid_t uid, uid_t uid2);
-//void swab(const void *, void *, ssize_t nbytes);
+//void swab(const void*, void*, ssize_t nbytes);
 void sync(void);
 int truncate(const char* path, off_t offset);
 useconds_t ualarm(useconds_t value, useconds_t interval);
@@ -138,7 +138,7 @@ pid_t vfork(void) @(deprecated="Use posix_spawn or fork");
 
 int fsync(int fd);
 int ftruncate(int fd, off_t offset);
-int getlogin_r(char *name, size_t name_len);
+int getlogin_r(char* name, size_t name_len);
 
 /* Additional functionality provided by:
  * POSIX.1-2001
@@ -146,8 +146,8 @@ int getlogin_r(char *name, size_t name_len);
  */
 
 int fchown(int fd, uid_t owner, gid_t group);
-int gethostname(char *name, size_t len);
-ssize_t readlink(const char* path, char *buf, size_t bufsize);
+int gethostname(char* name, size_t len);
+ssize_t readlink(const char* path, char* buf, size_t bufsize);
 int setegid(gid_t);
 int seteuid(uid_t);
 int symlink(const char* from, const char* to);
@@ -157,9 +157,9 @@ int dup3(int oldfd, int newfd, int flags);
 int faccessat(int fd, const char* file, int type_, int flag);
 int fchownat(int fd, const char* file, uid_t owner, gid_t group, int flag);
 int fdatasync(int fd);
-int fexecve(int fd, char */*const*/ *argv, char */*const*/ *envp);
+int fexecve(int fd, char* /*const*/ *argv, char* /*const*/ *envp);
 int linkat(int fromfd, const char* from, int tofd, const char* to, int flags);
-ssize_t readlinkat(int fd, const char* path, char *buf, size_t len);
+ssize_t readlinkat(int fd, const char* path, char* buf, size_t len);
 int symlinkat(const char* from, int tofd, const char* to);
 int unlinkat(int fd, const char* name, int flag);
 
@@ -170,18 +170,18 @@ char* mkdtemp(char* tpl);
 gid_t getegid(void);
 uid_t geteuid(void);
 gid_t getgid(void);
-ssize_t freadlink(int fd, char *buf, size_t bufsize);
+ssize_t freadlink(int fd, char* buf, size_t bufsize);
 int setrgid(gid_t gid);
 int setruid(uid_t uid);
 
 #if SYSTEM_LINUX
 
 //#ifdef_GNU_SOURCE       /* See feature_test_macros(7) */
-int pipe2(int *pipefd, int flags);
+int pipe2(int* pipefd, int flags);
 
 #else
 
-int pipe2(int *pipefd, int flags) {
+int pipe2(int* pipefd, int flags) {
   if (pipe(pipefd) < 0) {
     return -1;
   }

--- a/libs/math/math.c2i
+++ b/libs/math/math.c2i
@@ -162,17 +162,17 @@ float logbf(float) @(pure);
 double logb(double) @(pure);
 //long double logbl(long double) @(pure);
 
-float modff(float, float *) @(pure);
-double modf(double, double *) @(pure);
-//long double modfl(long double, long double *) @(pure);
+float modff(float, float*) @(pure);
+double modf(double, double*) @(pure);
+//long double modfl(long double, long double*) @(pure);
 
 float ldexpf(float, int) @(pure);
 double ldexp(double, int) @(pure);
 //long double ldexpl(long double, int) @(pure);
 
-float frexpf(float, int *) @(pure);
-double frexp(double, int *) @(pure);
-//long double frexpl(long double, int *) @(pure);
+float frexpf(float, int*) @(pure);
+double frexp(double, int*) @(pure);
+//long double frexpl(long double, int*) @(pure);
 
 int ilogbf(float) @(pure);
 int ilogb(double) @(pure);
@@ -270,17 +270,17 @@ float remainderf(float, float) @(pure);
 double remainder(double, double) @(pure);
 //long double remainderl(long double, long double) @(pure);
 
-float remquof(float, float, int *) @(pure);
-double remquo(double, double, int *) @(pure);
-//long double remquol(long double, long double, int *) @(pure);
+float remquof(float, float, int*) @(pure);
+double remquo(double, double, int*) @(pure);
+//long double remquol(long double, long double, int*) @(pure);
 
 float copysignf(float, float) @(pure);
 double copysign(double, double) @(pure);
 //long double copysignl(long double, long double) @(pure);
 
-float nanf(const char* );
-double nan(const char* );
-//long double nanl(const char* );
+float nanf(const char*);
+double nan(const char*);
+//long double nanl(const char*);
 
 float nextafterf(float, float) @(pure);
 double nextafter(double, double) @(pure);

--- a/libs/mbedtls/mbedtls.c2i
+++ b/libs/mbedtls/mbedtls.c2i
@@ -500,7 +500,7 @@ type Ssl_session struct @(cname="mbedtls_ssl_session") {
 
 
 
-type Cfg_dbg_f fn void(void *, c_int, const char* , c_int, const char* );
+type Cfg_dbg_f fn void(void *, c_int, const char*, c_int, const char*);
 type Cfg_rng_f fn c_int(void *, c_uchar*, c_size);
 type Cfg_get_cache_f fn c_int(void *, Ssl_session*);
 type Cfg_set_cache_f fn c_int(void *, const Ssl_session*);
@@ -1052,7 +1052,7 @@ fn void ctr_drbg_init( Ctr_drbg_context *ctx ) @(cname="mbedtls_ctr_drbg_init");
 
 fn c_int ctr_drbg_random( void *p_rng, c_uchar *output, c_size output_len) @(cname="mbedtls_ctr_drbg_random");
 
-type Dbg_fn fn void(void*, c_int, const char* , c_int, const char* );
+type Dbg_fn fn void(void*, c_int, const char*, c_int, const char*);
 fn void ssl_conf_dbg( Ssl_config *conf, Dbg_fn f_dbg, void  *p_dbg ) @(cname="mbedtls_ssl_conf_dbg");
 
 // ------ sha512.h ------

--- a/libs/sdl2/sdl.c2i
+++ b/libs/sdl2/sdl.c2i
@@ -314,7 +314,7 @@ type Event union @(cname="SDL_Event") {
        the next multiple of 16, 64, and on architectures where pointers are
        even larger the size of SDL_UserEvent will dominate as being 3 pointers.
     */
-    //u8 padding[sizeof(void *) <= 8 ? 56 : sizeof(void *) == 16 ? 64 : 3 * sizeof(void *)];
+    //u8 padding[sizeof(void*) <= 8 ? 56 : sizeof(void*) == 16 ? 64 : 3 * sizeof(void*)];
     u8[56] padding;
 }
 
@@ -1066,7 +1066,7 @@ type AudioSpec struct @(cname="SDL_AudioSpec") {
     u16 padding;             /**< Necessary for some compile environments */
     u32 size;                /**< Audio buffer size in bytes (calculated) */
     AudioCallback callback; /**< Callback that feeds the audio device (NULL to use SDL_QueueAudio()). */
-    void *userdata;             /**< Userdata passed to callback (ignored for NULL callbacks). */
+    void* userdata;             /**< Userdata passed to callback (ignored for NULL callbacks). */
 }
 
 type AudioDeviceID u32 @(cname="SDL_AudioDeviceID");
@@ -1246,7 +1246,7 @@ fn void free(void* mem) @(cname="SDL_free");
 
 type PixelFormat struct @(cname="SDL_PixelFormat") {
     u32 format;
-    Palette *palette;
+    Palette* palette;
     u8 BitsPerPixel;
     u8 BytesPerPixel;
     u8[2] padding;
@@ -1263,7 +1263,7 @@ type PixelFormat struct @(cname="SDL_PixelFormat") {
     u8 Bshift;
     u8 Ashift;
     c_int refcount;
-    PixelFormat *next;
+    PixelFormat* next;
 }
 
 // TEMP, avoid macros

--- a/libs/sdl2_ttf/sdl_ttf.c2i
+++ b/libs/sdl2_ttf/sdl_ttf.c2i
@@ -11,7 +11,7 @@ type Font struct @(cname="TTF_FONT", opaque);
 
 fn Font* openFont(const char* file, c_int ptsize) @(cname="TTF_OpenFont");
 
-fn void Font.close(Font *font) @(cname="TTF_CloseFont");
+fn void Font.close(Font* font) @(cname="TTF_CloseFont");
 
 fn c_int Font.setSize(Font* font, c_int ptsize) @(cname="TTF_SetFontSize");
 

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -419,10 +419,10 @@ fn void Parser.parseTopLevel(Parser* p) {
     default:
         p.parseVarDecl(is_public);
         break;
-    invalid_c :
+    invalid_c:
         p.error("invalid keyword '%s' in extern C code", p.tok.kind.name);
         //noreturn;
-    invalid_c2 :
+    invalid_c2:
         p.error("invalid '%s' definition in C2 code", p.tok.kind.name);
         //noreturn;
     }

--- a/parser/c2_tokenizer.c2
+++ b/parser/c2_tokenizer.c2
@@ -1514,9 +1514,9 @@ type Operand struct {
     u8 prec;
 }
 
-fn i64 Tokenizer.parse_ppexpr(Tokenizer* t, Token *result) {
+fn i64 Tokenizer.parse_ppexpr(Tokenizer* t, Token* result) {
     Operand[MAX_LEVEL] stack;
-    Operand *sp;
+    Operand* sp;
     Kind op;
     u8 prec;
     Value val.setUnsigned(0);

--- a/plugins/unit_test_plugin.c2
+++ b/plugins/unit_test_plugin.c2
@@ -90,7 +90,7 @@ fn const char* Plugin.getName(Plugin* p, Decl* d) {
 const char[] Content1 @(embed="plugins/unit_test1.c2");
 const char[] Content2 @(embed="plugins/unit_test2.c2");
 
-fn void generate_types(Plugin *p) {
+fn void generate_types(Plugin* p) {
     string_buffer.Buf* out = string_buffer.create(4096, false, 2);
 
     out.add(Content1);

--- a/test/expr/binary/invalid_operands.c2
+++ b/test/expr/binary/invalid_operands.c2
@@ -15,8 +15,8 @@ u32 ui;
 u64 ul;
 f32 f;
 f64 d;
-char *p;
-void *vp;
+char* p;
+void* vp;
 
 fn void f1() {}
 

--- a/test/functions/indirect_calls.c2
+++ b/test/functions/indirect_calls.c2
@@ -23,7 +23,7 @@ fn Operator getop(char c) {
     }
 }
 
-type Evaluator fn u32 (Num *sp);
+type Evaluator fn u32 (Num* sp);
 
 fn u32 error(Num*) { printf("invalid operator\n"); return 0; }
 fn u32 add(Num* sp) { *sp += sp[1]; return 1; }
@@ -49,7 +49,7 @@ public fn i32 main() {
 
         Num[32] stack;
         Num* sp = stack;
-        char *p = buf;
+        char* p = buf;
         while (*p) {
             if (isspace(*p)) {
                 p++;

--- a/test/stmt/for_const.c2
+++ b/test/stmt/for_const.c2
@@ -2,6 +2,6 @@ module test;
 
 public fn i32 main() {
     for (const char* p = "abc"; *p; p++) {}
-    for (const volatile char *p = "abc"; *p; p++) {}
+    for (const volatile char* p = "abc"; *p; p++) {}
     return 0;
 }

--- a/test/stmt/switch/switch_case_duplicate_str.c2
+++ b/test/stmt/switch/switch_case_duplicate_str.c2
@@ -1,6 +1,6 @@
 module test;
 
-fn void test1(char *s) {
+fn void test1(char* s) {
     switch (s) {
     case nil:     // @note{previous case is here}
         break;
@@ -11,7 +11,7 @@ fn void test1(char *s) {
     }
 }
 
-fn void test2(char *s) {
+fn void test2(char* s) {
     switch (s) {
     case "a":     // @note{previous case is here}
         break;

--- a/test/stmt/switch/switch_case_embedded_null.c2
+++ b/test/stmt/switch/switch_case_embedded_null.c2
@@ -1,6 +1,6 @@
 module test;
 
-fn void test3(char *s) {
+fn void test3(char* s) {
     switch (s) {
     case "a\0b":     // @error{case string value has embedded null byte}
         break;

--- a/test/types/const/multi_const.c2t
+++ b/test/types/const/multi_const.c2t
@@ -24,7 +24,7 @@ public fn i32 main() {
     const char* const s = "a";
     const char* const[1][1][1] a = {{{ s }}}
     const char* const* p = a[0][0];
-    const void *q = (const char* const*)p;
+    const void* q = (const char* const*)p;
     A* const cc = nil;
     q = (A* const*)&cc;
     A[1] aa;

--- a/test/types/struct/bitfield_validator.c2
+++ b/test/types/struct/bitfield_validator.c2
@@ -547,7 +547,7 @@ fn i32 dump_bin(u8 b) {
 }
 
 u32 nvals;
-char **vals;
+char** vals;
 
 fn bool filter_name(const char* name) {
     if (!name || !nvals) return true;
@@ -616,7 +616,7 @@ fn void check(const char* s, usize a, u8* p1, u8* p2) {
     }
 }
 
-public fn i32 main(i32 argc, char **argv) {
+public fn i32 main(i32 argc, char** argv) {
     i32 i;
     for (i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-d")) dump = 16;

--- a/tools/tester/tester.c2
+++ b/tools/tester/tester.c2
@@ -307,14 +307,14 @@ fn u64 now() {
 public fn i32 main(i32 argc, char** argv) {
     u32 num_threads = 0;
     TestQueue* queue = TestQueue.create();
-    char *target = nil;
+    char* target = nil;
 
     u64 t1 = now();
 
     set_color_output(argv[0], color.useColor());
 
     for (i32 i = 1; i < argc; i++) {
-        char *arg = argv[i];
+        char* arg = argv[i];
         if (arg[0] == '-') {
             switch (arg) {
             case "-s":


### PR DESCRIPTION
* use `char* xxx` instead of `char *xxx`, etc.
* remove redundant spaces before `,`, `)` and `:` (for labels)