### PR TITLE
Language: `import` accepts optional list of imported symbols

### DIFF
--- a/analyser/module_analyser.c2
+++ b/analyser/module_analyser.c2
@@ -172,6 +172,9 @@ public fn void Analyser.checkModule(Analyser* ma, Module* mod) {
 
     if (ma.diags.hasErrors()) return;
 
+    mod.visitImports(Analyser.handleImportList, ma);
+    //if (ma.has_error) return;
+
     ma.collectTypeFunctions();
     if (ma.has_error) return;
 
@@ -322,6 +325,27 @@ fn void Analyser.handleImport(void* arg, ast.ImportDecl* id) {
     if (dest.isExternal()) return;
     if (!dest.isExported()) {
         ma.error(d.getLoc(), "exported module '%s' publicly uses non-exported module '%s'", ma.mod.getName(), dest.getName());
+    }
+}
+
+fn void Analyser.handleImportList(void* arg, ast.ImportDecl* id) {
+    Analyser* ma = arg;
+    Module* dest = id.getDest();
+    u32 symlist_count = id.getSymlistSize();
+    ast.Symbol* symlist = id.getSymlistData();
+    for (u32 i = 0; i < symlist_count; i++) {
+        u32 name_idx = symlist[i].name_idx;
+        symlist[i].decl = dest.findPublicSymbol(name_idx);
+        if (!symlist[i].decl) {
+            u32 loc = symlist[i].loc;
+            if (Decl* d = dest.findSymbol(name_idx)) {
+                ma.error(loc, "symbol '%s' is not public", ma.getFullName(d));
+                ma.note(d.getLoc(), "symbol definition is here");
+            } else {
+                ma.error(loc, "module '%s' has no symbol '%s'",
+                         ma.idx2name(((Decl*)id).getNameIdx()), ma.idx2name(name_idx));
+            }
+        }
     }
 }
 

--- a/analyser/scope.c2
+++ b/analyser/scope.c2
@@ -402,7 +402,8 @@ public fn bool Scope.checkGlobalSymbol(Scope* s, u32 name_idx, SrcLoc loc) {
             decl = (ast.Decl*)id;
             break;
         }
-
+        decl = id.findSymbol(name_idx);
+        if (decl) break;
         if (id.isLocal()) {
             ast.Module* dest = id.getDest();
             decl = dest.findSymbol(name_idx);
@@ -505,17 +506,20 @@ fn ast.Decl* Scope.findGlobalSymbol(Scope* s, u32 name_idx, SrcLoc loc, bool* ot
 
     for (u32 i = 0; i < s.imports.size(); i++) {
         ast.ImportDecl* id = s.imports.get(i);
-        if (!id.isLocal()) continue;    // this includes implicit self-import
 
-        ast.Module* dest = id.getDest();
-        // first search visible symbols only
-        ast.Decl* d;
-        if (s.mod == dest) {
-            d = dest.findSymbol(name_idx);
-        } else {
-            d = dest.findPublicSymbol(name_idx);
+        ast.Decl* d = id.findSymbol(name_idx);
+        if (!d) {
+            if (!id.isLocal()) continue;    // this includes implicit self-import
+
+            ast.Module* dest = id.getDest();
+            // first search visible symbols only
+            if (s.mod == dest) {
+                d = dest.findSymbol(name_idx);
+            } else {
+                d = dest.findPublicSymbol(name_idx);
+            }
+            if (!d) continue;
         }
-        if (!d) continue;
 
         if (decl) { // already have result
             const char* name = s.idx2name(name_idx);

--- a/analyser/unused_checker.c2
+++ b/analyser/unused_checker.c2
@@ -39,6 +39,7 @@ public fn void check(diagnostics.Diags* diags,
 
     if (mod.isUsed()) {
         mod.visitDecls(Checker.check, &c);
+        mod.visitImports(Checker.checkImportList, &c);
     } else {
         mod.visitASTs(Checker.unused_module, &c);
     }
@@ -112,6 +113,20 @@ fn void Checker.check(void* arg, Decl* d) {
     if (!used && !d.hasAttrUnused() && !d.isExported()) {
         c.diags.warn(d.getLoc(), "unused %s '%s'", d.getKindName(), c.getFullName(d));
         return;
+    }
+}
+
+fn void Checker.checkImportList(void* arg, ImportDecl* id) {
+    Checker* c = arg;
+    u32 symlist_count = id.getSymlistSize();
+    ast.Symbol* symlist = id.getSymlistData();
+    for (u32 i = 0; i < symlist_count; i++) {
+        Decl* d = symlist[i].decl;
+        if (!symlist[i].used) {
+            if (!c.warnings.no_unused_import) {
+                c.diags.warn(symlist[i].loc, "unused import '%s'", c.getFullName(d));
+            }
+        }
     }
 }
 

--- a/ast/import_decl.c2
+++ b/ast/import_decl.c2
@@ -18,11 +18,13 @@ module ast;
 import ast_context;
 import string_buffer;
 import src_loc local;
+import string local;
 
 type ImportDeclBits struct {
     u32 : NumDeclBits;
     u32 is_local : 1;
 //    u32 own_component : 1;
+    u32 symlist_count : 16;
 }
 
 public type ImportDecl struct @(opaque) {
@@ -30,6 +32,7 @@ public type ImportDecl struct @(opaque) {
     u32 alias_idx;
     SrcLoc alias_loc;
     Module* dest;
+    Symbol[0] symlist;
 }
 
 public fn ImportDecl* ImportDecl.create(ast_context.Context* c,
@@ -38,16 +41,21 @@ public fn ImportDecl* ImportDecl.create(ast_context.Context* c,
                                           u32 alias_name,
                                           SrcLoc alias_loc,
                                           u32 ast_idx,
-                                          bool is_local)
+                                          bool is_local,
+                                          Symbol* symlist,
+                                          u32 symlist_count)
 {
-    ImportDecl* d = c.alloc(sizeof(ImportDecl));
+    u32 size = sizeof(ImportDecl) + symlist_count * sizeof(*symlist);
+    ImportDecl* d = c.alloc(size);
     d.base.init(Import, name, loc, false, QualType_Invalid, ast_idx);
     d.base.importDeclBits.is_local = is_local;
+    d.base.importDeclBits.symlist_count = symlist_count;
     d.alias_idx = alias_name;
     d.alias_loc = alias_loc;
     d.dest = nil;
+    memcpy(d.symlist, symlist, symlist_count * sizeof(*symlist));
 #if AstStatistics
-    Stats.addDecl(Import, sizeof(ImportDecl));
+    Stats.addDecl(Import, size);
 #endif
     return d;
 }
@@ -66,11 +74,24 @@ public fn SrcLoc ImportDecl.getLoc(const ImportDecl* d) {
     return d.base.getLoc();
 }
 
+public fn Symbol* ImportDecl.getSymlistData(ImportDecl* d) { return d.symlist; }
+public fn u32 ImportDecl.getSymlistSize(const ImportDecl* d) { return d.base.importDeclBits.symlist_count; }
+
 public fn void ImportDecl.setDest(ImportDecl* d, Module* mod) { d.dest = mod; }
 
 public fn Module* ImportDecl.getDest(const ImportDecl* d) { return d.dest; }
 
 public fn bool ImportDecl.isLocal(const ImportDecl* d) { return d.base.importDeclBits.is_local; }
+
+public fn Decl* ImportDecl.findSymbol(ImportDecl* d, u32 name_idx) {
+    for (u32 i = 0; i < d.base.importDeclBits.symlist_count; i++) {
+        if (d.symlist[i].as_name_idx == name_idx) {
+            d.symlist[i].used = true;
+            return d.symlist[i].decl;
+        }
+    }
+    return nil;
+}
 
 fn void ImportDecl.print(const ImportDecl* d, string_buffer.Buf* out, u32 indent) {
     out.indent(indent);
@@ -94,6 +115,18 @@ fn void ImportDecl.print(const ImportDecl* d, string_buffer.Buf* out, u32 indent
         out.add(" as ");
         out.color(col_Value);
         out.add(idx2name(d.alias_idx));
+    }
+    if (d.base.importDeclBits.symlist_count) {
+        out.color(col_Normal);
+        out.add(" {");
+        for (u32 i = 0; i < d.base.importDeclBits.symlist_count; i++) {
+            const Symbol* sp = &d.symlist[i];
+            out.print(" %s", idx2name(sp.name_idx));
+            if (sp.name_idx != sp.as_name_idx) {
+                out.print(" as %s", idx2name(sp.as_name_idx));
+            }
+        }
+        out.add(" }");
     }
     out.newline();
 }

--- a/ast/symbol_list.c2
+++ b/ast/symbol_list.c2
@@ -1,0 +1,72 @@
+/* Copyright 2022-2026 Bas van den Berg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ast;
+
+import string local;
+import stdlib local;
+import src_loc local;
+
+// Use stack for small lists, heap for larger ones
+
+public type Symbol struct {
+    u32 name_idx;
+    SrcLoc loc;
+    u32 as_name_idx;
+    bool used;
+    Decl* decl;
+}
+
+public type SymbolList struct {
+    u32 count;
+    u32 capacity;
+    Symbol* data;
+    Symbol[16] stash;
+}
+
+public fn void SymbolList.init(SymbolList* l) {
+    memset(l, 0, sizeof(SymbolList));
+    l.data = l.stash;
+    l.capacity = elemsof(l.stash);
+}
+
+public fn void SymbolList.clear(SymbolList* l) @(unused) {
+    l.count = 0;
+}
+
+public fn void SymbolList.add(SymbolList* l, Symbol sym) {
+    if (l.count == l.capacity) {
+        l.capacity *= 2;
+        Symbol* data2 = malloc(l.capacity * sizeof(*l.data));
+        memcpy(data2, l.data, l.count * sizeof(*l.data));
+        if (l.data != l.stash) free(l.data);
+        l.data = data2;
+    }
+    l.data[l.count] = sym;
+    l.count++;
+}
+
+public fn void SymbolList.free(SymbolList* l) {
+    if (l.data != l.stash) free(l.data);
+}
+
+public fn u32 SymbolList.size(const SymbolList* l) {
+    return l.count;
+}
+
+public fn Symbol* SymbolList.getData(SymbolList* l) {
+    return l.data;
+}
+

--- a/ast/utils.c2
+++ b/ast/utils.c2
@@ -35,6 +35,7 @@ static_assert(32, sizeof(FunctionTypeDecl));
 static_assert(32, sizeof(VarDecl));
 static_assert(40, sizeof(EnumConstantDecl));
 static_assert(40, sizeof(ImportDecl));
+static_assert(24, sizeof(Symbol));
 static_assert(48, sizeof(StructTypeDecl));
 static_assert(80, sizeof(FunctionDecl));
 

--- a/common/ast_builder.c2
+++ b/common/ast_builder.c2
@@ -122,7 +122,7 @@ public fn void Builder.actOnModule(Builder* b,
     b.ast_idx = b.ast.getIdx();
 
     // NOTE: make special ImportDecl to add own symbols
-    ImportDecl* i = ImportDecl.create(b.context, mod_name, mod_loc, 0, 0, b.ast_idx, true);
+    ImportDecl* i = ImportDecl.create(b.context, mod_name, mod_loc, 0, 0, b.ast_idx, true, nil, 0);
     Decl* d = (Decl*)i;
     d.setUsed();
     d.setChecked();
@@ -136,7 +136,9 @@ public fn Decl* Builder.actOnImport(Builder* b,
                                    SrcLoc mod_loc,
                                    u32 alias_name,
                                    SrcLoc alias_loc,
-                                   bool islocal) {
+                                   bool islocal,
+                                   Symbol* symlist,
+                                   u32 symlist_count) {
     if (b.ast.getNameIdx() == mod_name) {
         if (mod_loc) {
             // reject self imports, no error for implicit imports (eg: varargs)
@@ -169,7 +171,9 @@ public fn Decl* Builder.actOnImport(Builder* b,
                                       alias_name,
                                       alias_loc,
                                       b.ast_idx,
-                                      islocal);
+                                      islocal,
+                                      symlist,
+                                      symlist_count);
     b.ast.addImport(d);
     return (Decl*)d;
 }

--- a/parser/c2_parser.c2
+++ b/parser/c2_parser.c2
@@ -322,7 +322,7 @@ fn void Parser.parseModule(Parser* p) {
 }
 
 fn void Parser.addImplicitImport(Parser* p, u32 mod_name, bool islocal) {
-    Decl* d = p.builder.actOnImport(mod_name, 0, 0, 0, islocal);
+    Decl* d = p.builder.actOnImport(mod_name, 0, 0, 0, islocal, nil, 0);
     if (d) d.setAttrUnused();
 }
 
@@ -354,13 +354,41 @@ fn void Parser.parseImports(Parser* p) {
         }
         // TODO: accept @(unused) attribute on imports
         //u32 num_attr = p.parseOptionalAttributes();
-        p.expectAndConsume(Semicolon);
+        SymbolList symlist.init();
+        if (p.tok.kind == LBrace) {
+            p.consumeToken();
+            if (p.tok.kind == Star) {
+                islocal = true;
+                p.consumeToken();
+            } else {
+                while (p.tok.kind == Identifier) {
+                    u32 name_idx = p.tok.name_idx;
+                    u32 as_name_idx = name_idx;
+                    SrcLoc loc = p.tok.loc;
+                    p.consumeToken();
+                    if (p.tok.kind == KW_as) {
+                        p.consumeToken();
+                        p.expectIdentifier();
+                        as_name_idx = p.tok.name_idx;
+                        p.consumeToken();
+                    }
+                    symlist.add({ name_idx, loc, as_name_idx });
+                    if (p.tok.kind != Comma) break;
+                    p.consumeToken();
+                }
+            }
+            p.expectAndConsume(RBrace);
+        } else {
+            p.expectAndConsume(Semicolon);
+        }
 
         if (mod_name != p.stdarg_idx) {
             // ignore import stdarg: vararg is imported implicitly from c2 library
-            p.builder.actOnImport(mod_name, mod_loc, alias_name, alias_loc, islocal);
+            p.builder.actOnImport(mod_name, mod_loc, alias_name, alias_loc,
+                                  islocal, symlist.getData(), symlist.size());
             //if (d) p.applyAttributes(d, num_attr);
         }
+        symlist.free();
     }
 }
 

--- a/recipe.txt
+++ b/recipe.txt
@@ -55,6 +55,7 @@ set ast
     ast/struct_type_decl.c2
     ast/var_decl.c2
     ast/var_decl_list.c2
+    ast/symbol_list.c2
 
     # ast statements
     ast/stmt.c2

--- a/test/import/import_non_public_symbol.c2t
+++ b/test/import/import_non_public_symbol.c2t
@@ -8,7 +8,4 @@ const i32 Priv = 0;  // @note{symbol definition is here}
 
 // @file{file2}
 module bar;
-import foo local;
-
-i32 c = Priv;         // @error{symbol 'foo.Priv' is not public}
-
+import foo { Priv }   // @error{symbol 'foo.Priv' is not public}

--- a/test/import/import_symbols.c2
+++ b/test/import/import_symbols.c2
@@ -1,0 +1,8 @@
+module test;
+
+import stdio { printf }
+
+public fn i32 main() {
+    printf("Hello world!\n");
+    return 0;
+}

--- a/test/import/import_symbols_as.c2t
+++ b/test/import/import_symbols_as.c2t
@@ -1,0 +1,19 @@
+// @recipe bin
+    $backend c
+
+// @file{file1}
+module test;
+
+import stdio { printf as my_printf }
+
+public fn i32 main() {
+    my_printf("Hello world!\n");
+    return 0;
+}
+
+// @expect{atleast, cgen/build.c}
+int main(void)
+{
+    printf("Hello world!\n");
+    return 0;
+}

--- a/test/import/import_symbols_bad.c2
+++ b/test/import/import_symbols_bad.c2
@@ -1,0 +1,11 @@
+module test;
+
+import stdio {
+    printf,
+    xxx,    // @error{module 'stdio' has no symbol 'xxx'}
+}
+
+public fn i32 main() {
+    printf("Hello world!\n");
+    return 0;
+}

--- a/test/import/import_symbols_unused.c2
+++ b/test/import/import_symbols_unused.c2
@@ -1,0 +1,13 @@
+module test;
+
+import stdlib { * }  // @warning{unused import 'stdlib'}
+
+import stdio {
+    printf,
+    scanf,  // @warning{unused import 'stdio.scanf'}
+}
+
+public fn i32 main() {
+    printf("Hello world!\n");
+    return 0;
+}

--- a/test/vars/use_non_public_symbol3.c2t
+++ b/test/vars/use_non_public_symbol3.c2t
@@ -8,7 +8,6 @@ const i32 Priv = 0;  // @note{symbol definition is here}
 
 // @file{file2}
 module bar;
-import foo local;
+import foo { * }
 
-i32 c = Priv;         // @error{symbol 'foo.Priv' is not public}
-
+i32 a = foo.Priv;     // @error{symbol 'foo.Priv' is not public}


### PR DESCRIPTION
* syntax is `import stdio { fopen, fclose, printf }`
* this helps readability and reduces symbol table lookups