### PR TITLE
Compiler: use enum type as array sizes if possible

### DIFF
--- a/analyser/module_analyser_binop.c2
+++ b/analyser/module_analyser_binop.c2
@@ -248,7 +248,7 @@ fn QualType Analyser.checkBinopLogical(Analyser* ma, BinaryOperator* b, QualType
 // 6  pointer -= builtin/enum
 // 7  enum -= builtin
 // 8  enum -= enum -> int (CTV)
-const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvAddSubAss = {
+const u8[TypeKind][TypeKind] BinOpConvAddSubAss = {
     //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin += / -=
     {   4,      2,      0,      2,      5,      2,     2,     0,     0  },
@@ -312,7 +312,7 @@ fn QualType Analyser.checkBinopAddSubAssign(Analyser* ma, BinaryOperator* b, Qua
 // 8  ptr + builtin/enum
 // TODO remove Alias/Module (+Array, need to move) since already checked
 // TODO need to fix C2C.c++ (asserts of elemsof(..) -2), then table can be 5x5
-const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvAdd = {
+const u8[TypeKind][TypeKind] BinOpConvAdd = {
     //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin +
     {   4,      7,      0,      2,      5,      2,     2,     0,     0  },
@@ -395,7 +395,7 @@ fn QualType Analyser.checkBinopAddArgs(Analyser* ma, BinaryOperator* b, QualType
 // 7  enum - enum -> int if same enum
 // 8  pointer - builtin/enum
 // 9  pointer - pointer -> isize
-const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvSub = {
+const u8[TypeKind][TypeKind] BinOpConvSub = {
     //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin -
     {   4,      3,      0,      2,      5,      2,     2,     0,     0  },
@@ -490,7 +490,7 @@ fn QualType Analyser.checkBinopSubArgs(Analyser* ma, BinaryOperator* b, QualType
 // 10  invalid lhs
 // 11  invalid rhs
 // TODO: accept pointer/function : 0 and 0 : pointer/function
-const u8[elemsof(TypeKind)][elemsof(TypeKind)] BinOpConvComparison = {
+const u8[TypeKind][TypeKind] BinOpConvComparison = {
     //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin :
     {   2,      1,      0,     11,      3,      0,    11,     0,     0  },

--- a/analyser/module_analyser_expr.c2
+++ b/analyser/module_analyser_expr.c2
@@ -284,7 +284,7 @@ fn IdentifierKind Analyser.setExprFlags(Analyser* ma, Expr** e_ptr, Decl* d) {
 // 10  struct : struct
 // 11  void : void
 // TODO: accept pointer/function : 0 and 0 : pointer/function
-const u8[elemsof(TypeKind)][elemsof(TypeKind)] CondOpTable = {
+const u8[TypeKind][TypeKind] CondOpTable = {
     //  Builtin Pointer Array   Struct  Enum    Func   Void   Alias  Module
     //  Builtin :
     {   2,      1,      0,      1,      3,      0,     1,     0,     0  },

--- a/ast/statistics.c2
+++ b/ast/statistics.c2
@@ -28,10 +28,10 @@ type Stat struct {
 }
 
 type Stats struct {
-    Stat[elemsof(TypeKind)] types;
-    Stat[elemsof(ExprKind)] exprs;
-    Stat[elemsof(StmtKind)] stmts;
-    Stat[elemsof(DeclKind)] decls;
+    Stat[TypeKind] types;
+    Stat[ExprKind] exprs;
+    Stat[StmtKind] stmts;
+    Stat[DeclKind] decls;
     Stat[3] others; // 0=ArrayValue, 1=StaticAssert, 2=SwitchCase
 }
 

--- a/ast_utils/attr.c2
+++ b/ast_utils/attr.c2
@@ -77,13 +77,14 @@ public fn const char* Attr.kind2name(const Attr* a) {
 }
 
 public type AttrRegistry struct {
-    u32[elemsof(AttrKind)] name_indexes;
+    u32[AttrKind] name_indexes;
 }
 
 public fn void AttrRegistry.init(AttrRegistry* ar, string_pool.Pool* pool) {
     // skip unknown attribute
-    ar.name_indexes[0] = 0;
-    for (AttrKind kind = (AttrKind)1; kind <= AttrKind.max; kind++) {
+    AttrKind kind = (AttrKind)0;
+    ar.name_indexes[kind++] = 0;
+    for (; kind <= AttrKind.max; kind++) {
         ar.name_indexes[kind] = pool.addStr(kind.name, true);
     }
 }

--- a/ast_utils/color.c2
+++ b/ast_utils/color.c2
@@ -55,7 +55,7 @@ public const Color Bcyan    = Bcyan;
 public const Color White    = White;
 public const Color Normal   = Normal;
 
-const char*[elemsof(Color)] defaultColors = {
+const char*[Color] defaultColors = {
     [Color.None]     = "",
     [Color.Black]    = "\033[0;30m",
     [Color.Red]      = "\033[0;31m",

--- a/ir/context.c2
+++ b/ir/context.c2
@@ -434,7 +434,7 @@ public fn Ref Context.addLoadInstr(Context* c, Type t, Ref src) {
     return out;
 }
 
-const InstrKind[elemsof(Type)] Type2Store = {
+const InstrKind[Type] Type2Store = {
     [Type.I8]  = InstrKind.Store1,
     [Type.I16] = InstrKind.Store2,
     [Type.I32] = InstrKind.Store4,

--- a/test/c_generator/types/enum_assoc_depend.c2t
+++ b/test/c_generator/types/enum_assoc_depend.c2t
@@ -30,8 +30,8 @@ type StatKind enum u8 (const StatGroup group, const char* const name) {
 }
 
 type Stats struct {
-    u32[elemsof(StatKind)] count;
-    u32[elemsof(StatKind)] size;
+    u32[StatKind] count;
+    u32[StatKind] size;
 }
 
 fn void Stats.add(Stats* s, StatKind kind, u32 size) {


### PR DESCRIPTION
* use enum name instead of `elemsof(type)` for arrays that are indexed by enum values.