### PR TITLE
Compiler: add `unused-struct-member` warning kind

### DIFF
--- a/analyser/unused_checker.c2
+++ b/analyser/unused_checker.c2
@@ -174,7 +174,7 @@ fn void Checker.checkStructMembers(Checker* c, Decl* d) {
         if (member.isStructType()) {
             c.checkStructMembers(member);
         } else {
-            if (!member.isUsed() && !member.hasAttrUnused() && !c.warnings.no_unused_variable) {
+            if (!member.isUsed() && !member.hasAttrUnused() && !c.warnings.no_unused_struct_member) {
                 c.diags.warn(member.getLoc(), "unused %s member '%s'", std.isStruct() ? "struct" : "union", c.getName(member));
             }
         }

--- a/common/build_target.c2
+++ b/common/build_target.c2
@@ -191,6 +191,7 @@ public fn void Target.addLib(Target* t, u32 lib, Kind kind) {
 public fn void Target.disableWarnings(Target* t) {
     t.warnings.no_unused = true;
     t.warnings.no_unused_variable = true;
+    t.warnings.no_unused_struct_member = true;
     t.warnings.no_unused_function = true;
     t.warnings.no_unused_parameter = true;
     t.warnings.no_unused_type = true;
@@ -208,6 +209,7 @@ public fn void Target.disableWarnings(Target* t) {
 public fn void Target.enableWarnings(Target* t) {
     t.warnings.no_unused = false;
     t.warnings.no_unused_variable = false;
+    t.warnings.no_unused_struct_member = false;
     t.warnings.no_unused_function = false;
     t.warnings.no_unused_parameter = false;
     t.warnings.no_unused_type = false;

--- a/common/warning_flags.c2
+++ b/common/warning_flags.c2
@@ -18,6 +18,7 @@ module warning_flags;
 public type Flags struct {
     bool no_unused;
     bool no_unused_variable;
+    bool no_unused_struct_member;
     bool no_unused_function;
     bool no_unused_parameter;
     bool no_unused_type;

--- a/compiler/c2recipe_parser.c2
+++ b/compiler/c2recipe_parser.c2
@@ -522,6 +522,7 @@ fn void Parser.parseWarnings(Parser* p) {
         case "unused":
             warnings.no_unused = disable;
             warnings.no_unused_variable = disable;
+            warnings.no_unused_struct_member = disable;
             warnings.no_unused_function = disable;
             warnings.no_unused_parameter = disable;
             warnings.no_unused_type = disable;
@@ -534,6 +535,10 @@ fn void Parser.parseWarnings(Parser* p) {
             break;
         case "unused-variable":
             warnings.no_unused_variable = disable;
+            warnings.no_unused_struct_member = disable;  // temporary until new bootstrap
+            break;
+        case "unused-struct-member":
+            warnings.no_unused_struct_member = disable;
             break;
         case "unused-function":
             warnings.no_unused_function = disable;

--- a/examples/recipe.txt
+++ b/examples/recipe.txt
@@ -15,7 +15,10 @@ executable cstrip
 end
 
 executable event
-    $warnings no-unused
+    $warnings no-unused-parameter
+    $warnings no-unused-variable
+    $warnings no-unused-public
+    $warnings no-unused-function
     $backend c
     common/color.c2
     common/logger.c2
@@ -37,7 +40,10 @@ executable inline_asm
 end
 
 executable json_parser
-    $warnings no-unused
+    $warnings no-unused-parameter
+    $warnings no-unused-struct-member
+    $warnings no-unused-function
+    $warnings no-unused-public
     $backend c
     common/file/reader.c2
     common/file/writer.c2
@@ -72,7 +78,7 @@ end
 # Disabled because location of lua.a/lua.so needs to be specified
 #executable lua_test
 #    $warnings no-unused-parameter
-#	$backend c
+#    $backend c
 #    $use lua dynamic
 #    common/color.c2
 #    lua/script.c2
@@ -96,7 +102,8 @@ executable string
 end
 
 executable toml_parser
-    $warnings no-unused
+    $warnings no-unused-function
+    $warnings no-unused-struct-member
     $backend c
 #    $config DEBUG_NODES
     common/file/reader.c2
@@ -106,7 +113,10 @@ executable toml_parser
 end
 
 executable yaml_parser
-    $warnings no-unused
+    $warnings no-unused-function
+    $warnings no-unused-parameter
+    $warnings no-unused-public
+    $warnings no-unused-struct-member
     $backend c
 #    $config YAML_PRINT_TOKENS
     common/file/reader.c2
@@ -119,7 +129,8 @@ executable yaml_parser
 end
 
 executable xml_parser
-    $warnings no-unused
+    $warnings no-unused-function
+    $warnings no-unused-variable
     $backend c
     common/color.c2
     common/file/reader.c2
@@ -145,14 +156,14 @@ lib plugin1 dynamic
 end
 
 lib plugin2 dynamic
-    $warnings no-unused-public
+#    $warnings no-unused-public
     $backend c
     $export plugin_main
     plugin/plugin2.c2
 end
 
 executable plugin_mgr
-    $warnings no-unused-public
+#    $warnings no-unused-public
     $backend c
     $use dl dynamic
     plugin/other.c2
@@ -180,7 +191,10 @@ executable load_file
 end
 
 executable unit_test
-    $warnings no-unused
+    $warnings no-unused-function
+    $warnings no-unused-parameter
+    $warnings no-unused-public
+    $warnings no-unused-struct-member
     $backend c
     $plugin unit_test []
 
@@ -216,7 +230,6 @@ executable dir_walker
 end
 
 executable terminal
-    $warnings no-unused-public
     $backend c
 
     terminal/main.c2

--- a/examples/terminal/main.c2
+++ b/examples/terminal/main.c2
@@ -19,7 +19,7 @@ import ctermios local;
 import stdio local;
 import unistd local;
 
-public fn void init(Termios *save) {
+fn void init(Termios *save) {
     tcgetattr(0, save);
     Termios new = *save;
     new.c_lflag &= ~(ICANON | ECHO);
@@ -28,11 +28,11 @@ public fn void init(Termios *save) {
     tcsetattr(0, TCSANOW, &new);
 }
 
-public fn void reset(Termios *old) {
+fn void reset(Termios *old) {
     tcsetattr(0, TCSANOW, old);
 }
 
-public fn char read_char() {
+fn char read_char() {
     char c;
     isize numread = read(0, &c, 1);
     if (numread == 1) return c;


### PR DESCRIPTION
* use a different warning flag for unused variable and unused struct member