### PR TITLE
Compiler: refine support of memory models (ILP32, LP64, LLP64)

### DIFF
--- a/common/target_info.c2
+++ b/common/target_info.c2
@@ -87,7 +87,8 @@ public type Info struct {
     Vendor vendor;
     Abi abi;
 
-    u32 intWidth;   // 32/64
+    u32 ptrWidth;   // 32/64
+    u32 longWidth;  // 32/64
 
     char[80] triple;
 }
@@ -95,22 +96,27 @@ public type Info struct {
 public fn void Info.init(Info* info) {
     switch (info.arch) {
     case Unknown:
-        info.intWidth = 64;
+        info.ptrWidth = 64;
+        info.longWidth = 64;
         break;
     case I686:
     case Arm:
-        info.intWidth = 32;
+        info.ptrWidth = 32;
+        info.longWidth = 32;
         break;
     case X86_64:
     case Arm64:
     case Amd64:
-        info.intWidth = 64;
+        info.ptrWidth = 64;
+        info.longWidth = 64;
         break;
     case Riscv_32:
-        info.intWidth = 32;
+        info.ptrWidth = 32;
+        info.longWidth = 32;
         break;
     case Riscv_64:
-        info.intWidth = 64;
+        info.ptrWidth = 64;
+        info.longWidth = 64;
         break;
     }
 

--- a/compiler/compiler.c2
+++ b/compiler/compiler.c2
@@ -269,11 +269,8 @@ fn void Compiler.build(Compiler* c,
 
     c.addGlobalDefine("SYSTEM", c.targetInfo.getSystemName());
     c.addGlobalDefine("ARCH", c.targetInfo.getArchName());
-    if (c.targetInfo.intWidth == 64) {
-        c.addFeature("ARCH_64BIT");
-    } else {
-        c.addFeature("ARCH_32BIT");
-    }
+    c.addFeature(c.targetInfo.ptrWidth == 32 ? "ARCH_32BIT" : "ARCH_64BIT");
+    c.addFeature(c.targetInfo.longWidth == 32 ? "LONG_32BIT" : "LONG_64BIT");
     if (opts.asan) c.addFeature("__ASAN__");
     if (opts.msan) c.addFeature("__MSAN__");
     if (opts.ubsan) c.addFeature("__UBSAN__");
@@ -288,7 +285,7 @@ fn void Compiler.build(Compiler* c,
 
     // TODO: reorganize these objects:
     //  ast.AstContext should the global object
-    c.context = ast_context.create(16*1024, c.targetInfo.intWidth / 8);
+    c.context = ast_context.create(16*1024, c.targetInfo.ptrWidth / 8);
     ast.initialize(c.context, c.astPool, color.useColor());
 
     c.attr_handler = attr_handler.create(diags, c.astPool, target.getWarnings());

--- a/generator/c/c_generator.c2
+++ b/generator/c/c_generator.c2
@@ -1450,31 +1450,31 @@ fn void Generator.emit_external_header(Generator* gen, string_buffer.Buf* out) {
     out.add(Include_guard1);
     out.add(Warning_control);
     out.add(C_types);
-    if (gen.targetInfo.intWidth == 32) {
-        // ILP32 (32-bit int, long and pointers)
+    // we support 3 models:
+    // ILP32: 32-bit int, long and pointers
+    // LP64: 32-bit int, 64-bit long and pointers
+    // LLP64: 32-bit int and long, 64-bit pointers
+    if (gen.targetInfo.longWidth == 32) {
         out.add(```c
                 typedef signed long long i64;
                 typedef unsigned long long u64;
-                typedef signed long ssize_t;
-                typedef unsigned long size_t;
                 ```);
     } else {
-        // LP64 (64-bit long and pointers)
         out.add(```c
                 typedef signed long i64;
                 typedef unsigned long u64;
-                typedef signed long ssize_t;
-                typedef unsigned long size_t;
                 ```);
-#if 0
-        // TODO support LLP64 (64-bit long long and pointers, but 32-bit long)
+    }
+    if (gen.targetInfo.ptrWidth == 32) {
         out.add(```c
-                typedef signed long long i64;
-                typedef unsigned long long u64;
+                typedef signed int ssize_t;
+                typedef unsigned int size_t;
+                ```);
+    } else {
+        out.add(```c
                 typedef signed long long ssize_t;
                 typedef unsigned long long size_t;
                 ```);
-#endif
     }
     out.add(C_defines);
 #if 1

--- a/generator/ir/ir_generator.c2
+++ b/generator/ir/ir_generator.c2
@@ -91,7 +91,7 @@ fn void Generator.init(Generator* gen,
     gen.locals.init();
     gen.print = print;
     gen.enable_asserts = enable_asserts;
-    gen.ptr_type = targetInfo.intWidth == 64 ? ir.Type.U64 : ir.Type.U32;
+    gen.ptr_type = targetInfo.ptrWidth == 64 ? ir.Type.U64 : ir.Type.U32;
     gen.sm = sm;
     gen.name_buf = string_buffer.create(128, false, 0);
 }

--- a/libs/c2/c_types.c2i
+++ b/libs/c2/c_types.c2i
@@ -11,13 +11,16 @@ type c_ulonglong u64 @(cname="unsigned long long");
 type c_float f32 @(cname="float");
 type c_double f64 @(cname="double");
 #if ARCH_32BIT
-type c_long i32 @(cname="long");
-type c_ulong u32 @(cname="unsigned long");
 type c_size u32 @(cname="size_t");
 type c_ssize i32 @(cname="ssize_t");
 #else
-type c_long i64 @(cname="long");
-type c_ulong u64 @(cname="unsigned long");
 type c_size u64 @(cname="size_t");
 type c_ssize i64 @(cname="ssize_t");
+#endif
+#if LONG_32BIT
+type c_long i32 @(cname="long");
+type c_ulong u32 @(cname="unsigned long");
+#else
+type c_long i64 @(cname="long");
+type c_ulong u64 @(cname="unsigned long");
 #endif

--- a/libs/libc/builtin.c2i
+++ b/libs/libc/builtin.c2i
@@ -1,37 +1,61 @@
 module builtin extern "C";
 
 // Returns one plus the index of the least significant 1-bit of x, or if x is zero, returns zero.
-u8 ffs(u32) @(cname="__builtin_ffs");
+int ffs(int) @(cname="__builtin_ffs");
 
 // Returns the number of leading 0-bits in x, starting at the most significant bit position. If x is 0, the result is undefined.
-u8 clz(u32) @(cname="__builtin_clz");
+int clz(u32) @(cname="__builtin_clz");
 
 // Returns the number of trailing 0-bits in x, starting at the least significant bit position. If x is 0, the result is undefined.
-u8 ctz(u32) @(cname="__builtin_ctz");
+int ctz(u32) @(cname="__builtin_ctz");
 
 // Returns the number of leading redundant sign bits in x, i.e. the number of bits following the most significant bit that are identical to it. There are no special cases for 0 or other values.
-u8 clrsb(i32) @(cname="__builtin_clrsb");
+int clrsb(i32) @(cname="__builtin_clrsb");
 
 // Returns the number of 1-bits in x.
-u8 popcount(u32) @(cname="__builtin_popcount");
+int popcount(u32) @(cname="__builtin_popcount");
 
 // Returns the parity of x, i.e. the number of 1-bits in x modulo 2.
-u8 parity(u32) @(cname="__builtin_parity");
+int parity(u32) @(cname="__builtin_parity");
+
+#if LONG_32BIT
 
 // Similar to __builtin_ffs, except the argument type is long long.
-u8 ffs64(i64) @(cname="__builtin_ffsll");
+int ffs64(long long) @(cname="__builtin_ffsll");
 
 // Similar to __builtin_clz, except the argument type is unsigned long long.
-u8 clz64(u64) @(cname="__builtin_clzll");
+int clz64(unsigned long long) @(cname="__builtin_clzll");
 
 // Similar to __builtin_ctz, except the argument type is unsigned long long.
-u8 ctz64(u64) @(cname="__builtin_ctzll");
+int ctz64(unsigned long long) @(cname="__builtin_ctzll");
 
 // Similar to __builtin_clrsb, except the argument type is long long.
-u8 clrsb64(i64) @(cname="__builtin_clrsbll");
+int clrsb64(long long) @(cname="__builtin_clrsbll");
 
 // Similar to __builtin_popcount, except the argument type is unsigned long long.
-u8 popcount64(u64) @(cname="__builtin_popcountll");
+int popcount64(unsigned long long) @(cname="__builtin_popcountll");
 
 // Similar to __builtin_parity, except the argument type is unsigned long long.
-u8 parity64(u64) @(cname="__builtin_parityll");
+int parity64(unsigned long long) @(cname="__builtin_parityll");
+
+#else
+
+// Similar to __builtin_ffs, except the argument type is long.
+int ffs64(long) @(cname="__builtin_ffsl");
+
+// Similar to __builtin_clz, except the argument type is unsigned long.
+int clz64(unsigned long) @(cname="__builtin_clzl");
+
+// Similar to __builtin_ctz, except the argument type is unsigned long.
+int ctz64(unsigned long) @(cname="__builtin_ctzl");
+
+// Similar to __builtin_clrsb, except the argument type is long.
+int clrsb64(long) @(cname="__builtin_clrsbl");
+
+// Similar to __builtin_popcount, except the argument type is unsigned long.
+int popcount64(unsigned long) @(cname="__builtin_popcountl");
+
+// Similar to __builtin_parity, except the argument type is unsigned long.
+int parity64(unsigned long) @(cname="__builtin_parityl");
+
+#endif


### PR DESCRIPTION
* renamed `target_info.Info.intWidth` as `ptrWidth`
* add `target_info.Info.longWidth` distinct from `target_info.Info.ptrWidth` to support LLP64 architectures. see https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
* define `LONG_32BIT` and `LONG_64BIT`, distinct from `ARCH-32BIT` and `ARCH_64BIT`
* fix builtin function prototypes

fixes #499