### PR TITLE
Misc: fix multiple bugs for formatting corner cases

### DIFF
--- a/ast_utils/string_buffer.c2
+++ b/ast_utils/string_buffer.c2
@@ -168,23 +168,47 @@ public fn void Buf.stripTrailingSpaces(Buf* buf) {
     while (buf.size_ && buf.data_[buf.size_-1] == ' ') buf.size_--;
 }
 
-public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) {
-    char[4096] tmp;
-    // NOTE: no growing
+public fn void Buf.print(Buf* buf, const char* format @(printf_format), ...) @(unused) {
     va_list args;
     va_start(args, format);
-    i32 len = vsnprintf(tmp, elemsof(tmp), format, args);
+    buf.vprintf(format, args);
     va_end(args);
-    assert(len < elemsof(tmp));
-    buf.add2(tmp, (u32)len);
 }
 
-public fn void Buf.vprintf(Buf* buf, const char* format, va_list args) {
+public fn void Buf.vprintf(Buf* buf, const char* format, va_list args) @(unused) {
+    // formatted output is limited to 4095 bytes
     char[4096] tmp;
-    // NOTE: no growing
-    i32 len = vsnprintf(tmp, elemsof(tmp), format, args);
-    assert(len < elemsof(tmp));
-    buf.add2(tmp, (u32)len);
+    char* dest = tmp;
+    u32 dest_size = elemsof(tmp);
+    u32 avail = buf.capacity - buf.size_;
+    if (!buf.grow || avail >= 4096) {
+        if (!avail) {
+            buf.truncated = true;
+            return;
+        }
+        dest = &buf.data_[buf.size_];
+        dest_size = avail;
+    }
+    i32 ret = vsnprintf(dest, dest_size, format, args);
+    if (ret < 0) {
+        return;
+    }
+    u32 len = (u32)ret;
+    if (len >= dest_size) {
+        buf.truncated = true;
+        len = dest_size - 1;    // we know that dest_size > 0
+    }
+    if (dest == tmp) {
+        if (len >= avail) {
+            buf.add2(tmp, len);
+        } else {
+            memcpy(&buf.data_[buf.size_], tmp, len);
+            buf.size_ += len;
+        }
+    } else {
+        // output is already in buffer
+        buf.size_ += len;
+    }
 }
 
 public fn void Buf.unindent(Buf* buf) {

--- a/common/process_utils.c2
+++ b/common/process_utils.c2
@@ -47,17 +47,15 @@ fn void child_error(i32 fd, const char* format @(printf_format), ...) @(noreturn
     char[256] msg;
     va_list args;
     va_start(args, format);
-    i32 res = vsnprintf(msg, elemsof(msg), format, args);
+    i32 res = vsnprintf(msg, elemsof(msg) - 1, format, args);
     va_end(args);
-    if (res >= 0) {
-        usize len = (usize)res;
-        msg[len++] = '\n';
-        msg[len] = '\0';
-        write(fd, msg, len);
-        fsync(fd);
-        fprintf(stderr, "[exec] %s\n", msg);
-        fflush(stderr);
-    }
+    if (res < 0) pstrcpy(msg, elemsof(msg), "formatting error");
+    pstrcat(msg, elemsof(msg), "\n");
+    write(fd, msg, strlen(msg));
+    fsync(fd);
+    fputs("[exec] ", stderr);
+    fputs(msg, stderr);
+    fflush(stderr);
     _exit(EXIT_FAILURE);      // don't call atexit functions
 }
 

--- a/common/yaml/yaml_parser.c2
+++ b/common/yaml/yaml_parser.c2
@@ -50,7 +50,7 @@ public fn void Parser.destroy(Parser* p) {
 }
 
 public fn bool Parser.parse(Parser* p, const char* input) {
-    p.tokenizer.init(input, &p.data, p.message);
+    p.tokenizer.init(input, &p.data, p.message, elemsof(p.message));
 
     p.token.kind = None;
 
@@ -75,10 +75,12 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) {
     va_list args;
     va_start(args, format);
     char* cp = p.message;
-    i32 len = vsnprintf(cp, MaxDiag, format, args);
+    usize size = elemsof(p.message);
+    i32 len = vsnprintf(cp, size, format, args);
     va_end(args);
-    if ((u32)len < MaxDiag) {
-        snprintf(cp + len, MaxDiag - len, "at line %d:%d", p.token.loc.line, p.token.loc.column);
+    if ((u32)len < size) {
+        // TODO output standard error message <filename:line:col: msg>
+        snprintf(cp + len, size - len, " at line %d:%d", p.token.loc.line, p.token.loc.column);
     }
     longjmp(&p.jmp_err, 1);
 }

--- a/common/yaml/yaml_tokenizer.c2
+++ b/common/yaml/yaml_tokenizer.c2
@@ -60,6 +60,7 @@ type Tokenizer struct {
     const char* input_start;
     const char* line_start;
     char* error_msg;
+    usize error_msg_size;
     u32 line_number;
     i32 cur_indent;
     bool same_line;
@@ -68,12 +69,13 @@ type Tokenizer struct {
     Token next;
 }
 
-fn void Tokenizer.init(Tokenizer* t, const char* input, Data* d, char* error_msg) {
+fn void Tokenizer.init(Tokenizer* t, const char* input, Data* d, char* error_msg, usize error_msg_size) {
     memset(t, 0, sizeof(Tokenizer));
     t.cur = input;
     t.input_start = input;
     t.line_start = input;
     t.error_msg = error_msg;
+    t.error_msg_size = error_msg_size;
     t.line_number = 1;
     t.data = d;
     t.next.kind = None;
@@ -275,10 +277,10 @@ fn void Tokenizer.lex_string(Tokenizer* t, Token* result) {
 fn void Tokenizer.error(Tokenizer* t, Token* result, const char* format @(printf_format), ...) {
     va_list args;
     va_start(args, format);
-    i32 len = vsnprintf(t.error_msg, MaxDiag, format, args);
-    if ((u32)len < MaxDiag) {
+    i32 len = vsnprintf(t.error_msg, t.error_msg_size, format, args);
+    if ((u32)len < t.error_msg_size) {
         // TODO output standard error message <filename:line:col: msg>
-        snprintf(t.error_msg + len, MaxDiag - len, "at line %d:%d", result.loc.line, result.loc.column);
+        snprintf(t.error_msg + len, t.error_msg_size - len, "at line %d:%d", result.loc.line, result.loc.column);
     }
     va_end(args);
     result.kind = Error;

--- a/examples/common/string_buffer.c2
+++ b/examples/common/string_buffer.c2
@@ -150,17 +150,27 @@ public fn void StringBuffer.vprintf(StringBuffer* buf, const char* format, va_li
         dest = &buf.data_ptr[buf.len];
         dest_size = avail;
     }
-    i32 len = vsnprintf(dest, avail, format, args);
-    if (len < 0) {
+    i32 ret = vsnprintf(dest, dest_size, format, args);
+    if (ret < 0) {
         buf.error = true;
         return;
     }
-    if (len >= (i32)dest_size) {
+    u32 len = (u32)ret;
+    if (len >= dest_size) {
         buf.truncated = true;
-        len = (i32)dest_size - 1;
+        len = dest_size - 1;    // we know that dest_size > 0
     }
-    if (dest == tmp) memcpy(&buf.data_ptr[buf.len], tmp, (u32)len + 1);
-    buf.len += len;
+    if (dest == tmp) {
+        if (len >= avail) {
+            buf.add2(tmp, len);
+        } else {
+            memcpy(&buf.data_ptr[buf.len], tmp, len);
+            buf.len += len;
+        }
+    } else {
+        // output is already in buffer
+        buf.len += len;
+    }
 }
 
 fn bool StringBuffer.extend(StringBuffer* buf, u32 len) @(unused) {

--- a/examples/yaml_parser/yaml_parser.c2
+++ b/examples/yaml_parser/yaml_parser.c2
@@ -76,8 +76,8 @@ fn void Parser.error(Parser* p, const char* format @(printf_format), ...) {
     va_start(args, format);
     i32 len = vsnprintf(p.message, elemsof(p.message), format, args);
     va_end(args);
-    if (len < elemsof(p.message))
-        snprintf(p.message + len, elemsof(p.message) - len, " %s", p.token.loc.str());
+    if ((u32)len < elemsof(p.message))
+        snprintf(p.message + (u32)len, elemsof(p.message) - (u32)len, " %s", p.token.loc.str());
     longjmp(&p.jmp_err, 1);
 }
 

--- a/plugins/unit_test2.c2
+++ b/plugins/unit_test2.c2
@@ -40,7 +40,7 @@ fn void run_group(const Group* g, Stats* stats) {
   for (u32 i=0; i<g.num_tests; i++) {
     const C2Test* t = &g.tests[i];
 
-    error_size = sizeof(error_buffer) -1;
+    error_size = elemsof(error_buffer);
     error_msg = error_buffer;
     printf("TEST [%d/%d] %s.%s ", i+1+stats.done, stats.total, g.name, t.name);
     fflush(stdout);
@@ -60,15 +60,14 @@ fn void run_group(const Group* g, Stats* stats) {
 }
 
 fn void vprint_errormsg(const char* fmt, va_list ap) {
+  if (error_size <= 1) return;
   i32 ret = vsnprintf(error_msg, error_size, fmt, ap);
   if (ret < 0) {
     error_msg[0] = 0;
   } else {
-    const usize size = (usize)ret;
-    const usize s = (error_size <= size) ? size - error_size : size;
-    // error_size may overflow at this point
-    error_size -= s;
-    error_msg += s;
+    const usize len = (usize)ret < error_size ? (usize)ret : error_size - 1;
+    error_size -= len;
+    error_msg += len;
   }
 }
 


### PR DESCRIPTION
* fix potential buffer overflow in examples' `StringBuffer.vprintf`
* fix off by one issues in formatting calls
* improve `string_buffer.Buf.print`: generate output directly in buffer if possible