### PR TITLE
Language: accept untyped global constant definitions

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -713,8 +713,29 @@ fn void Analyser.analyseGlobalVarDecl(Analyser* ma, VarDecl* v) {
 
     QualType canon = res.getCanonicalType();
     if (canon.isVoid()) {
-        ma.error(ref.getLoc(), "%s has invalid type 'void'", res.isConst() ? "constant" : "variable");
-        return;
+        if (!ref.isUntyped()) {
+            ma.error(ref.getLoc(), "%s has invalid type 'void'", res.isConst() ? "constant" : "variable");
+            return;
+        }
+        if (!init_expr) {
+            ma.error(ref.getLoc(), "untyped global constant requires an initializer");
+            return;
+        }
+        if (init_expr.isInitList()) {
+            ma.error(ref.getLoc(), "untyped global constant initializer cannot be an init list");
+            return;
+        }
+        ma.global_initializer++;
+        QualType qt = ma.analyseExpr(v.getInit2(), false, RHS);
+        ma.global_initializer--;
+        if (qt.isInvalid() || qt.isVoid()) {
+            ma.error(v.getInit().getLoc(), "invalid constant value");
+            return;
+        }
+        qt.copyQuals(res);
+        res = qt;
+        canon = res.getCanonicalType();
+        v.setUntyped();
     }
 
     const Attr* embed = d.getAttr(Embed);

--- a/analyser/module_analyser_stmt.c2
+++ b/analyser/module_analyser_stmt.c2
@@ -448,14 +448,34 @@ fn QualType Analyser.analyseDecl(Analyser* ma, VarDecl* vd) {
         return QualType_Invalid;
     }
 
+    Expr* init_expr = vd.getInit();
+
     QualType res = ma.analyseTypeRef(ref, true);
     if (res.isInvalid()) return QualType_Invalid;
-    d.setType(res);
 
     if (res.isVoid()) {
-        ma.error(ref.getLoc(), "variable has invalid type 'void'");
-        return QualType_Invalid;
+        if (!ref.isUntyped()) {
+            ma.error(ref.getLoc(), "variable has invalid type 'void'");
+            return QualType_Invalid;
+        }
+        if (!init_expr) {
+            ma.error(ref.getLoc(), "untyped constant requires an initializer");
+            return QualType_Invalid;
+        }
+        if (init_expr.isInitList()) {
+            ma.error(ref.getLoc(), "untyped constant initializer cannot be an init list");
+            return QualType_Invalid;
+        }
+        QualType qt = ma.analyseExpr(vd.getInit2(), false, RHS);
+        if (qt.isInvalid() || qt.isVoid()) {
+            ma.error(vd.getInit().getLoc(), "invalid initializer");
+            return QualType_Invalid;
+        }
+        qt.copyQuals(res);
+        res = qt;
+        vd.setUntyped();
     }
+    d.setType(res);
 
     if (!d.getAST().isInterface())
         ma.checkName(d, false);

--- a/analyser/module_analyser_type.c2
+++ b/analyser/module_analyser_type.c2
@@ -199,6 +199,7 @@ fn QualType Analyser.analyseTypeRef(Analyser* ma, TypeRef* ref, bool full) {
         base = ma.builder.actOnBuiltinType(kind);
         assert(base.isValid());
         break;
+    case Untyped:
     case Void:
         base = ma.builder.actOnVoidType();
         assert(base.isValid());

--- a/analyser/module_analyser_unaryop.c2
+++ b/analyser/module_analyser_unaryop.c2
@@ -92,6 +92,10 @@ fn QualType Analyser.analyseUnaryOperator(Analyser* ma, Expr** e_ptr, u32 side) 
         if (!ma.getIdentifierKind(inner)) return QualType_Invalid;
         if (canon.isConst() && (inner.isIdentifier() || inner.isMember())) {
             VarDecl* vd = getVarDecl(inner);
+            if (vd.isUntypedGlobal()) {
+                ma.errorRange(e.getLoc(), e.getRange(), "cannot take the address of an untyped global constant");
+                return QualType_Invalid;
+            }
             if (vd) vd.setAddrUsed();
         }
         t = ma.builder.actOnPointerType(canon);

--- a/ast/static_assert.c2
+++ b/ast/static_assert.c2
@@ -60,6 +60,6 @@ fn void StaticAssert.print(const StaticAssert* d, string_buffer.Buf* out, u32 in
     out.color(col_Decl);
     out.add("StaticAssert\n");
     d.lhs.print(out, indent + 1);
-    d.rhs.print(out, indent + 1);
+    if (d.rhs) d.rhs.print(out, indent + 1);
 }
 

--- a/ast/type_ref.c2
+++ b/ast/type_ref.c2
@@ -23,6 +23,7 @@ import string;
 public type TypeRefKind enum u8 (const char* const name) {
     Builtin   : { "builtin" },
     Void      : { "void" },
+    Untyped   : { "untyped" },
     User      : { "user" },
     Function  : { "function" },
 }
@@ -33,7 +34,7 @@ type TypeRefBits struct {
     u32 num_arrays : 2; // limit to 3-dimensional arrays
     u32 incr_array : 1;
     u32 has_prefix : 1;
-    TypeRefKind kind : 2;
+    TypeRefKind kind : 3;
     BuiltinKind builtin_kind : 4;   // only if builtin (!is_user)
 }
 
@@ -162,6 +163,12 @@ public fn void TypeRefHolder.rotateArrays(TypeRefHolder* h, u32 r) {
     }
 }
 
+public fn void TypeRefHolder.setUntyped(TypeRefHolder* h, SrcLoc loc) {
+    TypeRef* r = (TypeRef*)&h.ref;
+    r.flags.kind = Untyped;
+    r.loc = loc;
+}
+
 public fn void TypeRefHolder.setBuiltin(TypeRefHolder* h, BuiltinKind kind, SrcLoc loc) {
     TypeRef* r = (TypeRef*)&h.ref;
     r.flags.builtin_kind = kind;
@@ -221,6 +228,7 @@ fn void TypeRef.init(TypeRef* dest, const TypeRefHolder* h) {
 
     // copy for tail-allocated info
     switch (r.getKind()) {
+    case Untyped:
     case Builtin:
     case Void:
         break;
@@ -288,7 +296,7 @@ public fn void TypeRef.setDest(TypeRef* r, u32 dest) {
 
 fn u32 TypeRef.getExtraSize(const TypeRef* r) {
     // User, StructMemberType use Ref
-    u32 numrefs = (r.flags.kind != Builtin) + r.flags.has_prefix;
+    u32 numrefs = (r.flags.kind >= User) + r.flags.has_prefix;
     u32 extra = numrefs * sizeof(Ref);
     extra += r.flags.num_arrays * sizeof(Expr*);
     return extra;
@@ -318,6 +326,10 @@ public fn u32 TypeRef.getQuals(const TypeRef* r, u32 level) {
 
 public fn bool TypeRef.isUser(const TypeRef* r) {
     return r.flags.kind == User;
+}
+
+public fn bool TypeRef.isUntyped(const TypeRef* r) {
+    return r.flags.kind == Untyped;
 }
 
 fn bool TypeRef.isBuiltin(const TypeRef* r) {
@@ -364,6 +376,7 @@ public fn TypeRefKind TypeRef.getKind(const TypeRef* r) {
 
 public fn SrcLoc TypeRef.getLoc(const TypeRef* r) {
     switch (r.getKind()) {
+    case Untyped:
     case Builtin:
     case Void:
         break;
@@ -450,6 +463,8 @@ fn void TypeRef.printLiteral(const TypeRef* r, string_buffer.Buf* out, bool prin
     if (r.isVolatile(num_ptrs)) out.add("volatile ");
 
     switch (r.flags.kind) {
+    case Untyped:
+        break;
     case Builtin:
         out.add(r.getBuiltinKind().name);
         break;
@@ -497,6 +512,8 @@ fn void TypeRef.print(const TypeRef* r, string_buffer.Buf* out, bool filled) {
     if (r.isVolatile(num_ptrs)) out.add("volatile ");
 
     switch (r.flags.kind) {
+    case Untyped:
+        break;
     case Builtin:
         out.add(r.getBuiltinKind().name);
         break;

--- a/ast/var_decl.c2
+++ b/ast/var_decl.c2
@@ -52,6 +52,7 @@ type VarDeclBits struct {
     AutoAttr auto_attr : 2;  // for parameters only
     FormatAttr format_attr : 2; // for parameters only
     u32 is_tlocal : 1;  // local or global variables with thread local storage
+    u32 is_untyped : 1;  // variable was defined without a type
 }
 
 public type BitFieldLayout struct {
@@ -182,7 +183,7 @@ public fn Decl* VarDecl.asDecl(VarDecl* d) {
     return &d.base;
 }
 
-fn QualType VarDecl.getType(const VarDecl* d) {
+public fn QualType VarDecl.getType(const VarDecl* d) {
     return d.base.qt;
 }
 
@@ -309,6 +310,15 @@ public fn void VarDecl.setTLocal(VarDecl* d) {
     d.base.varDeclBits.is_tlocal = true;
 }
 
+public fn bool VarDecl.isUntypedGlobal(const VarDecl* d) {
+    return (d.base.varDeclBits.kind == GlobalVar &&
+            d.base.varDeclBits.is_untyped);
+}
+
+public fn void VarDecl.setUntyped(VarDecl* d) {
+    d.base.varDeclBits.is_untyped = true;
+}
+
 public fn void VarDecl.setInitCall(VarDecl* d, bool has_init_call) {
     d.base.varDeclBits.has_init_call = has_init_call;
 }
@@ -388,6 +398,7 @@ fn void VarDecl.print(const VarDecl* d, string_buffer.Buf* out, u32 indent) {
     if (d.isStatic()) out.add(" (static)");
     if (d.base.varDeclBits.attr_weak) out.add(" weak");
     if (d.base.varDeclBits.addr_used) out.add(" addr_used");
+    if (d.base.varDeclBits.is_untyped) out.add(" untyped");
     switch (d.base.varDeclBits.auto_attr) {
     case None: break;
     case File: out.add(" auto_file"); break;

--- a/generator/c/c_generator_stmt.c2
+++ b/generator/c/c_generator_stmt.c2
@@ -175,8 +175,15 @@ fn void Generator.emitStmt(Generator* gen, string_buffer.Buf* out, Stmt* s, u32 
         DeclStmt* ds = (DeclStmt*)s;
         u32 count = ds.getDeclCount();
         bool first = true;
+        QualType qt = QualType_Invalid;
         for (u32 i = 0; i < count; i++) {
             VarDecl* vd = ds.getDecl(i);
+            QualType qt1 = vd.getType();
+            if (!first && qt1.ptr != qt.ptr) {
+                out.add(";\n");
+                first = true;
+            }
+            qt = qt1;
             gen.emitVarDecl(vd, out, true, first);
             first = false;
         }

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -793,6 +793,12 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
     TypeRefHolder ref.init();
     p.parseTypeSpecifier(&ref);
 
+    bool has_block = false;
+    if (p.tok.kind == LBrace) {
+        has_block = true;
+        p.consumeToken();
+    }
+
     for (;;) {
         p.expectIdentifier();
 
@@ -854,10 +860,13 @@ fn void Parser.parseVarDecl(Parser* p, bool is_public) {
         if (p.tok.kind != Comma)
             break;
         p.consumeToken();
+        if (has_block && p.tok.kind == RBrace)
+            break;
         if (ref.isPointer() || ref.isArray())
             p.error("pointer and array variables must be defined separately");
     }
-    p.consumeSemicolon(need_semi);
+    if (has_block) p.expectAndConsume(RBrace);
+    else p.consumeSemicolon(need_semi);
 }
 
 fn void Parser.parseStaticAssert(Parser* p) {
@@ -928,6 +937,7 @@ fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref) {
     u32 type_qualifiers = p.parseOptionalTypeQualifier();
     ref.setQuals(type_qualifiers);
 
+    bool has_block = false;
     Kind kind = p.tok.kind;
     SrcLoc loc = p.tok.loc;
     if (kind.isBuiltinType()) {
@@ -938,6 +948,10 @@ fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref) {
         ref.setVoid(loc);
         p.consumeToken();
     } else if (kind == Identifier) {
+        if (p.peekToken(1) == Equal) {
+            ref.setUntyped(loc);
+            return;
+        }
         p.parseFullTypeIdentifier(ref);
         if (ref.user.name_idx == p.va_list_idx)
             p.addImplicitImport(p.varargs_idx, true);
@@ -945,6 +959,9 @@ fn void Parser.parseSingleTypeSpecifier(Parser* p, TypeRefHolder* ref) {
         if (!p.tokenizer.c_mode) p.error("invalid keyword");
         CTypeKind c_kind = p.convertCType();
         ref.setBuiltin(cTypeToBuiltinKind(c_kind), loc);
+    } else if (kind == LBrace) {
+        ref.setUntyped(loc);
+        return;
     } else {
         p.error("expected type specifier");
     }

--- a/parser/c2_parser_stmt.c2
+++ b/parser/c2_parser_stmt.c2
@@ -544,6 +544,12 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
     TypeRefHolder ref.init();
     p.parseTypeSpecifier(&ref);
 
+    bool has_block = false;
+    if (p.tok.kind == LBrace) {
+        has_block = true;
+        p.consumeToken();
+    }
+
     for (;;) {
         p.expectIdentifier();
 
@@ -602,6 +608,8 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
         if (p.tok.kind != Comma)
             break;
         p.consumeToken();
+        if (has_block && p.tok.kind == RBrace)
+            break;
         if (isCondition)
             p.error("cannot define multiple variables in a condition");
         if (ref.isPointer() || ref.isArray())
@@ -609,6 +617,9 @@ fn Stmt* Parser.parseDeclStmt(Parser* p, bool checkSemi, bool allowLocal, bool i
         if (num_decls >= elemsof(decls))
             p.error("too many variables defined in a single statement");
     }
+    if (has_block) {
+        p.expectAndConsume(RBrace);
+    } else
     if (checkSemi) {
         p.consumeSemicolon(need_semi);
     }

--- a/test/functions/untyped_const_error.c2
+++ b/test/functions/untyped_const_error.c2
@@ -1,0 +1,26 @@
+// @warnings{no-unused}
+module test;
+
+import string local;
+
+fn void foo1() {
+    const invalid = (     // @error{invalid initializer}
+        1 / 0             // @error{division by zero is undefined}
+    );
+}
+
+fn void foo2() {
+    const inv2 = {}       // @error{untyped constant initializer cannot be an init list}
+}
+
+fn void foo3() {
+    const inv3 = { 1 }    // @error{untyped constant initializer cannot be an init list}
+}
+
+fn void foo4() {
+    const inv4 = { test } // @error{untyped constant initializer cannot be an init list}
+}
+
+fn void foo5() {
+    const { inv5 }        // @error{untyped constant requires an initializer}
+}

--- a/test/globals/vars/untyped_const.c2
+++ b/test/globals/vars/untyped_const.c2
@@ -1,0 +1,68 @@
+// @warnings{no-unused}
+module test;
+
+import string local;
+
+const TRUE = true;
+const ZERO = 0;
+const ONE = ZERO + 1;
+const MAX = u64.max;
+const {
+    F1 = 1.0F,
+    D1 = 1.0,
+    NULL = nil,
+}
+const { HELLO = "Hello" }
+
+const STRCPY = strcpy;
+
+const char* p1 = HELLO;
+
+static_assert(sizeof(TRUE) == 1);
+static_assert(sizeof(ZERO) == 4);
+static_assert(sizeof(ONE) == 4);
+static_assert(sizeof(MAX) == 8);
+static_assert(sizeof(F1) == 4);
+static_assert(sizeof(D1) == 8);
+static_assert(sizeof(NULL) == sizeof(void*));
+static_assert(sizeof(HELLO) == 6);
+static_assert(sizeof(STRCPY) == sizeof(void*));
+
+public fn i32 main() {
+    const true_ = true;
+    const zero = 0;
+    const one = zero + 1;
+    const max = u64.max;
+    const {
+        f1 = 1.0F,
+        d1 = 1.0,
+        null = nil,
+    }
+    const { hello = "Hello" }
+    const mystrcpy = strcpy;
+
+    const char* p2 = hello;
+
+    assert(sizeof(true_) == 1);
+    assert(sizeof(zero) == 4);
+    assert(sizeof(one) == 4);
+    assert(sizeof(max) == 8);
+    assert(sizeof(f1) == 4);
+    assert(sizeof(d1) == 8);
+    assert(sizeof(null) == sizeof(void*));
+    assert(sizeof(hello) == 6);
+    assert(sizeof(mystrcpy) == sizeof(void*));
+
+    assert(true_ == TRUE);
+    assert(zero == ZERO);
+    assert(one == ONE);
+    assert(max == MAX);
+    assert(f1 == F1);
+    assert(d1 == D1);
+    assert(null == NULL);
+    assert(!strcmp(hello, HELLO));
+    assert(!strcmp(p1, p2));
+    assert(mystrcpy == STRCPY);
+
+    return 0;
+}

--- a/test/globals/vars/untyped_const_errors.c2
+++ b/test/globals/vars/untyped_const_errors.c2
@@ -1,0 +1,24 @@
+// @warnings{no-unused}
+module test;
+
+import string local;
+
+const TRUE = true;
+const ZERO = 0;
+const ONE = ZERO + 1;
+const MAX = u64.max;
+const F1 = 1.0F;
+const D1 = 1.0;
+const NULL = nil;
+const HELLO = "Hello";
+const INVALID = (     // @error{invalid constant value}
+    1 / 0             // @error{division by zero is undefined}
+);
+const INV2 = {}       // @error{untyped global constant initializer cannot be an init list}
+const INV3 = { 1 }    // @error{untyped global constant initializer cannot be an init list}
+const INV4 = { test } // @error{untyped global constant initializer cannot be an init list}
+const { INV6 }        // @error{untyped global constant requires an initializer}
+
+const char* p1 = HELLO;  // this one is OK
+
+const i32* p2 = &ONE;   // @error{cannot take the address of an untyped global constant}


### PR DESCRIPTION
* type is inferred from init value
* cannot take the address of an untyped global constant
* add tests
* need bootstrap to use in the compiler or libraries